### PR TITLE
Fix GoReleaser before hook and add Node.js setup to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ version: 2
 
 before:
   hooks:
-    - cd internal/web/frontend && npm ci && npm run build
+    - sh -c "cd internal/web/frontend && npm ci && npm run build"
 
 builds:
   - main: ./cmd/dotvault


### PR DESCRIPTION
## Summary

- Fix GoReleaser before hook by wrapping in `sh -c` — GoReleaser executes hooks as raw commands (not via a shell), so `cd` was not found as an executable
- Add `actions/setup-node@v4` to the release workflow so `npm` is available for the frontend build step