### PR TITLE
Add SSH enrolment engine with Ed25519 key generation

### DIFF
--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goodtune/dotvault/internal/web"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var version = "dev"
@@ -270,6 +271,16 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		Out:     os.Stderr,
 		Browser: browser.OpenURL,
 		Log:     slog.Default(),
+		Username: username,
+		PromptSecret: func(label string) (string, error) {
+			fmt.Fprintf(os.Stderr, "%s ", label)
+			pass, err := term.ReadPassword(int(os.Stdin.Fd()))
+			fmt.Fprintln(os.Stderr) // newline after hidden input
+			if err != nil {
+				return "", err
+			}
+			return string(pass), nil
+		},
 	})
 	if _, err := enrolMgr.CheckAll(ctx); err != nil {
 		slog.Warn("enrolment check failed", "error", err)

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -269,8 +269,12 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		Log:     slog.Default(),
 		Username: username,
 		PromptSecret: func(label string) (string, error) {
+			fd := int(os.Stdin.Fd())
+			if !term.IsTerminal(fd) {
+				return "", fmt.Errorf("cannot prompt for passphrase: stdin is not a terminal (use web UI or set passphrase to unsafe)")
+			}
 			fmt.Fprintf(os.Stderr, "%s ", label)
-			pass, err := term.ReadPassword(int(os.Stdin.Fd()))
+			pass, err := term.ReadPassword(fd)
 			fmt.Fprintln(os.Stderr) // newline after hidden input
 			if err != nil {
 				return "", err

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -263,11 +263,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Create enrolment manager and run initial check.
-	enrolMgr := enrol.NewManager(enrol.ManagerConfig{
-		Enrolments: cfg.Enrolments,
-		KVMount:    cfg.Vault.KVMount,
-		UserPrefix: cfg.Vault.UserPrefix + username + "/",
-	}, vc, enrol.IO{
+	enrolIO := enrol.IO{
 		Out:     os.Stderr,
 		Browser: browser.OpenURL,
 		Log:     slog.Default(),
@@ -281,7 +277,17 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 			}
 			return string(pass), nil
 		},
-	})
+	}
+	if webServer != nil {
+		enrolIO.PromptSecret = func(label string) (string, error) {
+			return webServer.EnrolPromptSecret(ctx, label)
+		}
+	}
+	enrolMgr := enrol.NewManager(enrol.ManagerConfig{
+		Enrolments: cfg.Enrolments,
+		KVMount:    cfg.Vault.KVMount,
+		UserPrefix: cfg.Vault.UserPrefix + username + "/",
+	}, vc, enrolIO)
 	if _, err := enrolMgr.CheckAll(ctx); err != nil {
 		slog.Warn("enrolment check failed", "error", err)
 	}

--- a/docs/superpowers/plans/2026-04-08-ssh-enrolment-engine.md
+++ b/docs/superpowers/plans/2026-04-08-ssh-enrolment-engine.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add an SSH enrolment engine that generates Ed25519 key pairs in OpenSSH format and stores them in Vault KVv2, with configurable passphrase protection prompted via CLI or web UI.
 
-**Architecture:** New `SSHEngine` in `internal/enrol/ssh.go` implements the existing `Engine` interface. The `IO` struct gains `Username` and `PromptSecret` fields to support identity-aware engines and masked user input. The manager wires a CLI-based `PromptSecret` (using `golang.org/x/term`), and the web server adds two endpoints for browser-based secret prompting. Passphrase policy is a three-tier setting: `required` (default), `recommended`, `unsafe`.
+**Architecture:** New `SSHEngine` in `internal/enrol/ssh.go` implements the existing `Engine` interface. The `IO` struct gains `Username` and `PromptSecret` fields to support identity-aware engines and masked user input. The CLI entrypoint (`cmd/dotvault/main.go`) wires a terminal-based `PromptSecret` (using `golang.org/x/term`) into `enrol.IO`, which the manager receives and passes to engines, and the web server adds two endpoints for browser-based secret prompting. Passphrase policy is a three-tier setting: `required` (default), `recommended`, `unsafe`.
 
 **Tech Stack:** `crypto/ed25519`, `crypto/rand`, `encoding/pem`, `golang.org/x/crypto/ssh` (marshalling), `golang.org/x/term` (CLI hidden input)
 
@@ -543,7 +543,7 @@ Replace the IO struct literal at lines 269-273:
 	})
 ```
 
-Add `"golang.org/x/term"` to the import block. `golang.org/x/term` is already an indirect dependency in `go.mod`.
+Add `"golang.org/x/term"` to the import block. `golang.org/x/term` is already a direct dependency in `go.mod`.
 
 - [ ] **Step 2: Build to verify compilation**
 
@@ -754,7 +754,7 @@ git commit -m "Wire web-based PromptSecret when web UI is active"
 
 Run: `go mod tidy`
 
-This will promote `golang.org/x/crypto` from indirect to direct (since `ssh.go` imports `golang.org/x/crypto/ssh`) and promote `golang.org/x/term` from indirect to direct (since `main.go` imports it).
+This will promote `golang.org/x/crypto` from indirect to direct (since `ssh.go` imports `golang.org/x/crypto/ssh`). `golang.org/x/term` is already a direct dependency.
 
 - [ ] **Step 2: Verify the build**
 

--- a/docs/superpowers/plans/2026-04-08-ssh-enrolment-engine.md
+++ b/docs/superpowers/plans/2026-04-08-ssh-enrolment-engine.md
@@ -1,0 +1,774 @@
+# SSH Enrolment Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an SSH enrolment engine that generates Ed25519 key pairs in OpenSSH format and stores them in Vault KVv2, with configurable passphrase protection prompted via CLI or web UI.
+
+**Architecture:** New `SSHEngine` in `internal/enrol/ssh.go` implements the existing `Engine` interface. The `IO` struct gains `Username` and `PromptSecret` fields to support identity-aware engines and masked user input. The manager wires a CLI-based `PromptSecret` (using `golang.org/x/term`), and the web server adds two endpoints for browser-based secret prompting. Passphrase policy is a three-tier setting: `required` (default), `recommended`, `unsafe`.
+
+**Tech Stack:** `crypto/ed25519`, `crypto/rand`, `encoding/pem`, `golang.org/x/crypto/ssh` (marshalling), `golang.org/x/term` (CLI hidden input)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/enrol/engine.go` | Modify | Add `Username` and `PromptSecret` fields to `IO` struct; register `"ssh"` engine |
+| `internal/enrol/ssh.go` | Create | `SSHEngine` implementation: key generation, passphrase prompting, OpenSSH marshalling |
+| `internal/enrol/ssh_test.go` | Create | Unit tests for all passphrase modes, key validity, error cases |
+| `internal/enrol/manager_test.go` | Modify | Update `testIO` helper to include new `IO` fields |
+| `cmd/dotvault/main.go` | Modify | Wire `Username` and CLI `PromptSecret` into `enrol.IO` |
+| `internal/web/server.go` | Modify | Add enrolment prompt endpoints and state tracking |
+| `internal/web/api.go` | Modify | Add `handleEnrolPrompt` and `handleEnrolSecret` handlers |
+
+---
+
+### Task 1: Add `Username` and `PromptSecret` to `IO` struct
+
+**Files:**
+- Modify: `internal/enrol/engine.go:28-34`
+- Modify: `internal/enrol/manager_test.go:56-62`
+
+- [ ] **Step 1: Add fields to IO struct**
+
+In `internal/enrol/engine.go`, add `Username` and `PromptSecret` to the `IO` struct:
+
+```go
+// IO provides user interaction capabilities to engines.
+type IO struct {
+	Out          io.Writer
+	In           io.Reader // optional; defaults to os.Stdin if nil
+	Browser      BrowserOpener
+	Log          *slog.Logger
+	Username     string                        // authenticated Vault username
+	PromptSecret func(label string) (string, error) // masked user input
+}
+```
+
+- [ ] **Step 2: Update testIO helper**
+
+In `internal/enrol/manager_test.go`, update the `testIO` function to include the new fields so existing tests continue to compile:
+
+```go
+func testIO(buf *bytes.Buffer) IO {
+	return IO{
+		Out:      buf,
+		Browser:  func(url string) error { return nil },
+		Log:      slog.New(slog.NewTextHandler(buf, nil)),
+		Username: "testuser",
+	}
+}
+```
+
+`PromptSecret` is left nil — existing engines (GitHub) don't call it, and the mock engine doesn't either.
+
+- [ ] **Step 3: Run tests to verify nothing is broken**
+
+Run: `go test ./internal/enrol/ -count=1 -short`
+Expected: All existing tests pass (tests requiring Vault will be skipped with `-short`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/enrol/engine.go internal/enrol/manager_test.go
+git commit -m "Add Username and PromptSecret fields to enrol.IO struct"
+```
+
+---
+
+### Task 2: Implement SSHEngine with TDD — Fields, Name, and unsafe mode
+
+**Files:**
+- Create: `internal/enrol/ssh_test.go`
+- Create: `internal/enrol/ssh.go`
+
+- [ ] **Step 1: Write failing tests for Name, Fields, and unsafe key generation**
+
+Create `internal/enrol/ssh_test.go`:
+
+```go
+package enrol
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/pem"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func sshTestIO(promptResponses ...string) IO {
+	callIdx := 0
+	return IO{
+		Out:      &bytes.Buffer{},
+		Log:      slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		Username: "testuser",
+		PromptSecret: func(label string) (string, error) {
+			if callIdx >= len(promptResponses) {
+				return "", nil
+			}
+			resp := promptResponses[callIdx]
+			callIdx++
+			return resp, nil
+		},
+	}
+}
+
+func TestSSHEngine_Name(t *testing.T) {
+	e := &SSHEngine{}
+	if got := e.Name(); got != "SSH" {
+		t.Errorf("Name() = %q, want %q", got, "SSH")
+	}
+}
+
+func TestSSHEngine_Fields(t *testing.T) {
+	e := &SSHEngine{}
+	fields := e.Fields()
+	if len(fields) != 2 {
+		t.Fatalf("Fields() returned %d fields, want 2", len(fields))
+	}
+	if fields[0] != "public_key" || fields[1] != "private_key" {
+		t.Errorf("Fields() = %v, want [public_key private_key]", fields)
+	}
+}
+
+func TestSSHEngine_Unsafe_NoPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO() // no prompt responses needed
+	settings := map[string]any{"passphrase": "unsafe"}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Check both fields present
+	privPEM := creds["private_key"]
+	pubKey := creds["public_key"]
+	if privPEM == "" {
+		t.Fatal("private_key is empty")
+	}
+	if pubKey == "" {
+		t.Fatal("public_key is empty")
+	}
+
+	// Verify private key is valid OpenSSH PEM
+	block, _ := pem.Decode([]byte(privPEM))
+	if block == nil {
+		t.Fatal("private_key is not valid PEM")
+	}
+	if block.Type != "OPENSSH PRIVATE KEY" {
+		t.Errorf("PEM type = %q, want %q", block.Type, "OPENSSH PRIVATE KEY")
+	}
+
+	// Verify private key can be parsed without passphrase
+	rawKey, err := ssh.ParseRawPrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatalf("ParseRawPrivateKey() error: %v", err)
+	}
+	if _, ok := rawKey.(*ed25519.PrivateKey); !ok {
+		t.Errorf("parsed key type = %T, want *ed25519.PrivateKey", rawKey)
+	}
+
+	// Verify public key format
+	if !strings.HasPrefix(pubKey, "ssh-ed25519 ") {
+		t.Errorf("public_key does not start with 'ssh-ed25519 ': %q", pubKey)
+	}
+	if !strings.HasSuffix(pubKey, " testuser@dotvault") {
+		t.Errorf("public_key does not end with ' testuser@dotvault': %q", pubKey)
+	}
+
+	// Verify public key is parseable
+	_, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKey))
+	if err != nil {
+		t.Fatalf("ParseAuthorizedKey() error: %v", err)
+	}
+	if comment != "testuser@dotvault" {
+		t.Errorf("comment = %q, want %q", comment, "testuser@dotvault")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/enrol/ -run TestSSH -count=1`
+Expected: FAIL — `SSHEngine` not defined.
+
+- [ ] **Step 3: Write minimal SSHEngine implementation**
+
+Create `internal/enrol/ssh.go`:
+
+```go
+package enrol
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHEngine generates Ed25519 SSH key pairs.
+type SSHEngine struct{}
+
+func (e *SSHEngine) Name() string     { return "SSH" }
+func (e *SSHEngine) Fields() []string { return []string{"public_key", "private_key"} }
+
+func (e *SSHEngine) Run(ctx context.Context, settings map[string]any, io IO) (map[string]string, error) {
+	mode := "required"
+	if v, ok := settings["passphrase"].(string); ok && v != "" {
+		mode = v
+	}
+
+	passphrase, err := promptPassphrase(io, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	comment := io.Username + "@dotvault"
+
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	// Marshal private key to OpenSSH PEM format.
+	var pemBlock *pem.Block
+	if passphrase != "" {
+		pemBlock, err = ssh.MarshalPrivateKeyWithPassphrase(privKey, comment, []byte(passphrase))
+	} else {
+		pemBlock, err = ssh.MarshalPrivateKey(privKey, comment)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	privPEM := string(pem.EncodeToMemory(pemBlock))
+
+	// Marshal public key to authorized_keys format with comment.
+	sshPub, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("create ssh public key: %w", err)
+	}
+	pubLine := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub))) + " " + comment
+
+	return map[string]string{
+		"private_key": privPEM,
+		"public_key":  pubLine,
+	}, nil
+}
+
+func promptPassphrase(io IO, mode string) (string, error) {
+	switch mode {
+	case "unsafe":
+		return "", nil
+	case "required", "recommended":
+		// handled below
+	default:
+		return "", fmt.Errorf("invalid passphrase mode: %q (must be required, recommended, or unsafe)", mode)
+	}
+
+	if io.PromptSecret == nil {
+		return "", fmt.Errorf("passphrase prompt not available (PromptSecret is nil)")
+	}
+
+	first, err := io.PromptSecret("Enter passphrase:")
+	if err != nil {
+		return "", fmt.Errorf("passphrase prompt: %w", err)
+	}
+
+	if first == "" {
+		if mode == "required" {
+			return "", fmt.Errorf("passphrase is required")
+		}
+		// recommended: user opted out
+		return "", nil
+	}
+
+	second, err := io.PromptSecret("Confirm passphrase:")
+	if err != nil {
+		return "", fmt.Errorf("passphrase confirm prompt: %w", err)
+	}
+
+	if first != second {
+		return "", fmt.Errorf("passphrases do not match")
+	}
+
+	return first, nil
+}
+```
+
+Note: add `"context"` to the import block — the `Run` method signature requires it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/enrol/ -run TestSSH -count=1`
+Expected: PASS — all three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/enrol/ssh.go internal/enrol/ssh_test.go
+git commit -m "Add SSHEngine with Ed25519 key generation (unsafe mode)"
+```
+
+---
+
+### Task 3: TDD — passphrase-protected key generation
+
+**Files:**
+- Modify: `internal/enrol/ssh_test.go`
+
+- [ ] **Step 1: Write failing test for passphrase-protected key**
+
+Add to `internal/enrol/ssh_test.go`:
+
+```go
+func TestSSHEngine_Required_WithPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("hunter2", "hunter2") // two matching entries
+	settings := map[string]any{"passphrase": "required"}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	privPEM := creds["private_key"]
+
+	// Verify the key cannot be parsed without passphrase
+	_, err = ssh.ParseRawPrivateKey([]byte(privPEM))
+	if err == nil {
+		t.Fatal("expected error parsing encrypted key without passphrase")
+	}
+
+	// Verify the key can be parsed with the correct passphrase
+	rawKey, err := ssh.ParseRawPrivateKeyWithPassphrase([]byte(privPEM), []byte("hunter2"))
+	if err != nil {
+		t.Fatalf("ParseRawPrivateKeyWithPassphrase() error: %v", err)
+	}
+	if _, ok := rawKey.(*ed25519.PrivateKey); !ok {
+		t.Errorf("parsed key type = %T, want *ed25519.PrivateKey", rawKey)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./internal/enrol/ -run TestSSHEngine_Required_WithPassphrase -count=1`
+Expected: PASS — the implementation from Task 2 already handles this case.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/enrol/ssh_test.go
+git commit -m "Add test for passphrase-protected SSH key generation"
+```
+
+---
+
+### Task 4: TDD — passphrase error cases
+
+**Files:**
+- Modify: `internal/enrol/ssh_test.go`
+
+- [ ] **Step 1: Write tests for all error cases**
+
+Add to `internal/enrol/ssh_test.go`:
+
+```go
+func TestSSHEngine_Required_EmptyPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("", "") // empty entries
+	settings := map[string]any{"passphrase": "required"}
+
+	_, err := e.Run(context.Background(), settings, io)
+	if err == nil {
+		t.Fatal("expected error for empty passphrase in required mode")
+	}
+	if !strings.Contains(err.Error(), "passphrase is required") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "passphrase is required")
+	}
+}
+
+func TestSSHEngine_Recommended_EmptyPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("", "") // empty entries
+	settings := map[string]any{"passphrase": "recommended"}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Should produce a valid unencrypted key
+	privPEM := creds["private_key"]
+	_, err = ssh.ParseRawPrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatalf("key should be unencrypted but ParseRawPrivateKey() failed: %v", err)
+	}
+}
+
+func TestSSHEngine_Mismatch(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("hunter2", "hunter3") // mismatched entries
+	settings := map[string]any{"passphrase": "required"}
+
+	_, err := e.Run(context.Background(), settings, io)
+	if err == nil {
+		t.Fatal("expected error for mismatched passphrases")
+	}
+	if !strings.Contains(err.Error(), "passphrases do not match") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "passphrases do not match")
+	}
+}
+
+func TestSSHEngine_InvalidMode(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO()
+	settings := map[string]any{"passphrase": "bogus"}
+
+	_, err := e.Run(context.Background(), settings, io)
+	if err == nil {
+		t.Fatal("expected error for invalid passphrase mode")
+	}
+	if !strings.Contains(err.Error(), "invalid passphrase mode") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "invalid passphrase mode")
+	}
+}
+
+func TestSSHEngine_DefaultMode(t *testing.T) {
+	e := &SSHEngine{}
+	// No passphrase in settings — defaults to "required"
+	io := sshTestIO("mypass", "mypass")
+	settings := map[string]any{}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Key should be encrypted
+	_, err = ssh.ParseRawPrivateKey([]byte(creds["private_key"]))
+	if err == nil {
+		t.Fatal("expected error parsing encrypted key without passphrase")
+	}
+	_, err = ssh.ParseRawPrivateKeyWithPassphrase([]byte(creds["private_key"]), []byte("mypass"))
+	if err != nil {
+		t.Fatalf("ParseRawPrivateKeyWithPassphrase() error: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./internal/enrol/ -run "TestSSHEngine_(Required_Empty|Recommended_Empty|Mismatch|InvalidMode|DefaultMode)" -count=1`
+Expected: PASS — all error paths are already implemented.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/enrol/ssh_test.go
+git commit -m "Add tests for SSH engine passphrase error cases"
+```
+
+---
+
+### Task 5: Register SSH engine
+
+**Files:**
+- Modify: `internal/enrol/engine.go:36-41`
+
+- [ ] **Step 1: Add SSH engine to registry**
+
+In `internal/enrol/engine.go`, add `"ssh"` to the `engines` map:
+
+```go
+var (
+	enginesMu sync.RWMutex
+	engines   = map[string]Engine{
+		"github": &GitHubEngine{},
+		"ssh":    &SSHEngine{},
+	}
+)
+```
+
+- [ ] **Step 2: Run all enrol tests to verify**
+
+Run: `go test ./internal/enrol/ -count=1 -short`
+Expected: PASS — all tests pass, including existing GitHub/manager tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/enrol/engine.go
+git commit -m "Register SSH engine in enrolment registry"
+```
+
+---
+
+### Task 6: Wire CLI PromptSecret and Username in main.go
+
+**Files:**
+- Modify: `cmd/dotvault/main.go:264-273`
+
+- [ ] **Step 1: Add CLI PromptSecret and Username to IO construction**
+
+In `cmd/dotvault/main.go`, update the `enrol.IO` construction at line 269. The `PromptSecret` implementation uses `golang.org/x/term` to read hidden input. Add the necessary imports (`os`, `fmt`, `golang.org/x/term` — `os` and `fmt` are likely already imported).
+
+Replace the IO struct literal at lines 269-273:
+
+```go
+	}, vc, enrol.IO{
+		Out:     os.Stderr,
+		Browser: browser.OpenURL,
+		Log:     slog.Default(),
+		Username: username,
+		PromptSecret: func(label string) (string, error) {
+			fmt.Fprintf(os.Stderr, "%s ", label)
+			pass, err := term.ReadPassword(int(os.Stdin.Fd()))
+			fmt.Fprintln(os.Stderr) // newline after hidden input
+			if err != nil {
+				return "", err
+			}
+			return string(pass), nil
+		},
+	})
+```
+
+Add `"golang.org/x/term"` to the import block. `golang.org/x/term` is already an indirect dependency in `go.mod`.
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `go build ./cmd/dotvault/`
+Expected: Builds successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/dotvault/main.go go.mod go.sum
+git commit -m "Wire CLI PromptSecret and Username into enrolment IO"
+```
+
+---
+
+### Task 7: Add web enrolment prompt endpoints
+
+**Files:**
+- Modify: `internal/web/server.go:18-43` (add prompt state fields to Server)
+- Modify: `internal/web/server.go:91-121` (register new routes)
+- Modify: `internal/web/api.go` (add handler implementations)
+
+- [ ] **Step 1: Add prompt state to Server struct**
+
+In `internal/web/server.go`, add fields to the `Server` struct for managing enrolment prompt state:
+
+```go
+type Server struct {
+	// ... existing fields ...
+	enrolPromptMu    sync.Mutex
+	enrolPromptLabel string
+	enrolPromptCh    chan string
+}
+```
+
+Add `"sync"` to the import block.
+
+- [ ] **Step 2: Add PromptSecret method to Server**
+
+Add a method to `internal/web/server.go` that the manager can use as the web `PromptSecret` implementation:
+
+```go
+// EnrolPromptSecret implements a web-based PromptSecret. It sets the pending
+// prompt state and blocks until the frontend submits a value via the
+// /api/v1/enrol/secret endpoint, or the context is cancelled.
+func (s *Server) EnrolPromptSecret(ctx context.Context, label string) (string, error) {
+	ch := make(chan string, 1)
+
+	s.enrolPromptMu.Lock()
+	s.enrolPromptLabel = label
+	s.enrolPromptCh = ch
+	s.enrolPromptMu.Unlock()
+
+	defer func() {
+		s.enrolPromptMu.Lock()
+		s.enrolPromptLabel = ""
+		s.enrolPromptCh = nil
+		s.enrolPromptMu.Unlock()
+	}()
+
+	select {
+	case val := <-ch:
+		return val, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+```
+
+Note this method takes a `context.Context` parameter. The caller in `main.go` will wrap it to match the `func(label string) (string, error)` signature by closing over the context.
+
+- [ ] **Step 3: Register new routes**
+
+In `internal/web/server.go` `registerRoutes()`, add after the existing API routes (line 111):
+
+```go
+	// Enrolment prompt routes
+	s.mux.HandleFunc("GET /api/v1/enrol/prompt", s.handleEnrolPrompt)
+	s.mux.HandleFunc("POST /api/v1/enrol/secret", s.requireCSRF(s.handleEnrolSecret))
+```
+
+- [ ] **Step 4: Add handler implementations**
+
+Add to `internal/web/api.go`:
+
+```go
+func (s *Server) handleEnrolPrompt(w http.ResponseWriter, r *http.Request) {
+	s.enrolPromptMu.Lock()
+	label := s.enrolPromptLabel
+	pending := s.enrolPromptCh != nil
+	s.enrolPromptMu.Unlock()
+
+	writeJSON(w, map[string]any{
+		"pending": pending,
+		"label":   label,
+	})
+}
+
+func (s *Server) handleEnrolSecret(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	s.enrolPromptMu.Lock()
+	ch := s.enrolPromptCh
+	s.enrolPromptMu.Unlock()
+
+	if ch == nil {
+		writeError(w, "no pending prompt", http.StatusConflict)
+		return
+	}
+
+	select {
+	case ch <- req.Value:
+		writeJSON(w, map[string]any{"status": "accepted"})
+	default:
+		writeError(w, "prompt already answered", http.StatusConflict)
+	}
+}
+```
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `go build ./cmd/dotvault/`
+Expected: Builds successfully.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/web/server.go internal/web/api.go
+git commit -m "Add web enrolment prompt endpoints for passphrase collection"
+```
+
+---
+
+### Task 8: Wire web PromptSecret in main.go
+
+**Files:**
+- Modify: `cmd/dotvault/main.go`
+
+- [ ] **Step 1: Conditionally set web PromptSecret when web server is running**
+
+In `cmd/dotvault/main.go`, after the web server is created and started but before the enrolment manager is created, the `PromptSecret` should be set to the web implementation when the web UI is active.
+
+Find the section where the web server is set up (before line 264) and where the enrolment manager IO is constructed. The logic is:
+
+- If the web server is running, use `webServer.EnrolPromptSecret(ctx, label)` as the `PromptSecret`
+- Otherwise, use the terminal-based `PromptSecret` from Task 6
+
+Update the IO construction to conditionally select the implementation:
+
+```go
+	enrolIO := enrol.IO{
+		Out:      os.Stderr,
+		Browser:  browser.OpenURL,
+		Log:      slog.Default(),
+		Username: username,
+		PromptSecret: func(label string) (string, error) {
+			fmt.Fprintf(os.Stderr, "%s ", label)
+			pass, err := term.ReadPassword(int(os.Stdin.Fd()))
+			fmt.Fprintln(os.Stderr)
+			if err != nil {
+				return "", err
+			}
+			return string(pass), nil
+		},
+	}
+	if webServer != nil {
+		enrolIO.PromptSecret = func(label string) (string, error) {
+			return webServer.EnrolPromptSecret(ctx, label)
+		}
+	}
+
+	enrolMgr := enrol.NewManager(enrol.ManagerConfig{
+		Enrolments: cfg.Enrolments,
+		KVMount:    cfg.Vault.KVMount,
+		UserPrefix: cfg.Vault.UserPrefix + username + "/",
+	}, vc, enrolIO)
+```
+
+The variable `webServer` is declared at `main.go:179` as `var webServer *web.Server` and is nil when the web UI is disabled.
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `go build ./cmd/dotvault/`
+Expected: Builds successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/dotvault/main.go
+git commit -m "Wire web-based PromptSecret when web UI is active"
+```
+
+---
+
+### Task 9: Update go.mod dependencies
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1: Tidy module dependencies**
+
+Run: `go mod tidy`
+
+This will promote `golang.org/x/crypto` from indirect to direct (since `ssh.go` imports `golang.org/x/crypto/ssh`) and promote `golang.org/x/term` from indirect to direct (since `main.go` imports it).
+
+- [ ] **Step 2: Verify the build**
+
+Run: `go build ./...`
+Expected: Builds successfully.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./... -count=1 -short`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "Promote golang.org/x/crypto and golang.org/x/term to direct dependencies"
+```

--- a/docs/superpowers/specs/2026-04-08-ssh-enrolment-engine-design.md
+++ b/docs/superpowers/specs/2026-04-08-ssh-enrolment-engine-design.md
@@ -56,13 +56,13 @@ A helper function `promptPassphrase(io IO, mode string) (string, error)` in `ssh
 6. If entries don't match: return error `"passphrases do not match"`.
 7. Return the passphrase.
 
-No retry loop on mismatch — the wizard logs the failure and continues. Re-run via config reload or daemon restart.
+No retry loop on mismatch — the wizard logs the failure and continues. Enrolment is retried automatically on the next periodic `CheckAll` cycle.
 
 ## IO Struct Changes
 
 Two additions to the `IO` struct in `internal/enrol/engine.go`:
 
-- **`Username string`** — the authenticated Vault username. Set by the manager when constructing `IO`. The SSH engine uses it for the key comment (`username@dotvault`).
+- **`Username string`** — the authenticated Vault username. Set by the caller when constructing `IO` and passed through to the manager/engine. The SSH engine uses it for the key comment (`username@dotvault`).
 - **`PromptSecret func(label string) (string, error)`** — requests masked input from the user. Returns the entered string, or error on cancellation/IO failure.
 
 ### CLI Implementation

--- a/docs/superpowers/specs/2026-04-08-ssh-enrolment-engine-design.md
+++ b/docs/superpowers/specs/2026-04-08-ssh-enrolment-engine-design.md
@@ -1,0 +1,148 @@
+# SSH Enrolment Engine Design
+
+## Overview
+
+A new enrolment engine that generates Ed25519 SSH key pairs in OpenSSH format, storing the result as `public_key` and `private_key` fields in Vault KVv2. Key generation uses native Go libraries with no subprocess calls.
+
+## Engine: `SSHEngine`
+
+New file: `internal/enrol/ssh.go`
+
+Zero-field struct implementing the `Engine` interface:
+
+- **`Name()`** — returns `"SSH"`
+- **`Fields()`** — returns `["public_key", "private_key"]` (both are completeness gates)
+- **`Run(ctx, settings, io)`** — generates key pair and returns `map[string]string{"public_key": "...", "private_key": "..."}`
+
+Registered as `"ssh"` in the engine map in `engine.go`.
+
+## Key Generation
+
+All native Go, no subprocess:
+
+1. `crypto/ed25519.GenerateKey(crypto/rand.Reader)` produces the key pair.
+2. Private key marshalled to OpenSSH PEM format:
+   - Without passphrase: `ssh.MarshalPrivateKey(privateKey, "username@dotvault")`
+   - With passphrase: `ssh.MarshalPrivateKeyWithPassphrase(privateKey, "username@dotvault", []byte(passphrase))`
+   - `pem.EncodeToMemory(block)` produces the final PEM string.
+3. Public key marshalled to authorized_keys format:
+   - `ssh.NewPublicKey(publicKey)` wraps the raw key.
+   - `ssh.MarshalAuthorizedKey(sshPub)` produces the `ssh-ed25519 AAAA...` line.
+   - Trailing newline trimmed, ` username@dotvault` comment appended.
+
+Dependencies: `crypto/ed25519`, `crypto/rand`, `encoding/pem`, `golang.org/x/crypto/ssh` (already an indirect dependency, becomes direct).
+
+## Passphrase Modes
+
+Configured via the `passphrase` setting in the enrolment config. Three tiers:
+
+| Value | Behaviour |
+|-------|-----------|
+| `required` (default) | User must enter a non-empty passphrase, entered twice for verification |
+| `recommended` | User is prompted but may leave both entries empty to skip |
+| `unsafe` | No prompt at all, key always generated without passphrase |
+
+An unrecognised value causes `Run()` to return an error.
+
+### Passphrase Verification Flow
+
+A helper function `promptPassphrase(io IO, mode string) (string, error)` in `ssh.go`:
+
+1. If `mode == "unsafe"`: return `""` immediately.
+2. Call `io.PromptSecret("Enter passphrase:")` — get first entry.
+3. If `mode == "recommended"` and first entry is empty: return `""` (user opted out).
+4. If `mode == "required"` and first entry is empty: return error `"passphrase is required"`.
+5. Call `io.PromptSecret("Confirm passphrase:")` — get second entry.
+6. If entries don't match: return error `"passphrases do not match"`.
+7. Return the passphrase.
+
+No retry loop on mismatch — the wizard logs the failure and continues. Re-run via config reload or daemon restart.
+
+## IO Struct Changes
+
+Two additions to the `IO` struct in `internal/enrol/engine.go`:
+
+- **`Username string`** — the authenticated Vault username. Set by the manager when constructing `IO`. The SSH engine uses it for the key comment (`username@dotvault`).
+- **`PromptSecret func(label string) (string, error)`** — requests masked input from the user. Returns the entered string, or error on cancellation/IO failure.
+
+### CLI Implementation
+
+Uses `golang.org/x/term.ReadPassword()` on the terminal file descriptor. The label is printed to `io.Out` before reading.
+
+### Web Implementation
+
+Blocks on a channel until a form submission arrives via HTTP:
+
+1. Engine calls `PromptSecret("Enter passphrase:")`.
+2. Implementation sets the pending prompt state (label + response channel).
+3. Frontend polls `GET /api/v1/enrol/prompt`, sees a pending prompt, displays a masked input form.
+4. User submits, frontend POSTs to `POST /api/v1/enrol/secret`.
+5. Handler sends value through the channel, `PromptSecret` returns.
+
+Context cancellation unblocks the channel with an error.
+
+## Web Endpoints
+
+Two new endpoints for passphrase collection:
+
+- **`GET /api/v1/enrol/prompt`** — returns current prompt state: `{"pending": true, "label": "Enter passphrase:"}` or `{"pending": false}`.
+- **`POST /api/v1/enrol/secret`** — accepts `{"value": "..."}`, CSRF-protected. Sends the value through the waiting channel.
+
+## Public Key Comment
+
+Hardcoded to `username@dotvault` where `username` is the Vault username from `IO.Username`. Not configurable.
+
+## Configuration
+
+No changes to the `Enrolment` struct. Example YAML:
+
+```yaml
+enrolments:
+  ssh:
+    engine: ssh
+    settings:
+      passphrase: required
+```
+
+The map key `ssh` becomes the Vault KV path segment: `{kv_mount}/data/{user_prefix}{username}/ssh`.
+
+## Registration
+
+Add `"ssh": &SSHEngine{}` to the `engines` map literal in `engine.go` alongside the existing `"github"` entry.
+
+## Vault Storage
+
+Two fields written to Vault KVv2:
+
+| Field | Content |
+|-------|---------|
+| `private_key` | OpenSSH PEM format (possibly passphrase-encrypted) |
+| `public_key` | OpenSSH authorized_keys format with `username@dotvault` comment |
+
+Both fields are declared in `Fields()` and are completeness gates — if either is missing or empty, the enrolment is treated as pending.
+
+## Testing
+
+Unit tests in `internal/enrol/ssh_test.go`:
+
+- **Key generation without passphrase** — `passphrase: "unsafe"`, verify both fields non-empty, parse private key PEM, parse public key authorized_keys line, verify comment is `username@dotvault`.
+- **Key generation with passphrase** — `passphrase: "required"`, wire `PromptSecret` to return a fixed string, verify the private key requires the passphrase to decrypt via `ssh.ParseRawPrivateKeyWithPassphrase`.
+- **Passphrase mismatch** — wire `PromptSecret` to return different values on successive calls, verify error.
+- **Required mode rejects empty** — wire `PromptSecret` to return `""`, verify error.
+- **Recommended mode allows empty** — wire `PromptSecret` to return `""`, verify success with unencrypted key.
+- **Invalid passphrase setting** — pass `passphrase: "bogus"`, verify error.
+- **`Fields()`** — returns exactly `["public_key", "private_key"]`.
+- **`Name()`** — returns `"SSH"`.
+
+`PromptSecret` as a function field on `IO` enables straightforward test injection — no mocks of terminal or HTTP needed.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/enrol/ssh.go` | New — `SSHEngine` implementation |
+| `internal/enrol/ssh_test.go` | New — unit tests |
+| `internal/enrol/engine.go` | Add `Username` and `PromptSecret` to `IO`; register `"ssh"` engine |
+| `internal/web/server.go` (or similar) | Add `/api/v1/enrol/prompt` and `/api/v1/enrol/secret` endpoints |
+| `internal/enrol/manager.go` | Wire `IO.Username` and `IO.PromptSecret` at construction time |
+| `go.mod` / `go.sum` | `golang.org/x/crypto/ssh` becomes a direct dependency |

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jdx/go-netrc v1.0.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/crypto v0.45.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
 	gopkg.in/ini.v1 v1.67.1
@@ -34,7 +35,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.12.0 // indirect

--- a/internal/enrol/engine.go
+++ b/internal/enrol/engine.go
@@ -39,6 +39,7 @@ var (
 	enginesMu sync.RWMutex
 	engines   = map[string]Engine{
 		"github": &GitHubEngine{},
+		"ssh":    &SSHEngine{},
 	}
 )
 

--- a/internal/enrol/engine.go
+++ b/internal/enrol/engine.go
@@ -27,10 +27,12 @@ type BrowserOpener func(url string) error
 
 // IO provides user interaction capabilities to engines.
 type IO struct {
-	Out     io.Writer
-	In      io.Reader // optional; defaults to os.Stdin if nil
-	Browser BrowserOpener
-	Log     *slog.Logger
+	Out          io.Writer
+	In           io.Reader // optional; defaults to os.Stdin if nil
+	Browser      BrowserOpener
+	Log          *slog.Logger
+	Username     string                              // authenticated Vault username
+	PromptSecret func(label string) (string, error) // masked user input
 }
 
 var (

--- a/internal/enrol/manager_test.go
+++ b/internal/enrol/manager_test.go
@@ -55,9 +55,10 @@ func (e *mockEngine) Run(_ context.Context, _ map[string]any, _ IO) (map[string]
 
 func testIO(buf *bytes.Buffer) IO {
 	return IO{
-		Out:     buf,
-		Browser: func(url string) error { return nil },
-		Log:     slog.New(slog.NewTextHandler(buf, nil)),
+		Out:      buf,
+		Browser:  func(url string) error { return nil },
+		Log:      slog.New(slog.NewTextHandler(buf, nil)),
+		Username: "testuser",
 	}
 }
 

--- a/internal/enrol/ssh.go
+++ b/internal/enrol/ssh.go
@@ -1,0 +1,100 @@
+package enrol
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHEngine generates Ed25519 SSH key pairs.
+type SSHEngine struct{}
+
+func (e *SSHEngine) Name() string     { return "SSH" }
+func (e *SSHEngine) Fields() []string { return []string{"public_key", "private_key"} }
+
+func (e *SSHEngine) Run(ctx context.Context, settings map[string]any, io IO) (map[string]string, error) {
+	mode := "required"
+	if v, ok := settings["passphrase"].(string); ok && v != "" {
+		mode = v
+	}
+
+	passphrase, err := promptPassphrase(io, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	comment := io.Username + "@dotvault"
+
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	// Marshal private key to OpenSSH PEM format.
+	var pemBlock *pem.Block
+	if passphrase != "" {
+		pemBlock, err = ssh.MarshalPrivateKeyWithPassphrase(privKey, comment, []byte(passphrase))
+	} else {
+		pemBlock, err = ssh.MarshalPrivateKey(privKey, comment)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	privPEM := string(pem.EncodeToMemory(pemBlock))
+
+	// Marshal public key to authorized_keys format with comment.
+	sshPub, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("create ssh public key: %w", err)
+	}
+	pubLine := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub))) + " " + comment
+
+	return map[string]string{
+		"private_key": privPEM,
+		"public_key":  pubLine,
+	}, nil
+}
+
+func promptPassphrase(io IO, mode string) (string, error) {
+	switch mode {
+	case "unsafe":
+		return "", nil
+	case "required", "recommended":
+		// handled below
+	default:
+		return "", fmt.Errorf("invalid passphrase mode: %q (must be required, recommended, or unsafe)", mode)
+	}
+
+	if io.PromptSecret == nil {
+		return "", fmt.Errorf("passphrase prompt not available (PromptSecret is nil)")
+	}
+
+	first, err := io.PromptSecret("Enter passphrase:")
+	if err != nil {
+		return "", fmt.Errorf("passphrase prompt: %w", err)
+	}
+
+	if first == "" {
+		if mode == "required" {
+			return "", fmt.Errorf("passphrase is required")
+		}
+		// recommended: user opted out
+		return "", nil
+	}
+
+	second, err := io.PromptSecret("Confirm passphrase:")
+	if err != nil {
+		return "", fmt.Errorf("passphrase confirm prompt: %w", err)
+	}
+
+	if first != second {
+		return "", fmt.Errorf("passphrases do not match")
+	}
+
+	return first, nil
+}

--- a/internal/enrol/ssh_test.go
+++ b/internal/enrol/ssh_test.go
@@ -102,3 +102,32 @@ func TestSSHEngine_Unsafe_NoPassphrase(t *testing.T) {
 		t.Errorf("comment = %q, want %q", comment, "testuser@dotvault")
 	}
 }
+
+func TestSSHEngine_Required_WithPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("hunter2", "hunter2") // two matching entries
+	settings := map[string]any{"passphrase": "required"}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	privPEM := creds["private_key"]
+
+	// Verify the key cannot be parsed without passphrase
+	_, err = ssh.ParseRawPrivateKey([]byte(privPEM))
+	if err == nil {
+		t.Fatal("expected error parsing encrypted key without passphrase")
+	}
+
+	// Verify the key can be parsed with the correct passphrase
+	rawKey, err := ssh.ParseRawPrivateKeyWithPassphrase([]byte(privPEM), []byte("hunter2"))
+	if err != nil {
+		t.Fatalf("ParseRawPrivateKeyWithPassphrase() error: %v", err)
+	}
+	if _, ok := rawKey.(*ed25519.PrivateKey); !ok {
+		t.Errorf("parsed key type = %T, want *ed25519.PrivateKey", rawKey)
+	}
+}
+

--- a/internal/enrol/ssh_test.go
+++ b/internal/enrol/ssh_test.go
@@ -131,3 +131,85 @@ func TestSSHEngine_Required_WithPassphrase(t *testing.T) {
 	}
 }
 
+func TestSSHEngine_Required_EmptyPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("", "") // empty entries
+	settings := map[string]any{"passphrase": "required"}
+
+	_, err := e.Run(context.Background(), settings, io)
+	if err == nil {
+		t.Fatal("expected error for empty passphrase in required mode")
+	}
+	if !strings.Contains(err.Error(), "passphrase is required") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "passphrase is required")
+	}
+}
+
+func TestSSHEngine_Recommended_EmptyPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("", "") // empty entries
+	settings := map[string]any{"passphrase": "recommended"}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Should produce a valid unencrypted key
+	privPEM := creds["private_key"]
+	_, err = ssh.ParseRawPrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatalf("key should be unencrypted but ParseRawPrivateKey() failed: %v", err)
+	}
+}
+
+func TestSSHEngine_Mismatch(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO("hunter2", "hunter3") // mismatched entries
+	settings := map[string]any{"passphrase": "required"}
+
+	_, err := e.Run(context.Background(), settings, io)
+	if err == nil {
+		t.Fatal("expected error for mismatched passphrases")
+	}
+	if !strings.Contains(err.Error(), "passphrases do not match") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "passphrases do not match")
+	}
+}
+
+func TestSSHEngine_InvalidMode(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO()
+	settings := map[string]any{"passphrase": "bogus"}
+
+	_, err := e.Run(context.Background(), settings, io)
+	if err == nil {
+		t.Fatal("expected error for invalid passphrase mode")
+	}
+	if !strings.Contains(err.Error(), "invalid passphrase mode") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "invalid passphrase mode")
+	}
+}
+
+func TestSSHEngine_DefaultMode(t *testing.T) {
+	e := &SSHEngine{}
+	// No passphrase in settings — defaults to "required"
+	io := sshTestIO("mypass", "mypass")
+	settings := map[string]any{}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Key should be encrypted
+	_, err = ssh.ParseRawPrivateKey([]byte(creds["private_key"]))
+	if err == nil {
+		t.Fatal("expected error parsing encrypted key without passphrase")
+	}
+	_, err = ssh.ParseRawPrivateKeyWithPassphrase([]byte(creds["private_key"]), []byte("mypass"))
+	if err != nil {
+		t.Fatalf("ParseRawPrivateKeyWithPassphrase() error: %v", err)
+	}
+}
+

--- a/internal/enrol/ssh_test.go
+++ b/internal/enrol/ssh_test.go
@@ -1,0 +1,104 @@
+package enrol
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/pem"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func sshTestIO(promptResponses ...string) IO {
+	callIdx := 0
+	return IO{
+		Out:      &bytes.Buffer{},
+		Log:      slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		Username: "testuser",
+		PromptSecret: func(label string) (string, error) {
+			if callIdx >= len(promptResponses) {
+				return "", nil
+			}
+			resp := promptResponses[callIdx]
+			callIdx++
+			return resp, nil
+		},
+	}
+}
+
+func TestSSHEngine_Name(t *testing.T) {
+	e := &SSHEngine{}
+	if got := e.Name(); got != "SSH" {
+		t.Errorf("Name() = %q, want %q", got, "SSH")
+	}
+}
+
+func TestSSHEngine_Fields(t *testing.T) {
+	e := &SSHEngine{}
+	fields := e.Fields()
+	if len(fields) != 2 {
+		t.Fatalf("Fields() returned %d fields, want 2", len(fields))
+	}
+	if fields[0] != "public_key" || fields[1] != "private_key" {
+		t.Errorf("Fields() = %v, want [public_key private_key]", fields)
+	}
+}
+
+func TestSSHEngine_Unsafe_NoPassphrase(t *testing.T) {
+	e := &SSHEngine{}
+	io := sshTestIO() // no prompt responses needed
+	settings := map[string]any{"passphrase": "unsafe"}
+
+	creds, err := e.Run(context.Background(), settings, io)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Check both fields present
+	privPEM := creds["private_key"]
+	pubKey := creds["public_key"]
+	if privPEM == "" {
+		t.Fatal("private_key is empty")
+	}
+	if pubKey == "" {
+		t.Fatal("public_key is empty")
+	}
+
+	// Verify private key is valid OpenSSH PEM
+	block, _ := pem.Decode([]byte(privPEM))
+	if block == nil {
+		t.Fatal("private_key is not valid PEM")
+	}
+	if block.Type != "OPENSSH PRIVATE KEY" {
+		t.Errorf("PEM type = %q, want %q", block.Type, "OPENSSH PRIVATE KEY")
+	}
+
+	// Verify private key can be parsed without passphrase
+	rawKey, err := ssh.ParseRawPrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatalf("ParseRawPrivateKey() error: %v", err)
+	}
+	if _, ok := rawKey.(*ed25519.PrivateKey); !ok {
+		t.Errorf("parsed key type = %T, want *ed25519.PrivateKey", rawKey)
+	}
+
+	// Verify public key format
+	if !strings.HasPrefix(pubKey, "ssh-ed25519 ") {
+		t.Errorf("public_key does not start with 'ssh-ed25519 ': %q", pubKey)
+	}
+	if !strings.HasSuffix(pubKey, " testuser@dotvault") {
+		t.Errorf("public_key does not end with ' testuser@dotvault': %q", pubKey)
+	}
+
+	// Verify public key is parseable
+	_, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKey))
+	if err != nil {
+		t.Fatalf("ParseAuthorizedKey() error: %v", err)
+	}
+	if comment != "testuser@dotvault" {
+		t.Errorf("comment = %q, want %q", comment, "testuser@dotvault")
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -155,10 +155,10 @@ func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleEnrolPrompt(w http.ResponseWriter, r *http.Request) {
-	s.enrolPromptMu.Lock()
+	s.enrolPromptMu.RLock()
 	label := s.enrolPromptLabel
 	pending := s.enrolPromptCh != nil
-	s.enrolPromptMu.Unlock()
+	s.enrolPromptMu.RUnlock()
 
 	writeJSON(w, map[string]any{
 		"pending": pending,

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -154,6 +154,44 @@ func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"status": "sync triggered"})
 }
 
+func (s *Server) handleEnrolPrompt(w http.ResponseWriter, r *http.Request) {
+	s.enrolPromptMu.Lock()
+	label := s.enrolPromptLabel
+	pending := s.enrolPromptCh != nil
+	s.enrolPromptMu.Unlock()
+
+	writeJSON(w, map[string]any{
+		"pending": pending,
+		"label":   label,
+	})
+}
+
+func (s *Server) handleEnrolSecret(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	s.enrolPromptMu.Lock()
+	ch := s.enrolPromptCh
+	s.enrolPromptMu.Unlock()
+
+	if ch == nil {
+		writeError(w, "no pending prompt", http.StatusConflict)
+		return
+	}
+
+	select {
+	case ch <- req.Value:
+		writeJSON(w, map[string]any{"status": "accepted"})
+	default:
+		writeError(w, "prompt already answered", http.StatusConflict)
+	}
+}
+
 func writeJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -177,17 +177,20 @@ func (s *Server) handleEnrolSecret(w http.ResponseWriter, r *http.Request) {
 
 	s.enrolPromptMu.Lock()
 	ch := s.enrolPromptCh
-	s.enrolPromptMu.Unlock()
-
 	if ch == nil {
+		s.enrolPromptMu.Unlock()
 		writeError(w, "no pending prompt", http.StatusConflict)
 		return
 	}
 
 	select {
 	case ch <- req.Value:
+		s.enrolPromptCh = nil
+		s.enrolPromptLabel = ""
+		s.enrolPromptMu.Unlock()
 		writeJSON(w, map[string]any{"status": "accepted"})
 	default:
+		s.enrolPromptMu.Unlock()
 		writeError(w, "prompt already answered", http.StatusConflict)
 	}
 }

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/goodtune/dotvault/internal/config"
@@ -141,6 +142,98 @@ func TestHandleStatus_AuthMethod(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp["auth_method"] != "ldap" {
 		t.Errorf("auth_method = %v, want %q", resp["auth_method"], "ldap")
+	}
+}
+
+func TestHandleEnrolPrompt_NoPending(t *testing.T) {
+	s := testServer(t)
+	req := httptest.NewRequest("GET", "/api/v1/enrol/prompt", nil)
+	w := httptest.NewRecorder()
+
+	s.handleEnrolPrompt(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["pending"] != false {
+		t.Errorf("pending = %v, want false", resp["pending"])
+	}
+}
+
+func TestHandleEnrolPrompt_Pending(t *testing.T) {
+	s := testServer(t)
+	s.enrolPromptCh = make(chan string, 1)
+	s.enrolPromptLabel = "Enter passphrase:"
+
+	req := httptest.NewRequest("GET", "/api/v1/enrol/prompt", nil)
+	w := httptest.NewRecorder()
+
+	s.handleEnrolPrompt(w, req)
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["pending"] != true {
+		t.Errorf("pending = %v, want true", resp["pending"])
+	}
+	if resp["label"] != "Enter passphrase:" {
+		t.Errorf("label = %v, want %q", resp["label"], "Enter passphrase:")
+	}
+}
+
+func TestHandleEnrolSecret_NoPending(t *testing.T) {
+	s := testServer(t)
+	body := strings.NewReader(`{"value":"secret"}`)
+	req := httptest.NewRequest("POST", "/api/v1/enrol/secret", body)
+	w := httptest.NewRecorder()
+
+	s.handleEnrolSecret(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", w.Code)
+	}
+}
+
+func TestHandleEnrolSecret_Accepted(t *testing.T) {
+	s := testServer(t)
+	ch := make(chan string, 1)
+	s.enrolPromptCh = ch
+	s.enrolPromptLabel = "Enter passphrase:"
+
+	body := strings.NewReader(`{"value":"hunter2"}`)
+	req := httptest.NewRequest("POST", "/api/v1/enrol/secret", body)
+	w := httptest.NewRecorder()
+
+	s.handleEnrolSecret(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// Verify value was sent through the channel
+	val := <-ch
+	if val != "hunter2" {
+		t.Errorf("channel value = %q, want %q", val, "hunter2")
+	}
+	// Verify state was cleared atomically
+	if s.enrolPromptCh != nil {
+		t.Error("enrolPromptCh should be nil after accepted submission")
+	}
+	if s.enrolPromptLabel != "" {
+		t.Errorf("enrolPromptLabel = %q, want empty", s.enrolPromptLabel)
+	}
+}
+
+func TestHandleEnrolSecretRequiresCSRF(t *testing.T) {
+	s := testServer(t)
+	body := strings.NewReader(`{"value":"secret"}`)
+	req := httptest.NewRequest("POST", "/api/v1/enrol/secret", body)
+	w := httptest.NewRecorder()
+
+	s.requireCSRF(s.handleEnrolSecret)(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for missing CSRF", w.Code)
 	}
 }
 

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -164,8 +164,10 @@ func TestHandleEnrolPrompt_NoPending(t *testing.T) {
 
 func TestHandleEnrolPrompt_Pending(t *testing.T) {
 	s := testServer(t)
+	s.enrolPromptMu.Lock()
 	s.enrolPromptCh = make(chan string, 1)
 	s.enrolPromptLabel = "Enter passphrase:"
+	s.enrolPromptMu.Unlock()
 
 	req := httptest.NewRequest("GET", "/api/v1/enrol/prompt", nil)
 	w := httptest.NewRecorder()
@@ -198,8 +200,10 @@ func TestHandleEnrolSecret_NoPending(t *testing.T) {
 func TestHandleEnrolSecret_Accepted(t *testing.T) {
 	s := testServer(t)
 	ch := make(chan string, 1)
+	s.enrolPromptMu.Lock()
 	s.enrolPromptCh = ch
 	s.enrolPromptLabel = "Enter passphrase:"
+	s.enrolPromptMu.Unlock()
 
 	body := strings.NewReader(`{"value":"hunter2"}`)
 	req := httptest.NewRequest("POST", "/api/v1/enrol/secret", body)
@@ -216,11 +220,15 @@ func TestHandleEnrolSecret_Accepted(t *testing.T) {
 		t.Errorf("channel value = %q, want %q", val, "hunter2")
 	}
 	// Verify state was cleared atomically
-	if s.enrolPromptCh != nil {
+	s.enrolPromptMu.RLock()
+	promptCh := s.enrolPromptCh
+	promptLabel := s.enrolPromptLabel
+	s.enrolPromptMu.RUnlock()
+	if promptCh != nil {
 		t.Error("enrolPromptCh should be nil after accepted submission")
 	}
-	if s.enrolPromptLabel != "" {
-		t.Errorf("enrolPromptLabel = %q, want empty", s.enrolPromptLabel)
+	if promptLabel != "" {
+		t.Errorf("enrolPromptLabel = %q, want empty", promptLabel)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,11 +7,12 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 
 	"github.com/goodtune/dotvault/internal/auth"
 	"github.com/goodtune/dotvault/internal/config"
 	"github.com/goodtune/dotvault/internal/paths"
-	"github.com/goodtune/dotvault/internal/sync"
+	internalsync "github.com/goodtune/dotvault/internal/sync"
 	"github.com/goodtune/dotvault/internal/vault"
 )
 
@@ -19,7 +20,7 @@ import (
 type Server struct {
 	cfg                config.WebConfig
 	vault              *vault.Client
-	engine             *sync.Engine
+	engine             *internalsync.Engine
 	csrf               *CSRFStore
 	oauth              *OAuthManager
 	login              *auth.LoginTracker
@@ -40,6 +41,9 @@ type Server struct {
 	authDone           chan struct{}
 	readyCh            chan error
 	listenAddr         string
+	enrolPromptMu      sync.Mutex
+	enrolPromptLabel   string
+	enrolPromptCh      chan string
 }
 
 // ServerConfig holds all dependencies for the web server.
@@ -48,7 +52,7 @@ type ServerConfig struct {
 	VaultCfg      config.VaultConfig
 	Rules         []config.Rule
 	Vault         *vault.Client
-	Engine        *sync.Engine
+	Engine        *internalsync.Engine
 	Username      string
 	TokenFilePath string
 	Version       string
@@ -109,6 +113,10 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/v1/sync", s.requireCSRF(s.handleSync))
 	s.mux.HandleFunc("GET /api/v1/oauth/{rule}/start", s.handleOAuthStart)
 	s.mux.HandleFunc("GET /api/v1/oauth/callback", s.handleOAuthCallback)
+
+	// Enrolment prompt routes
+	s.mux.HandleFunc("GET /api/v1/enrol/prompt", s.handleEnrolPrompt)
+	s.mux.HandleFunc("POST /api/v1/enrol/secret", s.requireCSRF(s.handleEnrolSecret))
 
 	// Static SPA files
 	staticSub, err := fs.Sub(staticFS, "static")
@@ -191,4 +199,30 @@ func (s *Server) URL() string {
 
 func (s *Server) userKVPrefix() string {
 	return s.userPrefix + s.username + "/"
+}
+
+// EnrolPromptSecret implements a web-based PromptSecret. It sets the pending
+// prompt state and blocks until the frontend submits a value via the
+// /api/v1/enrol/secret endpoint, or the context is cancelled.
+func (s *Server) EnrolPromptSecret(ctx context.Context, label string) (string, error) {
+	ch := make(chan string, 1)
+
+	s.enrolPromptMu.Lock()
+	s.enrolPromptLabel = label
+	s.enrolPromptCh = ch
+	s.enrolPromptMu.Unlock()
+
+	defer func() {
+		s.enrolPromptMu.Lock()
+		s.enrolPromptLabel = ""
+		s.enrolPromptCh = nil
+		s.enrolPromptMu.Unlock()
+	}()
+
+	select {
+	case val := <-ch:
+		return val, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -41,7 +41,7 @@ type Server struct {
 	authDone           chan struct{}
 	readyCh            chan error
 	listenAddr         string
-	enrolPromptMu      sync.Mutex
+	enrolPromptMu      sync.RWMutex
 	enrolPromptLabel   string
 	enrolPromptCh      chan string
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -208,14 +208,20 @@ func (s *Server) EnrolPromptSecret(ctx context.Context, label string) (string, e
 	ch := make(chan string, 1)
 
 	s.enrolPromptMu.Lock()
+	if s.enrolPromptCh != nil {
+		s.enrolPromptMu.Unlock()
+		return "", fmt.Errorf("enrol prompt already pending")
+	}
 	s.enrolPromptLabel = label
 	s.enrolPromptCh = ch
 	s.enrolPromptMu.Unlock()
 
 	defer func() {
 		s.enrolPromptMu.Lock()
-		s.enrolPromptLabel = ""
-		s.enrolPromptCh = nil
+		if s.enrolPromptCh == ch {
+			s.enrolPromptLabel = ""
+			s.enrolPromptCh = nil
+		}
 		s.enrolPromptMu.Unlock()
 	}()
 


### PR DESCRIPTION
## Summary

- Add SSH enrolment engine that generates Ed25519 key pairs in OpenSSH format, stored as `public_key` and `private_key` fields in Vault KVv2
- Three-tier passphrase policy: `required` (default), `recommended`, `unsafe` -- double-entry verification with masked input
- Extend `IO` struct with `Username` and `PromptSecret` fields to support identity-aware engines and masked user input
- CLI passphrase prompt via `golang.org/x/term`, web prompt via new `GET /api/v1/enrol/prompt` and `POST /api/v1/enrol/secret` endpoints
- Guard against non-interactive terminals with clear error message suggesting web UI or `passphrase: unsafe`
- Reject concurrent enrolment prompts and prevent double-POST race on secret submission
- 9 SSH engine unit tests covering all passphrase modes, key validity, and error cases; 5 web handler tests for enrolment prompt/secret endpoints
- Design spec and implementation plan in `docs/superpowers/specs/` and `docs/superpowers/plans/`

## Test plan

- [ ] `go test ./internal/enrol/ -run TestSSH -v` passes all 9 SSH engine tests
- [ ] `go test ./internal/web/ -run TestHandleEnrol -v` passes all 5 web handler tests
- [ ] `go test ./... -short` passes full test suite
- [ ] Manual: configure `enrolments.ssh` with `engine: ssh` and `passphrase: required`, verify key generation via wizard
- [ ] Manual: with web UI enabled, verify passphrase prompt appears in browser