### PR TITLE
Add JFrog Platform enrolment + token-refresh ownership + opt-in local dev stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,21 +203,32 @@ Overridable via settings: `client_id`, `scopes`, `host`. Returns `{"oauth_token"
 
 ### JFrog Engine
 
-Mirrors the `jf login` web login flow from `jfrog-cli`. No public OAuth app exists — JFrog Platform hosts its own browser login endpoint, so the engine just requires the platform URL.
+Mirrors the `jf login` web login flow from `jfrog-cli`, then mints a dotvault-owned refreshable token with a configurable TTL. No public OAuth app exists — JFrog Platform hosts its own browser login endpoint, so the engine just requires the platform URL.
 
 Required settings:
 - `url` — JFrog Platform URL (e.g. `https://mycompany.jfrog.io`)
 
-Defaults (from the upstream `jfrog-cli-core` source, overridable via settings):
+Optional settings:
+- `token_ttl` — lifetime of the dotvault-minted access token. Accepts `time.ParseDuration` syntax plus `Nd` for whole days (e.g. `60d`, `6h`, `10m`). Default `60d`. Floor `10m` — validated at config-load time. Non-admin users can mint refreshable tokens at any non-zero TTL; only the never-expire case (`expires_in=0`) requires admin.
 - `client_name`: `JFrog-CLI` (sent as `jfClientName` query parameter)
 - `client_code`: `1` (sent as `jfClientCode` query parameter)
 
-Flow:
+Flow (enrolment — runs once per user):
 1. POST `{url}/access/api/v2/authentication/jfrog_client_login/request` with a random UUID
 2. Open `{url}/ui/login?jfClientSession=<uuid>&jfClientName=JFrog-CLI&jfClientCode=1` — user confirms the last 4 chars of the UUID after sign-in
-3. Poll GET `{url}/access/api/v2/authentication/jfrog_client_login/token/<uuid>` until 200
+3. Poll GET `{url}/access/api/v2/authentication/jfrog_client_login/token/<uuid>` until 200 — returns a bootstrap token with the JFrog server default TTL (typically 1 year)
+4. POST `{url}/access/api/v2/tokens` with `Authorization: Bearer <bootstrap>` and `{"expires_in":<token_ttl_seconds>,"refreshable":true,"scope":"applied-permissions/user"}` — mints the dotvault-owned pair; the bootstrap token is discarded
 
-Returns the full identity needed to render a `jfrog-cli.conf.v6` server entry: `{"access_token", "refresh_token", "token_type", "expires_in", "scope", "url", "server_id", "user"}`. `server_id` is deduced from the platform hostname (e.g. `mycompany.jfrog.io` → `mycompany`, IP addresses → `default-server`); `user` is extracted from the access-token JWT subject. Requires JFrog Artifactory 7.64.0 or newer on the remote side.
+Flow (refresh — periodic, driven by `RefreshManager`):
+1. Every `check_interval` (daemon-wired at 5 min), iterate all enrolments whose engine implements `Refresher`
+2. For each, read the secret and skip unless `now >= issued_at + (expires_at - issued_at) / 2`
+3. POST `{url}/access/api/v1/tokens` with `grant_type=refresh_token&access_token=<current>&refresh_token=<current>` — **JFrog rotates both tokens on every successful refresh**, so the old refresh_token is invalid immediately
+4. Stamp new `issued_at: now`, `expires_at: now + token_ttl` (dotvault's configured TTL, not whatever JFrog returns), write the replacement map atomically
+5. `401`/`403` from the refresh endpoint is treated as permanent revocation — the secret is deleted from Vault and the user is prompted to re-enrol. Other errors are transient; the existing secret is kept and retried with exponential backoff
+
+Vault schema (7 fields): `access_token`, `refresh_token`, `url`, `server_id`, `user`, `issued_at` (RFC3339), `expires_at` (RFC3339). The rendered `jfrog-cli.conf.v6` only contains `accessToken` — `refreshToken` and `webLogin: true` are deliberately omitted so `jf` never attempts its own refresh (which would race the sync-engine clobber).
+
+`server_id` is deduced from the platform hostname (e.g. `mycompany.jfrog.io` → `mycompany`, IP addresses → `default-server`); `user` is extracted from the access-token JWT subject. Requires JFrog Artifactory 7.64.0 or newer on the remote side.
 
 ### SSH Engine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Automated credential acquisition from external services (`internal/enrol/`). Enr
 
 ### Engine Interface
 
-Engines implement `Name()`, `Run(ctx, settings, io)`, and `Fields()`. Registered in a package-level map. Currently implemented: GitHub (OAuth device flow), SSH (Ed25519 key generation).
+Engines implement `Name()`, `Run(ctx, settings, io)`, and `Fields()`. Registered in a package-level map. Currently implemented: GitHub (OAuth device flow), JFrog (browser-based web login), SSH (Ed25519 key generation).
 
 ### GitHub Engine Defaults
 
@@ -198,6 +198,24 @@ Engines implement `Name()`, `Run(ctx, settings, io)`, and `Fields()`. Registered
 - Host: `github.com`
 
 Overridable via settings: `client_id`, `scopes`, `host`. Returns `{"oauth_token": "<token>", "user": "<username>"}`.
+
+### JFrog Engine
+
+Mirrors the `jf login` web login flow from `jfrog-cli`. No public OAuth app exists — JFrog Platform hosts its own browser login endpoint, so the engine just requires the platform URL.
+
+Required settings:
+- `url` — JFrog Platform URL (e.g. `https://mycompany.jfrog.io`)
+
+Defaults (from the upstream `jfrog-cli-core` source, overridable via settings):
+- `client_name`: `JFrog-CLI` (sent as `jfClientName` query parameter)
+- `client_code`: `1` (sent as `jfClientCode` query parameter)
+
+Flow:
+1. POST `{url}/access/api/v2/authentication/jfrog_client_login/request` with a random UUID
+2. Open `{url}/ui/login?jfClientSession=<uuid>&jfClientName=JFrog-CLI&jfClientCode=1` — user confirms the last 4 chars of the UUID after sign-in
+3. Poll GET `{url}/access/api/v2/authentication/jfrog_client_login/token/<uuid>` until 200
+
+Returns the full identity needed to render a `jfrog-cli.conf.v6` server entry: `{"access_token", "refresh_token", "token_type", "expires_in", "scope", "url", "server_id", "user"}`. `server_id` is deduced from the platform hostname (e.g. `mycompany.jfrog.io` → `mycompany`, IP addresses → `default-server`); `user` is extracted from the access-token JWT subject. Requires JFrog Artifactory 7.64.0 or newer on the remote side.
 
 ### SSH Engine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ go run ./cmd/dotvault run --config config.dev.yaml
 
 Requires `127.0.0.1 dex` in `/etc/hosts`. Dex uses a mockCallback connector that auto-approves login. The dev Vault listens on `127.0.0.1:8200`; the dotvault web UI is configured on port 9000 (`127.0.0.1:9000`) in `config.dev.yaml` to avoid conflict.
 
+JFrog enrolment testing is opt-in: `docker compose --profile jfrog up -d` additionally starts a local Artifactory JCR on port 8082 alongside a Postgres sidecar (required by Artifactory 7.78+). Plain `docker compose up -d` does not include them. Allow ~3 minutes on the first cold start for JFrog to finish its cluster-join. The admin account keeps the out-of-the-box `admin`/`password` credentials; Artifactory forces a password change on first UI login.
+
 The vault-init container seeds sample secrets, enables OIDC auth via Dex, and exports the root token to `/vault/data/root-token`.
 
 `config.dev.yaml` points at the local Vault (`http://127.0.0.1:8200`), enables the web UI on port 9000, and configures all available enrolment engines. When adding a new enrolment engine, add a corresponding entry to `config.dev.yaml` under the `enrolments` section so the dev config exercises all available engines.

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -243,6 +243,18 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	// Start token lifecycle manager.
 	lm := auth.NewLifecycleManager(vc, 5*time.Minute)
 	lifecycleErrCh := lm.Start(ctx)
+
+	// Start refresh manager for any enrolment whose engine rotates its own
+	// credentials (currently JFrog). Failures are logged and retried on the
+	// next tick — never fatal to the daemon.
+	rm := enrol.NewRefreshManager(
+		vc,
+		cfg.Vault.KVMount,
+		cfg.Vault.UserPrefix+username+"/",
+		cfg.Enrolments,
+		5*time.Minute,
+	)
+	rm.Start(ctx)
 	go func() {
 		const reauthCooldown = 10 * time.Minute
 		var lastReauthOpen time.Time
@@ -329,6 +341,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 					if !reflect.DeepEqual(reloaded.Enrolments, lastEnrolments) {
 						slog.Info("enrolments config changed, re-checking")
 						enrolMgr.UpdateConfig(reloaded.Enrolments)
+						rm.UpdateConfig(reloaded.Enrolments)
 						lastEnrolments = reloaded.Enrolments
 					}
 					if ok, err := enrolMgr.CheckAll(ctx); err != nil {

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -78,5 +78,5 @@ enrolments:
   jfrog:
     engine: jfrog
     settings:
-      # Point at your JFrog Platform. Required — no sensible default exists.
-      url: "https://mycompany.jfrog.io"
+      # Local Artifactory JCR from `docker compose --profile jfrog`.
+      url: "http://127.0.0.1:8082"

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -60,8 +60,6 @@ rules:
               "accessUrl": "{{ .url }}/access/",
               "user": "{{ .user | default "" }}",
               "accessToken": "{{ .access_token }}",
-              "refreshToken": "{{ .refresh_token | default "" }}",
-              "webLogin": true,
               "isDefault": true
             }
           ],
@@ -80,3 +78,6 @@ enrolments:
     settings:
       # Local Artifactory JCR from `docker compose --profile jfrog`.
       url: "http://127.0.0.1:8082"
+      # Shorter-than-production TTL so the refresh cycle gets exercised
+      # during normal dev-loop sessions (halfway point = 3 h).
+      token_ttl: "6h"

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -41,6 +41,33 @@ rules:
       path: "~/tmp/.netrc"
       format: netrc
 
+  - name: jfrog
+    vault_key: "jfrog"
+    target:
+      path: "~/tmp/.jfrog/jfrog-cli.conf.v6"
+      format: json
+      template: |
+        {
+          "servers": [
+            {
+              "serverId": "{{ .server_id }}",
+              "url": "{{ .url }}/",
+              "artifactoryUrl": "{{ .url }}/artifactory/",
+              "distributionUrl": "{{ .url }}/distribution/",
+              "xrayUrl": "{{ .url }}/xray/",
+              "missionControlUrl": "{{ .url }}/mc/",
+              "pipelinesUrl": "{{ .url }}/pipelines/",
+              "accessUrl": "{{ .url }}/access/",
+              "user": "{{ .user | default "" }}",
+              "accessToken": "{{ .access_token }}",
+              "refreshToken": "{{ .refresh_token | default "" }}",
+              "webLogin": true,
+              "isDefault": true
+            }
+          ],
+          "version": "6"
+        }
+
 enrolments:
   gh:
     engine: github
@@ -48,3 +75,8 @@ enrolments:
     engine: ssh
     settings:
       passphrase: "recommended"
+  jfrog:
+    engine: jfrog
+    settings:
+      # Point at your JFrog Platform. Required — no sensible default exists.
+      url: "https://mycompany.jfrog.io"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -124,6 +124,65 @@ services:
     volumes:
       - vault-data:/vault/data
 
+  # Opt-in Artifactory JCR + Postgres for exercising the JFrog enrolment
+  # engine. Activated by `docker compose --profile jfrog up -d`. Plain `up`
+  # skips both. Artifactory 7.78+ no longer supports the embedded Derby DB,
+  # so Postgres is required even for single-node dev use.
+  artifactory-db:
+    image: postgres:16-alpine
+    container_name: dotvault-artifactory-db
+    profiles: ["jfrog"]
+    environment:
+      POSTGRES_USER: artifactory
+      POSTGRES_PASSWORD: dotvault-dev
+      POSTGRES_DB: artifactory
+    volumes:
+      - artifactory-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U artifactory -d artifactory"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  artifactory:
+    image: releases-docker.jfrog.io/jfrog/artifactory-jcr:7.98.9
+    container_name: dotvault-artifactory
+    profiles: ["jfrog"]
+    depends_on:
+      artifactory-db:
+        condition: service_healthy
+    ports:
+      - "8082:8082"
+    environment:
+      # Dev-only deterministic master/join keys. Artifactory refuses to start
+      # without these and its auto-generation on first boot is unreliable on
+      # Docker Desktop volumes; pinning them sidesteps that. NOT SECRETS —
+      # this stack binds only to loopback and is for enrolment testing.
+      JF_SHARED_SECURITY_MASTERKEY: "deadbeefcafebabe0123456789abcdeffedcba98765432100123456789abcdef"
+      JF_SHARED_SECURITY_JOINKEY: "cafebabedeadbeef00112233445566778899aabbccddeeff0011223344556677"
+      JF_SHARED_DATABASE_TYPE: "postgresql"
+      JF_SHARED_DATABASE_DRIVER: "org.postgresql.Driver"
+      JF_SHARED_DATABASE_URL: "jdbc:postgresql://artifactory-db:5432/artifactory"
+      JF_SHARED_DATABASE_USERNAME: "artifactory"
+      JF_SHARED_DATABASE_PASSWORD: "dotvault-dev"
+    volumes:
+      - artifactory-data:/var/opt/jfrog/artifactory
+    mem_limit: 4g
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 32000
+        hard: 40000
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8082/artifactory/api/system/ping >/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 120s
+
 volumes:
   vault-data:
   dex-data:
+  artifactory-data:
+  artifactory-db-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -152,8 +152,11 @@ services:
     depends_on:
       artifactory-db:
         condition: service_healthy
+    # Bind explicitly to loopback so the dev-only admin password + pinned
+    # master/join keys aren't reachable from the LAN. The plain "8082:8082"
+    # form binds on all interfaces on Docker Desktop.
     ports:
-      - "8082:8082"
+      - "127.0.0.1:8082:8082"
     environment:
       # Dev-only deterministic master/join keys. Artifactory refuses to start
       # without these and its auto-generation on first boot is unreliable on

--- a/docs/superpowers/plans/2026-04-16-artifactory-e2e.md
+++ b/docs/superpowers/plans/2026-04-16-artifactory-e2e.md
@@ -2,6 +2,30 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Status (2026-04-17):** Historical planning artifact — preserved for
+> audit trail. **What actually shipped differs from this plan**:
+>
+> - The `artifactory-init` sidecar was dropped mid-execution because
+>   rotating the admin password via REST was unreliable across Artifactory
+>   UI versions. The default `admin` / `password` credentials are kept
+>   as-is; Artifactory forces a first-login change that happens naturally
+>   during the Playwright verification flow.
+> - A `artifactory-db` Postgres sidecar was added (not in the original
+>   plan) because Artifactory 7.78+ dropped the embedded Derby database
+>   and fails to start without an external database.
+> - `JF_SHARED_SECURITY_MASTERKEY` and `JF_SHARED_SECURITY_JOINKEY` are
+>   pinned to deterministic hex fixtures; auto-generation is unreliable
+>   on Docker Desktop volumes.
+> - The `8082:8082` port mapping was tightened to `127.0.0.1:8082:8082`
+>   after a Copilot review noted the dev-only credentials + fixed keys
+>   would otherwise be reachable from the LAN.
+>
+> Refer to the current `docker-compose.yaml` and the companion spec
+> (`docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md`, which
+> has been updated to match what shipped) for the authoritative setup.
+> The step-by-step below is left intact so the decision history is not
+> lost.
+
 **Goal:** Add an opt-in local Artifactory JCR to `docker-compose.yaml` so the `JFrogEngine` can be exercised end-to-end, then verify the full browser-based enrolment flow once via the Playwright MCP.
 
 **Architecture:** Two new services (`artifactory`, `artifactory-init`) gated by `profiles: ["jfrog"]` so plain `docker compose up -d` stays lean. `artifactory-init` mirrors the existing `vault-init` pattern: waits for the healthcheck, then uses the default `admin/password` credentials to reset the admin password to `dotvault-dev` via REST, idempotently. No Go code changes.

--- a/docs/superpowers/plans/2026-04-16-artifactory-e2e.md
+++ b/docs/superpowers/plans/2026-04-16-artifactory-e2e.md
@@ -1,0 +1,434 @@
+# Local Artifactory E2E Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in local Artifactory JCR to `docker-compose.yaml` so the `JFrogEngine` can be exercised end-to-end, then verify the full browser-based enrolment flow once via the Playwright MCP.
+
+**Architecture:** Two new services (`artifactory`, `artifactory-init`) gated by `profiles: ["jfrog"]` so plain `docker compose up -d` stays lean. `artifactory-init` mirrors the existing `vault-init` pattern: waits for the healthcheck, then uses the default `admin/password` credentials to reset the admin password to `dotvault-dev` via REST, idempotently. No Go code changes.
+
+**Tech Stack:** Docker Compose v2 profiles, `releases-docker.jfrog.io/jfrog/artifactory-jcr:7.98.9` (multi-arch, arm64 native on Apple Silicon), the existing dotvault Go daemon + Preact web UI, and the Playwright MCP for one-shot verification.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `docker-compose.yaml` | Dev stack orchestration | Add `artifactory` + `artifactory-init` services under `profiles: ["jfrog"]`; add `artifactory-data` named volume |
+| `config.dev.yaml` | dotvault dev config | Point `enrolments.jfrog.settings.url` at `http://127.0.0.1:8082` |
+| `CLAUDE.md` | Contributor reference | One-sentence Local Development note about `docker compose --profile jfrog up -d` |
+
+No Go source, no tests, no docs under `docs/services/` change. The Playwright verification in Task 4 produces no committed artefact.
+
+---
+
+## Task 1: Add Artifactory services to docker-compose
+
+**Files:**
+- Modify: `docker-compose.yaml`
+
+- [ ] **Step 1: Read the current docker-compose.yaml**
+
+Check existing structure, confirm the `volumes:` block at the bottom and the `vault-init` service pattern you're mirroring.
+
+- [ ] **Step 2: Add the `artifactory` service**
+
+Insert after the existing `vault-init` service block, before the `volumes:` block at the bottom of the file. The service must be tagged with the `jfrog` profile.
+
+```yaml
+  artifactory:
+    image: releases-docker.jfrog.io/jfrog/artifactory-jcr:7.98.9
+    container_name: dotvault-artifactory
+    profiles: ["jfrog"]
+    ports:
+      - "8082:8082"
+    volumes:
+      - artifactory-data:/var/opt/jfrog/artifactory
+    mem_limit: 4g
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 32000
+        hard: 40000
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8082/artifactory/api/system/ping >/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 120s
+```
+
+- [ ] **Step 3: Add the `artifactory-init` service**
+
+Insert immediately after the `artifactory` service block.
+
+```yaml
+  artifactory-init:
+    image: alpine:3.20
+    container_name: dotvault-artifactory-init
+    profiles: ["jfrog"]
+    depends_on:
+      artifactory:
+        condition: service_healthy
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        set -eu
+        apk add --no-cache curl >/dev/null
+
+        echo "==> Checking if admin/password still works..."
+        code=$$(curl -s -o /dev/null -w '%{http_code}' \
+          -u admin:password \
+          http://artifactory:8082/artifactory/api/system/ping || true)
+
+        if [ "$$code" = "401" ] || [ "$$code" = "403" ]; then
+          echo "==> Admin already rotated (got HTTP $$code), nothing to do."
+          exit 0
+        fi
+
+        if [ "$$code" != "200" ]; then
+          echo "==> Unexpected ping status $$code with default creds; aborting." >&2
+          exit 1
+        fi
+
+        echo "==> Rotating admin password to dev fixture..."
+        status=$$(curl -s -o /tmp/resp -w '%{http_code}' \
+          -u admin:password \
+          -H 'Content-Type: application/json' \
+          -X POST \
+          -d '{"userName":"admin","oldPassword":"password","newPassword1":"dotvault-dev","newPassword2":"dotvault-dev"}' \
+          http://artifactory:8082/artifactory/api/security/users/authorization/changePassword)
+
+        if [ "$$status" != "200" ] && [ "$$status" != "204" ]; then
+          echo "==> changePassword failed (HTTP $$status):" >&2
+          cat /tmp/resp >&2 || true
+          exit 1
+        fi
+
+        echo "==> admin password set to 'dotvault-dev'."
+```
+
+- [ ] **Step 4: Add the `artifactory-data` volume**
+
+Extend the existing `volumes:` block at the bottom of the file.
+
+```yaml
+volumes:
+  vault-data:
+  dex-data:
+  artifactory-data:
+```
+
+- [ ] **Step 5: Validate docker-compose syntax**
+
+Run: `docker compose config --profile jfrog >/dev/null`
+Expected: exits 0, no warnings about unknown keys.
+
+- [ ] **Step 6: Verify the profile gate**
+
+Run: `docker compose config --services | sort`
+Expected output (plain `up` does NOT surface the jfrog services):
+```
+dex
+vault
+vault-init
+```
+
+Run: `docker compose --profile jfrog config --services | sort`
+Expected:
+```
+artifactory
+artifactory-init
+dex
+vault
+vault-init
+```
+
+- [ ] **Step 7: Bring the stack up**
+
+Run: `docker compose --profile jfrog up -d`
+
+- [ ] **Step 8: Wait for Artifactory to be healthy**
+
+Run: `docker compose --profile jfrog ps artifactory`
+Expected: `STATUS` column eventually shows `healthy` (allow up to 3 minutes on first boot — the image is ~2 GB and JFrog seeds its internal Derby DB on first start). Use `watch -n 5 'docker compose --profile jfrog ps artifactory'` or re-run until healthy.
+
+- [ ] **Step 9: Confirm `artifactory-init` exited cleanly**
+
+Run: `docker compose --profile jfrog logs artifactory-init`
+Expected: ends with `==> admin password set to 'dotvault-dev'.`
+
+Run: `docker inspect --format='{{.State.ExitCode}}' dotvault-artifactory-init`
+Expected: `0`
+
+- [ ] **Step 10: Sanity-check the new admin password**
+
+Run:
+```bash
+curl -sS -u admin:dotvault-dev http://127.0.0.1:8082/artifactory/api/system/ping
+```
+Expected: `OK`
+
+Run (negative check — old creds must be rejected):
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -u admin:password \
+  http://127.0.0.1:8082/artifactory/api/system/ping
+```
+Expected: `401` or `403`.
+
+- [ ] **Step 11: Confirm the web-login endpoint is live**
+
+Run:
+```bash
+curl -sS -X POST -H 'Content-Type: application/json' \
+  -d '{"session":"00000000-0000-4000-8000-000000000000"}' \
+  -w '\nHTTP %{http_code}\n' \
+  http://127.0.0.1:8082/access/api/v2/authentication/jfrog_client_login/request
+```
+Expected: `HTTP 200` in the trailing line. Any 404 means the Access service version is too old or the image mismatches the spec — stop and report.
+
+- [ ] **Step 12: Test idempotency**
+
+Run:
+```bash
+docker compose --profile jfrog rm -fsv artifactory-init
+docker compose --profile jfrog up -d artifactory-init
+docker compose --profile jfrog logs artifactory-init --tail=10
+```
+Expected: logs contain `==> Admin already rotated (got HTTP 401), nothing to do.` and exit code `0`.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add docker-compose.yaml
+git commit -m "$(cat <<'EOF'
+Add opt-in Artifactory JCR to dev compose stack
+
+Two new services under profiles: [jfrog] so plain `docker compose up -d`
+is unaffected. artifactory-init mirrors vault-init: waits for the
+healthcheck, then rotates the default admin password to dotvault-dev
+via REST, idempotently.
+
+Used to exercise the JFrogEngine end-to-end against a real Access
+service. See docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Point dev dotvault at the local Artifactory
+
+**Files:**
+- Modify: `config.dev.yaml`
+
+- [ ] **Step 1: Edit `config.dev.yaml`**
+
+Replace the `url:` line under `enrolments.jfrog.settings` with the local URL. The full `enrolments` block should read:
+
+```yaml
+enrolments:
+  gh:
+    engine: github
+  ssh:
+    engine: ssh
+    settings:
+      passphrase: "recommended"
+  jfrog:
+    engine: jfrog
+    settings:
+      # Local Artifactory JCR from `docker compose --profile jfrog`.
+      url: "http://127.0.0.1:8082"
+```
+
+- [ ] **Step 2: Validate config loads cleanly**
+
+Run: `go run ./cmd/dotvault run --config config.dev.yaml --dry-run --once 2>&1 | head -40`
+Expected: the daemon starts up, logs enrolment engines (including `jfrog`), exits after the one-shot sync without config-validation errors. (The sync itself may succeed or warn depending on Vault state — we're only checking config parse, so ignore errors about missing secrets.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config.dev.yaml
+git commit -m "$(cat <<'EOF'
+Point dev JFrog enrolment at local Artifactory
+
+Matches the new docker-compose profile: [jfrog] service on port 8082.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Document the opt-in profile in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (Local Development section)
+
+- [ ] **Step 1: Locate the Local Development section**
+
+Run: `grep -n '^## Local Development' CLAUDE.md`
+Note the line number.
+
+- [ ] **Step 2: Add a one-sentence note**
+
+Insert the following paragraph immediately after the existing paragraph that ends with `…web UI is configured on port 9000 (\`127.0.0.1:9000\`) in \`config.dev.yaml\` to avoid conflict.` (i.e. right before the `The vault-init container seeds…` paragraph):
+
+```markdown
+JFrog enrolment testing is opt-in: `docker compose --profile jfrog up -d` additionally starts a local Artifactory JCR on port 8082 (admin password `dotvault-dev`, credentials rotated on first boot by the `artifactory-init` sidecar). Plain `docker compose up -d` does not include it. Allow ~2 minutes on the first cold start for JFrog to seed its internal database.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+Document opt-in JFrog profile in Local Development
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Playwright E2E verification (one-shot, not committed)
+
+**Files:** none modified; this task produces evidence, not artefacts.
+
+**Prerequisites:**
+- Tasks 1–3 committed.
+- `docker compose --profile jfrog up -d` running, all services healthy (re-check `docker compose --profile jfrog ps`).
+- No existing dotvault daemon on `:9000` (check `lsof -iTCP:9000 -sTCP:LISTEN` — kill any stray `dotvault` process).
+- `~/tmp/.jfrog/` does not exist yet, so the sync definitively writes a fresh file (run `rm -rf ~/tmp/.jfrog`).
+- `/etc/hosts` has the existing `127.0.0.1 dex` entry.
+
+- [ ] **Step 1: Wipe any stale jfrog secret in Vault**
+
+Run:
+```bash
+ROOT_TOKEN=$(docker exec dotvault-vault cat /vault/data/root-token)
+docker exec -e VAULT_TOKEN="$ROOT_TOKEN" dotvault-vault \
+  vault kv delete kv/users/gary/jfrog 2>/dev/null || true
+docker exec -e VAULT_TOKEN="$ROOT_TOKEN" dotvault-vault \
+  vault kv metadata delete kv/users/gary/jfrog 2>/dev/null || true
+```
+Expected: either `Success!` or a "secret not found" message — both are fine.
+
+- [ ] **Step 2: Start the daemon in the background**
+
+Run:
+```bash
+go run ./cmd/dotvault run --config config.dev.yaml --log-level debug \
+  > /tmp/dotvault.log 2>&1 &
+echo $! > /tmp/dotvault.pid
+```
+
+Then: `sleep 3 && curl -fsS http://127.0.0.1:9000/api/v1/status >/dev/null && echo "daemon up"`
+Expected: `daemon up`.
+
+- [ ] **Step 3: Navigate to the dotvault UI via Playwright MCP**
+
+Use `mcp__plugin_playwright_playwright__browser_navigate` with `url: http://127.0.0.1:9000`.
+
+Then `mcp__plugin_playwright_playwright__browser_snapshot` to capture the DOM — expect the dotvault sign-in page.
+
+- [ ] **Step 4: Complete OIDC sign-in via Dex**
+
+Click the "Sign in with OIDC" button (use `browser_click` with the ref from the snapshot).
+
+Dex's mockCallback connector auto-approves; the browser will redirect through `http://dex:5556/...` and land back on dotvault at the enrolment page. Re-snapshot to confirm the enrolment cards (`gh`, `ssh`, `jfrog`) are visible.
+
+- [ ] **Step 5: Start the JFrog enrolment**
+
+Click the `Start` button on the JFrog card.
+
+Snapshot the page and capture two values from the DOM:
+- The displayed confirmation code (last 4 chars of the UUID).
+- The Artifactory login URL (should match `http://127.0.0.1:8082/ui/login?jfClientSession=<uuid>&jfClientName=JFrog-CLI&jfClientCode=1`).
+
+Record both — you will need them in Step 7.
+
+- [ ] **Step 6: Navigate the same browser context to Artifactory login**
+
+Use `browser_navigate` with the captured URL from Step 5. Artifactory's sign-in form appears.
+
+Fill in `admin` / `dotvault-dev` and submit. On first real login Artifactory may prompt to change the password again; if so, accept the current one as the new one (or dismiss if the UI allows). Expect to land on the "Confirm authorization for JFrog-CLI" screen showing the same last-4 chars captured in Step 5.
+
+- [ ] **Step 7: Verify the confirmation code matches and accept**
+
+Compare the last-4 chars displayed by Artifactory against the value captured in Step 5. They MUST match. If they don't, stop — something is wrong with session plumbing.
+
+Click `Accept` (or the button labeled to authorise the client).
+
+- [ ] **Step 8: Wait for dotvault to finish polling**
+
+Navigate back to `http://127.0.0.1:9000`, snapshot. The JFrog card should transition to `complete`. If still `pending`, wait 5 seconds and re-snapshot (the engine polls every 3 s; max 5 min).
+
+- [ ] **Step 9: Verify the Vault secret**
+
+Run:
+```bash
+ROOT_TOKEN=$(docker exec dotvault-vault cat /vault/data/root-token)
+docker exec -e VAULT_TOKEN="$ROOT_TOKEN" dotvault-vault \
+  vault kv get -format=json kv/users/gary/jfrog | \
+  python3 -c 'import json,sys; d=json.load(sys.stdin)["data"]["data"]; print(json.dumps({k: (v[:20]+"..." if k in ("access_token","refresh_token") else v) for k,v in d.items()}, indent=2))'
+```
+
+Expected — every one of these fields present:
+- `access_token` (JWT-looking string)
+- `refresh_token` (non-empty)
+- `token_type`: `Bearer`
+- `expires_in` (a numeric string like `"31536000"`)
+- `url`: `http://127.0.0.1:8082`
+- `server_id`: `default-server` (because the hostname is an IP)
+- `user`: `admin`
+
+- [ ] **Step 10: Verify the rendered config file**
+
+Run: `cat ~/tmp/.jfrog/jfrog-cli.conf.v6 | python3 -m json.tool`
+Expected: valid JSON, `servers[0].serverId == "default-server"`, `servers[0].url == "http://127.0.0.1:8082/"`, `servers[0].user == "admin"`, `servers[0].accessToken` is a non-empty string matching the Vault `access_token`.
+
+- [ ] **Step 11: Prove the minted token actually works**
+
+Run:
+```bash
+TOKEN=$(python3 -c 'import json; print(json.load(open("/Users/gary/tmp/.jfrog/jfrog-cli.conf.v6"))["servers"][0]["accessToken"])')
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8082/artifactory/api/system/ping
+```
+Expected: `OK`.
+
+- [ ] **Step 12: Tear down**
+
+Run:
+```bash
+kill "$(cat /tmp/dotvault.pid)" && rm -f /tmp/dotvault.pid
+```
+
+Leave the docker compose stack up — the user may want to inspect it. Do NOT `docker compose down` unless the user asks.
+
+- [ ] **Step 13: Report evidence**
+
+Summarise to the user:
+- The Vault fields captured in Step 9 (with tokens truncated).
+- The rendered `jfrog-cli.conf.v6` `user` / `url` / `serverId`.
+- The Step 11 `curl` result proving the token is live.
+
+This is the terminal state. No commit — Task 4 is verification, not code.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Architecture (Task 1), dotvault config (Task 2), CLAUDE.md (Task 3), Playwright flow (Task 4). All spec sections covered.
+- **Placeholders:** none — every command, env var, expected output, and DOM interaction is spelled out.
+- **Type/name consistency:** service names (`artifactory`, `artifactory-init`), container names (`dotvault-artifactory`, `dotvault-artifactory-init`), volume (`artifactory-data`), admin password (`dotvault-dev`), image tag (`7.98.9`), port (`8082`) all consistent across tasks.
+- **Risk flagged:** Step 1.11 (`jfrog_client_login/request` live check) and Step 4.7 (confirmation-code match) are explicit fail-early gates for the two assumptions most likely to break: image version supports the endpoint, and the session plumbing round-trips correctly.

--- a/docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md
+++ b/docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md
@@ -18,34 +18,30 @@ One-shot verification only. No committed E2E test, no CI wiring.
 
 ## Architecture
 
-Three new services in `docker-compose.yaml`, all tagged `profiles: ["jfrog"]` so they are skipped by default and activated only by `docker compose --profile jfrog up -d`.
+Two new services in `docker-compose.yaml`, both tagged `profiles: ["jfrog"]` so they are skipped by default and activated only by `docker compose --profile jfrog up -d`.
 
 ### `artifactory`
 
 - Image: `releases-docker.jfrog.io/jfrog/artifactory-jcr:7.98.9`
 - Rationale for JCR over OSS: JCR ships the full JFrog Platform UI chrome, including the `jfClientSession` confirmation screen that the web-login flow routes through. The Access service is bundled in both, but the OSS UI is thinner and has shown inconsistencies in the `/ui/login?jfClientSession=...` handoff. Multi-arch (`linux/amd64` + `linux/arm64`), so Apple Silicon runs native.
-- Port: `8082:8082` (JFrog router entrypoint — serves both `/ui/...` and `/access/api/...`).
+- Port: `127.0.0.1:8082:8082` (JFrog router entrypoint — serves both `/ui/...` and `/access/api/...`; bound to loopback so dev-only credentials aren't reachable from the LAN).
 - Memory limit: 4 GB (`mem_limit: 4g`).
 - Volume: named volume `artifactory-data` mounted at `/var/opt/jfrog/artifactory`.
+- Env: `JF_SHARED_SECURITY_MASTERKEY` and `JF_SHARED_SECURITY_JOINKEY` are pinned to deterministic 64-char hex dev fixtures because Artifactory refuses to start without them and its auto-generation on first boot is unreliable on Docker Desktop volumes.
 - Healthcheck: `GET /artifactory/api/system/ping` every 5 s, `start_period: 120s`, `retries: 30`.
+- Admin credentials: the default `admin` / `password` are kept as-is. Artifactory forces a password change on first UI login, which happens implicitly as part of the Playwright verification flow; no dedicated init container is needed.
 
-### `artifactory-init`
+### `artifactory-db`
 
-Mirrors the `vault-init` pattern. Runs once, exits 0.
+Postgres 16 sidecar (`postgres:16-alpine`). Artifactory 7.78+ dropped support for the embedded Derby database, so even a single-node dev instance requires an external database.
 
-Depends on `artifactory` with `condition: service_healthy`.
-
-Responsibilities:
-
-1. Resolve `admin/password` (default) into a known dev password `dotvault-dev` by `POST /artifactory/api/security/users/admin` with `Authorization: Basic YWRtaW46cGFzc3dvcmQ=`.
-2. Idempotency: if the initial basic-auth login returns 401, treat as "already initialised" and exit 0. If the reset itself returns 200, exit 0. Any other status is a hard failure with the response body logged.
-3. No secrets are logged. The new password is inline in the script because it is a dev-only fixture.
-
-Why REST rather than the file-based `bootstrap.creds` approach: `bootstrap.creds` only takes effect on a **pristine** volume. A REST-based init container survives `docker compose down && up` without needing the volume wiped, matching the ergonomic of `vault-init`.
+- Credentials: `artifactory` / `dotvault-dev` / database `artifactory`. Loopback-only via internal Docker networking (no published ports).
+- Healthcheck: `pg_isready -U artifactory -d artifactory` every 5 s.
+- `artifactory` depends on `artifactory-db` with `condition: service_healthy` so the database is ready before Artifactory tries to connect on startup.
 
 ### Shared profile tag
 
-All three existing services (`vault`, `dex`, `vault-init`) remain profile-less and are brought up by a plain `docker compose up -d`. Only the new `artifactory` + `artifactory-init` carry the `jfrog` profile. Existing devs see zero change in the default workflow.
+All existing services (`vault`, `dex`, `vault-init`) remain profile-less and are brought up by a plain `docker compose up -d`. Only the new `artifactory` + `artifactory-db` carry the `jfrog` profile. Existing devs see zero change in the default workflow.
 
 ## dotvault Configuration
 
@@ -65,7 +61,7 @@ No changes to sync rules, handlers, or engine code — the engine already accept
 
 `CLAUDE.md` — one sentence added to the **Local Development** section:
 
-> JFrog enrolment testing is opt-in: `docker compose --profile jfrog up -d` additionally starts a local Artifactory JCR on port 8082 (admin password `dotvault-dev`). The default `docker compose up -d` does not include it.
+> JFrog enrolment testing is opt-in: `docker compose --profile jfrog up -d` additionally starts a local Artifactory JCR on port 8082 alongside a Postgres sidecar (required by Artifactory 7.78+). The default `docker compose up -d` does not include them. The admin account keeps the out-of-the-box `admin`/`password` credentials; Artifactory forces a password change on first UI login.
 
 ## Playwright Verification Flow
 
@@ -73,7 +69,7 @@ Run once, interactively from this session. Not committed.
 
 ### Preconditions
 
-- `docker compose --profile jfrog up -d` — all five services (vault, dex, vault-init, artifactory, artifactory-init) healthy.
+- `docker compose --profile jfrog up -d` — all five services (vault, dex, vault-init, artifactory-db, artifactory) healthy.
 - `go run ./cmd/dotvault run --config config.dev.yaml` — daemon running on `127.0.0.1:9000`.
 - `/etc/hosts` entry for `dex` already exists (prerequisite of the existing dev setup).
 
@@ -81,7 +77,7 @@ Run once, interactively from this session. Not committed.
 
 1. **Dotvault login.** Playwright MCP navigates to `http://127.0.0.1:9000`, clicks "Sign in with OIDC", which redirects to Dex. Dex's mockCallback connector auto-approves. Returns to dotvault, lands on the enrolment page.
 2. **Start JFrog enrolment.** Playwright clicks `Start` on the JFrog card. The web UI displays the last-4-chars confirmation code and the Artifactory login URL `http://127.0.0.1:8082/ui/login?jfClientSession=<uuid>&jfClientName=JFrog-CLI&jfClientCode=1`. Both captured from the DOM.
-3. **Artifactory login** (same browser context). Playwright navigates to the captured URL, signs in as `admin` / `dotvault-dev`. The Artifactory UI surfaces the "Confirm you're authorizing JFrog-CLI" screen showing the expected last-4 chars. Playwright clicks `Accept`.
+3. **Artifactory login** (same browser context). Playwright navigates to the captured URL, signs in as `admin` / `password` (the out-of-the-box default), and handles the mandatory first-login password change in the same session. The Artifactory UI then surfaces the "Confirm you're authorizing JFrog-CLI" screen showing the expected last-4 chars. Playwright clicks `Accept`.
 4. **Token poll.** dotvault's background poll against `GET /access/api/v2/authentication/jfrog_client_login/token/<uuid>` flips from 400 to 200. The enrolment page transitions to `complete`.
 5. **Verify.** Three independent checks:
    - `docker exec dotvault-vault vault kv get kv/users/gary/jfrog` — contains `access_token`, `refresh_token`, `token_type=Bearer`, `expires_in`, `url=http://127.0.0.1:8082`, `server_id=default-server`, `user=admin`.
@@ -90,8 +86,8 @@ Run once, interactively from this session. Not committed.
 
 ## Error Handling
 
-- **Artifactory fails to boot within 180 s:** abort, surface `docker compose logs artifactory`, do not proceed.
-- **`artifactory-init` fails the admin-reset:** hard failure (any status other than 200 or initial 401). Log the response body.
+- **Artifactory fails to boot within ~3 minutes cold start:** abort, surface `docker compose logs artifactory` and `docker compose logs artifactory-db`, do not proceed.
+- **Postgres refuses Artifactory's connection:** usually a volume-state mismatch from a previous run. `docker compose down -v --profile jfrog` + retry.
 - **Playwright selector drift** (Artifactory UI version differences on the confirmation screen): screenshot the DOM, report, and ask the user rather than guessing. Do not auto-retry with different selectors.
 - **Token poll timeout (5 min default in the engine):** the engine already returns a timeout error with the elapsed duration; the web UI shows the failure and the enrolment stays `pending`.
 
@@ -99,7 +95,7 @@ Run once, interactively from this session. Not committed.
 
 | File | Change |
 |------|--------|
-| `docker-compose.yaml` | Add `artifactory` + `artifactory-init` services under `profiles: ["jfrog"]`; add `artifactory-data` named volume |
+| `docker-compose.yaml` | Add `artifactory` + `artifactory-db` services under `profiles: ["jfrog"]`; add `artifactory-data` and `artifactory-db-data` named volumes; bind Artifactory to `127.0.0.1:8082:8082` |
 | `config.dev.yaml` | Point `enrolments.jfrog.settings.url` at `http://127.0.0.1:8082` |
 | `CLAUDE.md` | One-sentence note in Local Development about the `--profile jfrog` variant |
 

--- a/docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md
+++ b/docs/superpowers/specs/2026-04-16-artifactory-e2e-design.md
@@ -1,0 +1,112 @@
+# Local Artifactory + JFrog Enrolment E2E Verification
+
+**Status:** Design
+**Date:** 2026-04-16
+
+## Goal
+
+Stand up a local JFrog Artifactory container in the dev compose stack so the newly-added `JFrogEngine` (see `internal/enrol/jfrog.go`) can be exercised end-to-end against a real Access service, then verify the full enrolment flow once via Playwright to prove the engine is correct before the work merges.
+
+One-shot verification only. No committed E2E test, no CI wiring.
+
+## Non-Goals
+
+- Changes to the `JFrogEngine` Go code, its unit tests, or the `CLAUDE.md` engine documentation.
+- A committed Playwright test script or `make test-e2e` target.
+- CI integration — Artifactory's 4 GB RAM and ~2 min cold boot make it unsuitable for per-PR test runs.
+- License-gated JFrog features (Xray, Distribution, SAML/OAuth federation).
+
+## Architecture
+
+Three new services in `docker-compose.yaml`, all tagged `profiles: ["jfrog"]` so they are skipped by default and activated only by `docker compose --profile jfrog up -d`.
+
+### `artifactory`
+
+- Image: `releases-docker.jfrog.io/jfrog/artifactory-jcr:7.98.9`
+- Rationale for JCR over OSS: JCR ships the full JFrog Platform UI chrome, including the `jfClientSession` confirmation screen that the web-login flow routes through. The Access service is bundled in both, but the OSS UI is thinner and has shown inconsistencies in the `/ui/login?jfClientSession=...` handoff. Multi-arch (`linux/amd64` + `linux/arm64`), so Apple Silicon runs native.
+- Port: `8082:8082` (JFrog router entrypoint — serves both `/ui/...` and `/access/api/...`).
+- Memory limit: 4 GB (`mem_limit: 4g`).
+- Volume: named volume `artifactory-data` mounted at `/var/opt/jfrog/artifactory`.
+- Healthcheck: `GET /artifactory/api/system/ping` every 5 s, `start_period: 120s`, `retries: 30`.
+
+### `artifactory-init`
+
+Mirrors the `vault-init` pattern. Runs once, exits 0.
+
+Depends on `artifactory` with `condition: service_healthy`.
+
+Responsibilities:
+
+1. Resolve `admin/password` (default) into a known dev password `dotvault-dev` by `POST /artifactory/api/security/users/admin` with `Authorization: Basic YWRtaW46cGFzc3dvcmQ=`.
+2. Idempotency: if the initial basic-auth login returns 401, treat as "already initialised" and exit 0. If the reset itself returns 200, exit 0. Any other status is a hard failure with the response body logged.
+3. No secrets are logged. The new password is inline in the script because it is a dev-only fixture.
+
+Why REST rather than the file-based `bootstrap.creds` approach: `bootstrap.creds` only takes effect on a **pristine** volume. A REST-based init container survives `docker compose down && up` without needing the volume wiped, matching the ergonomic of `vault-init`.
+
+### Shared profile tag
+
+All three existing services (`vault`, `dex`, `vault-init`) remain profile-less and are brought up by a plain `docker compose up -d`. Only the new `artifactory` + `artifactory-init` carry the `jfrog` profile. Existing devs see zero change in the default workflow.
+
+## dotvault Configuration
+
+`config.dev.yaml` — a single URL change:
+
+```diff
+   jfrog:
+     engine: jfrog
+     settings:
+-      # Point at your JFrog Platform. Required — no sensible default exists.
+-      url: "https://mycompany.jfrog.io"
++      # Local Artifactory JCR from docker-compose --profile jfrog.
++      url: "http://127.0.0.1:8082"
+```
+
+No changes to sync rules, handlers, or engine code — the engine already accepts any URL via the `url` setting.
+
+`CLAUDE.md` — one sentence added to the **Local Development** section:
+
+> JFrog enrolment testing is opt-in: `docker compose --profile jfrog up -d` additionally starts a local Artifactory JCR on port 8082 (admin password `dotvault-dev`). The default `docker compose up -d` does not include it.
+
+## Playwright Verification Flow
+
+Run once, interactively from this session. Not committed.
+
+### Preconditions
+
+- `docker compose --profile jfrog up -d` — all five services (vault, dex, vault-init, artifactory, artifactory-init) healthy.
+- `go run ./cmd/dotvault run --config config.dev.yaml` — daemon running on `127.0.0.1:9000`.
+- `/etc/hosts` entry for `dex` already exists (prerequisite of the existing dev setup).
+
+### Steps
+
+1. **Dotvault login.** Playwright MCP navigates to `http://127.0.0.1:9000`, clicks "Sign in with OIDC", which redirects to Dex. Dex's mockCallback connector auto-approves. Returns to dotvault, lands on the enrolment page.
+2. **Start JFrog enrolment.** Playwright clicks `Start` on the JFrog card. The web UI displays the last-4-chars confirmation code and the Artifactory login URL `http://127.0.0.1:8082/ui/login?jfClientSession=<uuid>&jfClientName=JFrog-CLI&jfClientCode=1`. Both captured from the DOM.
+3. **Artifactory login** (same browser context). Playwright navigates to the captured URL, signs in as `admin` / `dotvault-dev`. The Artifactory UI surfaces the "Confirm you're authorizing JFrog-CLI" screen showing the expected last-4 chars. Playwright clicks `Accept`.
+4. **Token poll.** dotvault's background poll against `GET /access/api/v2/authentication/jfrog_client_login/token/<uuid>` flips from 400 to 200. The enrolment page transitions to `complete`.
+5. **Verify.** Three independent checks:
+   - `docker exec dotvault-vault vault kv get kv/users/gary/jfrog` — contains `access_token`, `refresh_token`, `token_type=Bearer`, `expires_in`, `url=http://127.0.0.1:8082`, `server_id=default-server`, `user=admin`.
+   - `cat ~/tmp/.jfrog/jfrog-cli.conf.v6` — valid JSON matching the template, with the real access token embedded.
+   - `curl -H "Authorization: Bearer <token>" http://127.0.0.1:8082/artifactory/api/system/ping` — returns `OK`, proving the minted token is genuinely accepted by the live Artifactory.
+
+## Error Handling
+
+- **Artifactory fails to boot within 180 s:** abort, surface `docker compose logs artifactory`, do not proceed.
+- **`artifactory-init` fails the admin-reset:** hard failure (any status other than 200 or initial 401). Log the response body.
+- **Playwright selector drift** (Artifactory UI version differences on the confirmation screen): screenshot the DOM, report, and ask the user rather than guessing. Do not auto-retry with different selectors.
+- **Token poll timeout (5 min default in the engine):** the engine already returns a timeout error with the elapsed duration; the web UI shows the failure and the enrolment stays `pending`.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `docker-compose.yaml` | Add `artifactory` + `artifactory-init` services under `profiles: ["jfrog"]`; add `artifactory-data` named volume |
+| `config.dev.yaml` | Point `enrolments.jfrog.settings.url` at `http://127.0.0.1:8082` |
+| `CLAUDE.md` | One-sentence note in Local Development about the `--profile jfrog` variant |
+
+No Go code changes. No test changes.
+
+## Out of Scope / Follow-Ups
+
+- A committed `test/e2e/` Playwright harness — can be added later if the engine's behaviour becomes load-bearing enough to need regression protection.
+- Wiring Artifactory into `.claude/launch.json` for Claude Code Desktop — the profile already lets you opt in by hand; adding it to the launch config would make the Preview integration always pay the 4 GB cost.
+- A Makefile helper (`make up-jfrog`, etc.). The compose profile invocation is short enough that an additional alias is noise.

--- a/docs/superpowers/specs/2026-04-17-jfrog-token-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-17-jfrog-token-refresh-design.md
@@ -56,13 +56,16 @@ Modeled on `internal/auth/lifecycle.go`. Constructor:
 ```go
 func NewRefreshManager(
     client *vault.Client,
-    cfg *config.Config,
-    userPrefix, username string,
+    kvMount, userPrefix string, // userPrefix already includes username + trailing slash
+    enrolments map[string]config.Enrolment,
     checkInterval time.Duration,
+    opts ...RefreshManagerOption, // WithClock, WithMaxBackoff — test hooks
 ) *RefreshManager
 ```
 
-Default `checkInterval` is 5 minutes (caller-supplied so tests can inject shorter values).
+Design note: decoupling from `*config.Config` means the manager only depends on the slice of configuration it actually uses. `userPrefix` is pre-built by the caller (`cfg.Vault.UserPrefix + username + "/"`), matching the convention used by the enrolment manager.
+
+`checkInterval` is caller-supplied (5 minutes in the daemon, shorter values in tests). Non-positive values are coerced to a safe fallback with a WARN log so `time.NewTicker` cannot panic.
 
 `Start(ctx)` spawns a goroutine that ticks every `checkInterval`. Per tick:
 
@@ -80,9 +83,17 @@ Default `checkInterval` is 5 minutes (caller-supplied so tests can inject shorte
 After `auth.LifecycleManager.Start(ctx)`, also start the refresh manager:
 
 ```go
-rm := enrol.NewRefreshManager(vaultClient, cfg, cfg.Vault.UserPrefix, username, 5*time.Minute)
+rm := enrol.NewRefreshManager(
+    vaultClient,
+    cfg.Vault.KVMount,
+    cfg.Vault.UserPrefix+username+"/",
+    cfg.Enrolments,
+    5*time.Minute,
+)
 rm.Start(ctx)
 ```
+
+The daemon's existing config-reload loop calls `rm.UpdateConfig(reloaded.Enrolments)` alongside `enrolMgr.UpdateConfig` so the refresh manager notices when enrolments are added or removed.
 
 Failures from the refresh goroutine are logged, not bubbled up. Refresh is best-effort — the sync engine continues rendering whatever's in Vault, which degrades gracefully even if refresh is broken.
 

--- a/docs/superpowers/specs/2026-04-17-jfrog-token-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-17-jfrog-token-refresh-design.md
@@ -1,0 +1,231 @@
+# JFrog Token Refresh Ownership
+
+**Status:** Design
+**Date:** 2026-04-17
+
+## Goal
+
+Make dotvault the owner of JFrog access token lifecycle. Every JFrog enrolment produces a dotvault-minted, refreshable access token with a **configurable, shorter-than-default TTL**. A new background manager detects tokens past half-life and refreshes them in place, writing the rotated pair back to Vault. The sync engine renders only the current access token into the on-disk CLI config, so `jf` never attempts its own refresh.
+
+## Why
+
+1. **Shorter TTL is better security hygiene.** The JFrog server default is 1 year. Admin users — the class most likely to pick dotvault for credential management — deserve *shorter* token lifetimes, not longer. Sixty days is a sensible production default; the dev stack runs at 6 hours to exercise the refresh path in practice.
+2. **Refresh token rotation is a correctness hazard under the current design.** JFrog rotates the `refresh_token` on every successful refresh, so any copy outside Vault becomes stale immediately. If `jf` owned refresh (today's template emits `refreshToken` + `webLogin: true`), its in-place rewrites of `jfrog-cli.conf.v6` would race dotvault's sync rule, which clobbers the file on the next tick. Moving refresh ownership into dotvault resolves the race: Vault is authoritative, the sync rule renders only `accessToken`, and `jf` stays a passive consumer.
+
+## Non-Goals
+
+- A `CanRefresh()` bool or other addition to the base `Engine` interface — a new optional `Refresher` sub-interface is enough.
+- Refresh for GitHub OAuth tokens, SSH keys, or hypothetical future engines. Only JFrog expires and rotates today.
+- A user-facing "refresh now" button in the web UI. Periodic check + refresh-on-daemon-start is sufficient; manual refresh can be added later if needed.
+- Persisting per-enrolment refresh state to disk. Vault is authoritative; the manager is stateless between ticks.
+- A fallback that retains old refresh tokens in case mid-rotation fails. Either the next tick gets `ErrRevoked` (→ re-enrol) or the transient error clears naturally.
+- Migration of existing fat-secret enrolments — there is effectively one (the dev-stack enrolment from the E2E run) and it gets re-enrolled manually during this work.
+
+## Architecture
+
+### New: `Refresher` sub-interface (`internal/enrol/engine.go`)
+
+```go
+// Refresher is implemented by engines whose credentials expire and can be
+// rotated without user interaction. Today only JFrog implements it.
+type Refresher interface {
+    Engine
+
+    // Refresh takes the current Vault secret body and returns a replacement.
+    // The returned map overwrites the whole Vault secret (it must contain
+    // every field the engine still cares about, including a new expires_at).
+    //
+    // Returns ErrRevoked to signal the upstream credential is permanently
+    // gone (401/403) — caller wipes the Vault secret and flags for re-enrol.
+    // Any other error is transient; caller keeps the existing secret and
+    // retries with backoff.
+    Refresh(ctx context.Context, settings map[string]any, existing map[string]string) (map[string]string, error)
+}
+
+// ErrRevoked indicates the upstream credential is no longer valid and
+// cannot be recovered by refresh.
+var ErrRevoked = errors.New("credential revoked upstream")
+```
+
+Engines that don't implement `Refresher` are silently skipped by the manager — no impact on GitHub or SSH.
+
+### New: `RefreshManager` (`internal/enrol/refresh.go`)
+
+Modeled on `internal/auth/lifecycle.go`. Constructor:
+
+```go
+func NewRefreshManager(
+    client *vault.Client,
+    cfg *config.Config,
+    userPrefix, username string,
+    checkInterval time.Duration,
+) *RefreshManager
+```
+
+Default `checkInterval` is 5 minutes (caller-supplied so tests can inject shorter values).
+
+`Start(ctx)` spawns a goroutine that ticks every `checkInterval`. Per tick:
+
+1. Iterate `cfg.Enrolments`. For each key where the engine implements `Refresher`:
+2. Read the Vault secret at `{kv_mount}/data/{user_prefix}{username}/{key}`.
+3. If the secret has no `expires_at` field, skip (legacy pass-through — see Q2.A in Brainstorming).
+4. Parse `issued_at` and `expires_at` as RFC3339. Compute `halfLife := issuedAt.Add(expiresAt.Sub(issuedAt) / 2)`. If `now.Before(halfLife)`, skip.
+5. Call `engine.Refresh(ctx, settings, existing)`.
+6. **Success**: `vault.WriteKVv2` the returned map (full replace); reset this enrolment's backoff to `checkInterval`.
+7. **`ErrRevoked`**: `vault.Delete` the secret, log WARN. No retry — the existing web UI status-polling loop picks up the missing secret and surfaces a fresh `pending` card.
+8. **Other error**: log WARN, keep the existing secret, double this enrolment's backoff (capped at 5 min). Backoff is **per-enrolment** so one flaky JFrog instance doesn't stall other refreshes.
+
+### Daemon wiring (`cmd/dotvault/main.go`)
+
+After `auth.LifecycleManager.Start(ctx)`, also start the refresh manager:
+
+```go
+rm := enrol.NewRefreshManager(vaultClient, cfg, cfg.Vault.UserPrefix, username, 5*time.Minute)
+rm.Start(ctx)
+```
+
+Failures from the refresh goroutine are logged, not bubbled up. Refresh is best-effort — the sync engine continues rendering whatever's in Vault, which degrades gracefully even if refresh is broken.
+
+## Vault Schema
+
+Current JFrog KV secret (8 fields):
+`access_token, refresh_token, token_type, expires_in, scope, url, server_id, user`
+
+After this change (7 fields):
+`access_token, refresh_token, url, server_id, user, issued_at, expires_at`
+
+Changes:
+
+- **Add `issued_at`** — RFC3339. Stamped when the token is minted (or refreshed).
+- **Add `expires_at`** — RFC3339. Stamped as `issued_at + token_ttl`.
+- **Drop `expires_in`** — redundant once `expires_at` is absolute; storing both invites drift.
+- **Drop `token_type`** — constant `"Bearer"` for JFrog.
+- **Drop `scope`** — informational only; neither refresh nor render consumes it.
+- **Keep `refresh_token`** — the refresh cycle needs it. Never rendered to disk.
+
+## Config
+
+New optional setting on the JFrog enrolment:
+
+```yaml
+enrolments:
+  jfrog:
+    engine: jfrog
+    settings:
+      url: "https://mycompany.jfrog.io"
+      token_ttl: "60d"    # default if omitted; must be >= 10m
+```
+
+- **Engine default**: `60d` (applied in the engine, not by the config loader — keeps loader agnostic).
+- **Dev stack** (`config.dev.yaml`): `6h`.
+- **Floor**: 10 minutes. Anything smaller is rejected at config load with a clear error.
+- **Ceiling**: none — users can set it arbitrarily large, accepting that JFrog might reject values beyond its server-configured maximum (in which case enrolment fails with the server's error, which is fine).
+
+### Duration parsing
+
+Go's `time.ParseDuration` doesn't accept `d`. New helper `config.ParseDuration(s string) (time.Duration, error)`:
+
+- Accepts everything `time.ParseDuration` does.
+- Additionally accepts `Nd` where N is a positive integer, converting to hours before parsing. `60d` → `1440h`.
+- Returns the standard `time.ParseDuration` error for anything else.
+
+Used for `token_ttl` today; may replace `sync.interval`'s parsing later if we want to be consistent (out of scope for this spec).
+
+## Data Flow
+
+### Enrolment (new — runs once per user, on first enrolment)
+
+1. Web-login flow runs as today through the `jfrog_client_login/token/<uuid>` poll.
+2. The token returned is a **short-lived bootstrap token** (JFrog server default TTL, typically 1 year).
+3. The engine immediately calls `POST /access/api/v2/tokens` with `Authorization: Bearer <bootstrap>` and body:
+   ```json
+   {"expires_in": <token_ttl_seconds>, "refreshable": true, "scope": "applied-permissions/user"}
+   ```
+4. The response yields a **dotvault-owned token pair** (access + refresh) with the configured TTL.
+5. Engine stamps `issued_at: now`, `expires_at: now + token_ttl`, returns the 7 fields.
+6. Bootstrap token is discarded — it is never used or stored again.
+
+Non-admin users can successfully mint refreshable tokens for themselves with a non-zero TTL. The admin-only restriction is specifically on `expires_in: 0`, which we deliberately don't use.
+
+### Refresh (periodic — every 5 min)
+
+1. `RefreshManager` tick. For each enrolment whose engine implements `Refresher`:
+2. Read Vault secret. Skip if no `expires_at` (legacy). Skip if `now < halfLife`.
+3. Call `engine.Refresh(ctx, settings, existing)`.
+4. For JFrog, `Refresh` calls `POST /access/api/v1/tokens` with form body `grant_type=refresh_token&access_token=<current>&refresh_token=<current>`.
+5. On 200: parse the response, stamp new `issued_at: now`, new `expires_at: now + token_ttl` (dotvault's TTL, **not** whatever JFrog returns), return the full field map.
+6. `RefreshManager` writes the returned map to Vault.
+7. Sync engine's next tick (already independent, runs on its own schedule) picks up the new Vault version and re-renders `jfrog-cli.conf.v6`.
+
+### Template change (`config.dev.yaml`)
+
+Drop `refreshToken` and `webLogin: true` from the rendered `jfrog-cli.conf.v6`:
+
+```yaml
+template: |
+  {
+    "servers": [
+      {
+        "serverId": "{{ .server_id }}",
+        "url": "{{ .url }}/",
+        "artifactoryUrl": "{{ .url }}/artifactory/",
+        "distributionUrl": "{{ .url }}/distribution/",
+        "xrayUrl": "{{ .url }}/xray/",
+        "missionControlUrl": "{{ .url }}/mc/",
+        "pipelinesUrl": "{{ .url }}/pipelines/",
+        "accessUrl": "{{ .url }}/access/",
+        "user": "{{ .user | default "" }}",
+        "accessToken": "{{ .access_token }}",
+        "isDefault": true
+      }
+    ],
+    "version": "6"
+  }
+```
+
+Without `refreshToken` in the config, `jf` will not attempt its own refresh. Because dotvault refreshes at half-life and writes the new token to Vault — which triggers the sync engine to re-render the file (via the Events API stream in Enterprise Vault, or the next poll cycle otherwise) — `jf` in steady state always sees a valid, non-expiring-soon access token and never hits a 401 from expiry.
+
+## Error Handling
+
+| Failure | Engine returns | RefreshManager does |
+|---------|---------------|---------------------|
+| JFrog 401/403 on refresh | `enrol.ErrRevoked` | `vault.Delete(path)`, log WARN, no retry |
+| JFrog 5xx | wrapped error | log WARN, per-enrolment backoff, keep secret |
+| Network / timeout | wrapped error | log WARN, per-enrolment backoff, keep secret |
+| Vault unreachable on write-back | — (manager-side) | log WARN, per-enrolment backoff, retry next tick |
+| Secret shape unparseable | — (manager-side) | log ERROR, skip, continue with other enrolments |
+| `token_ttl` below 10-min floor | — (config-load time) | daemon refuses to start with clear error |
+
+Per-enrolment backoff means one flaky JFrog doesn't stall refresh of a (future) second JFrog enrolment. Starting delay equals `checkInterval` (5 min), cap 5 min. Since `checkInterval` already equals the cap, backoff in practice just means "don't retry sooner than the next tick". The data structure is in place so longer checkpoint intervals stay safe.
+
+## Testing
+
+1. **`JFrogEngine.Refresh` unit tests.** `httptest.Server` serving `POST /access/api/v1/tokens`. Cases: happy path (new pair returned); 401 → `ErrRevoked`; 403 → `ErrRevoked`; 500 → wrapped error; malformed JSON → wrapped error.
+2. **`RefreshManager` unit tests.** Fake clock (new internal `Clock` interface, default `realClock`), fake `vault.Client` (reuse existing test double if present), `Refresher` test double recording calls. Cases: no `expires_at` → skipped; before half-life → skipped; past half-life → `Refresh` called; returned map written back; `ErrRevoked` → `vault.Delete`; transient error → secret intact, backoff doubled.
+3. **Config parsing.** `ParseDuration("60d") == 1440h`; `ParseDuration("6h") == 6h`; `ParseDuration("5m")` rejected by `token_ttl` validator (floor check); `ParseDuration("bogus")` returns error.
+4. **Engine mint-on-enrol.** Extend `TestJFrogEngine_Run_FullFlow` to also serve `POST /access/api/v2/tokens`, assert the bootstrap token is discarded, the stored TTL matches `settings["token_ttl"]`, and `issued_at`/`expires_at` are present.
+5. **Manual verification** against the local Artifactory with `token_ttl: "6h"`: daemon logs should show a refresh at ~3 h, and the Vault version number increments. For a tighter loop, cranking `token_ttl: "10m"` + a test-only `check_interval_seconds: 30` demonstrates full rotation within minutes. Not committed as an automated test.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `internal/enrol/engine.go` | Add `Refresher` interface and `ErrRevoked` sentinel |
+| `internal/enrol/refresh.go` | New file: `RefreshManager` + `Clock` interface |
+| `internal/enrol/refresh_test.go` | New file: manager unit tests |
+| `internal/enrol/jfrog.go` | Add post-web-login `POST /access/api/v2/tokens`; add `Refresh` method; new schema (issued_at/expires_at; drop token_type/expires_in/scope) |
+| `internal/enrol/jfrog_test.go` | Extend for mint-on-enrol; add `Refresh` tests |
+| `internal/config/config.go` | Add `ParseDuration` helper; validate `token_ttl` at load |
+| `internal/config/config_test.go` | Duration parsing + validation tests |
+| `cmd/dotvault/main.go` | Construct and start `RefreshManager` after `LifecycleManager` |
+| `config.dev.yaml` | Add `token_ttl: "6h"`; drop `refreshToken` and `webLogin` from template |
+| `CLAUDE.md` | Document `token_ttl`, default 60d, refresh semantics, minimal template fields |
+
+## Out of Scope / Follow-Ups
+
+- `CanRefresh()` bool on base `Engine`.
+- Web UI "Refresh now" button.
+- Refresh support for other engines.
+- Config-level `check_interval` for the refresh manager (today it's wired at 5 min; if this becomes load-bearing we can surface it).
+- `w` and `y` duration suffixes.
+- Converting `sync.interval` to `config.ParseDuration` for consistency.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -52,6 +53,13 @@ func ParseDuration(s string) (time.Duration, error) {
 		}
 		if days < 0 {
 			return 0, fmt.Errorf("negative duration: %q", s)
+		}
+		// Guard against int64 overflow. time.Duration is nanoseconds in an
+		// int64, so max representable days ≈ MaxInt64 / (24*time.Hour in ns).
+		// Anything above that silently wraps to a negative/garbage value.
+		const maxDays = int(int64(math.MaxInt64) / int64(24*time.Hour))
+		if days > maxDays {
+			return 0, fmt.Errorf("duration %q exceeds time.Duration range (max %dd)", s, maxDays)
 		}
 		return time.Duration(days) * 24 * time.Hour, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,13 +40,23 @@ func ParseDuration(s string) (time.Duration, error) {
 	if s == "" {
 		return 0, fmt.Errorf("empty duration")
 	}
-	// Bare Nd: digits followed by 'd' with nothing after. A minus sign is
-	// allowed through strconv.Atoi but rejected explicitly below so the
-	// error is clearer than stdlib's "unknown unit" for the common mistake.
+	// Bare Nd: digits followed by 'd' with nothing after. Use ParseInt
+	// rather than Atoi so that very-large-day values that overflow int are
+	// caught here (Atoi returns "value out of range", which would otherwise
+	// fall through to time.ParseDuration and produce a confusing "unknown
+	// unit d" error). A minus sign is allowed through ParseInt but rejected
+	// explicitly below so the error message is clear.
 	if strings.HasSuffix(s, "d") {
 		num := s[:len(s)-1]
-		days, err := strconv.Atoi(num)
+		days, err := strconv.ParseInt(num, 10, 64)
 		if err != nil {
+			// Is the parse failure because the numeral is out of int64 range?
+			// That's a clear "too big" case — surface it directly instead of
+			// handing the string to time.ParseDuration where "d" is an
+			// unknown unit and the error would be confusing.
+			if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
+				return 0, fmt.Errorf("duration %q exceeds representable range", s)
+			}
 			// Not a bare Nd (e.g. "1.5d", "1dd", "1d12h") — fall through to
 			// stdlib, which will produce the standard "unknown unit" error.
 			return time.ParseDuration(s)
@@ -54,10 +64,10 @@ func ParseDuration(s string) (time.Duration, error) {
 		if days < 0 {
 			return 0, fmt.Errorf("negative duration: %q", s)
 		}
-		// Guard against int64 overflow. time.Duration is nanoseconds in an
-		// int64, so max representable days ≈ MaxInt64 / (24*time.Hour in ns).
-		// Anything above that silently wraps to a negative/garbage value.
-		const maxDays = int(int64(math.MaxInt64) / int64(24*time.Hour))
+		// Guard against int64 overflow when converting to nanoseconds.
+		// time.Duration is nanoseconds in an int64 so max representable
+		// days ≈ MaxInt64 / (24 * time.Hour in ns).
+		const maxDays = int64(math.MaxInt64 / int64(24*time.Hour))
 		if days > maxDays {
 			return 0, fmt.Errorf("duration %q exceeds time.Duration range (max %dd)", s, maxDays)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,6 +12,35 @@ import (
 	"github.com/goodtune/dotvault/internal/perms"
 	"gopkg.in/yaml.v3"
 )
+
+// ParseDuration extends time.ParseDuration with a "Nd" suffix representing
+// whole days (24 * N hours). Everything else is delegated to the stdlib
+// parser, so "6h", "30m", "1h30m" etc. continue to work as expected.
+//
+// Accepts: "60d" (=1440h), "6h", "10m", "45s", combined forms.
+// Rejects: "1.5d" (non-integer days), "w", "y" suffixes, empty string,
+// negative values (consistent with a duration setting).
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	// Detect a trailing Nd: digits followed by 'd' with nothing after.
+	if strings.HasSuffix(s, "d") {
+		num := s[:len(s)-1]
+		days, err := strconv.Atoi(num)
+		if err != nil {
+			// Not a bare Nd (e.g. "1.5d", "1dd") — fall through to stdlib,
+			// which will produce the standard "unknown unit" error.
+			return time.ParseDuration(s)
+		}
+		if days < 0 {
+			return 0, fmt.Errorf("negative duration: %q", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
+}
 
 // Config is the top-level system configuration.
 type Config struct {
@@ -207,6 +237,23 @@ func (c *Config) validate() error {
 		}
 		if e.Engine == "" {
 			return fmt.Errorf("enrolments[%q].engine is required", key)
+		}
+
+		// Engine-agnostic validation of token_ttl if present: must parse
+		// as a duration and be no smaller than the 10-minute floor so
+		// engines that refresh don't thrash the upstream API.
+		if raw, ok := e.Settings["token_ttl"]; ok {
+			s, ok := raw.(string)
+			if !ok {
+				return fmt.Errorf("enrolments[%q].settings.token_ttl must be a string, got %T", key, raw)
+			}
+			d, err := ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("enrolments[%q].settings.token_ttl %q: %w", key, s, err)
+			}
+			if d < 10*time.Minute {
+				return fmt.Errorf("enrolments[%q].settings.token_ttl %q is below the 10m minimum", key, s)
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,25 +13,41 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ParseDuration extends time.ParseDuration with a "Nd" suffix representing
-// whole days (24 * N hours). Everything else is delegated to the stdlib
-// parser, so "6h", "30m", "1h30m" etc. continue to work as expected.
+// ParseDuration extends time.ParseDuration with a standalone "Nd" suffix
+// representing whole days (N × 24h). It is a thin wrapper: anything other
+// than a bare Nd is delegated to the stdlib parser, so "6h", "30m",
+// "1h30m" etc. continue to work as normal.
 //
-// Accepts: "60d" (=1440h), "6h", "10m", "45s", combined forms.
-// Rejects: "1.5d" (non-integer days), "w", "y" suffixes, empty string,
-// negative values (consistent with a duration setting).
+// Accepts:
+//   - bare "Nd" where N is a non-negative integer ("60d" → 1440h, "1d" → 24h)
+//   - anything time.ParseDuration accepts ("6h", "30m", "1h30m", "45s")
+//
+// Rejects:
+//   - empty string
+//   - negative bare "Nd" (e.g. "-5d"): kept out as a guard-rail for
+//     settings like token_ttl where negative values never make sense.
+//     Note that stdlib forms like "-5m" are still parseable by
+//     time.ParseDuration and pass through unchanged — callers that need a
+//     "must be positive" invariant should enforce it at the validation
+//     site (e.g. the 10-min floor check for token_ttl)
+//   - mixed forms combining days with other units ("1d12h" is rejected
+//     because "d" is not understood by time.ParseDuration; if this ever
+//     becomes load-bearing we can extend the parser)
+//   - non-integer days ("1.5d") and unsupported suffixes ("w", "y")
 func ParseDuration(s string) (time.Duration, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return 0, fmt.Errorf("empty duration")
 	}
-	// Detect a trailing Nd: digits followed by 'd' with nothing after.
+	// Bare Nd: digits followed by 'd' with nothing after. A minus sign is
+	// allowed through strconv.Atoi but rejected explicitly below so the
+	// error is clearer than stdlib's "unknown unit" for the common mistake.
 	if strings.HasSuffix(s, "d") {
 		num := s[:len(s)-1]
 		days, err := strconv.Atoi(num)
 		if err != nil {
-			// Not a bare Nd (e.g. "1.5d", "1dd") — fall through to stdlib,
-			// which will produce the standard "unknown unit" error.
+			// Not a bare Nd (e.g. "1.5d", "1dd", "1d12h") — fall through to
+			// stdlib, which will produce the standard "unknown unit" error.
 			return time.ParseDuration(s)
 		}
 		if days < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -461,6 +461,137 @@ rules:
 	}
 }
 
+func TestParseDuration(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"60d", 60 * 24 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"6h", 6 * time.Hour, false},
+		{"10m", 10 * time.Minute, false},
+		{"1h30m", 90 * time.Minute, false},
+		{"45s", 45 * time.Second, false},
+		{"0d", 0, false},
+		{"-5d", 0, true},     // negative not allowed for Nd
+		{"1.5d", 0, true},     // stdlib rejects .5d as unknown unit
+		{"bogus", 0, true},
+		{"", 0, true},
+		{"1w", 0, true}, // not supported
+	}
+	for _, tc := range cases {
+		got, err := ParseDuration(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ParseDuration(%q) = %v, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseDuration(%q) error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseDuration(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLoadTokenTTLFloor(t *testing.T) {
+	yaml := `
+vault:
+  address: "https://vault.example.com:8200"
+  kv_mount: "kv"
+
+sync:
+  interval: "5m"
+
+rules:
+  - name: gh
+    vault_key: "gh"
+    target:
+      path: "~/.config/gh/hosts.yml"
+      format: yaml
+
+enrolments:
+  jfrog:
+    engine: jfrog
+    settings:
+      url: "https://mycompany.jfrog.io"
+      token_ttl: "5m"
+`
+	path := writeTemp(t, yaml)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for token_ttl below 10m floor")
+	}
+}
+
+func TestLoadTokenTTLValid(t *testing.T) {
+	yaml := `
+vault:
+  address: "https://vault.example.com:8200"
+  kv_mount: "kv"
+
+sync:
+  interval: "5m"
+
+rules:
+  - name: gh
+    vault_key: "gh"
+    target:
+      path: "~/.config/gh/hosts.yml"
+      format: yaml
+
+enrolments:
+  jfrog:
+    engine: jfrog
+    settings:
+      url: "https://mycompany.jfrog.io"
+      token_ttl: "6h"
+`
+	path := writeTemp(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	got := cfg.Enrolments["jfrog"].Settings["token_ttl"]
+	if got != "6h" {
+		t.Errorf("token_ttl = %v, want %q", got, "6h")
+	}
+}
+
+func TestLoadTokenTTLInvalid(t *testing.T) {
+	yaml := `
+vault:
+  address: "https://vault.example.com:8200"
+  kv_mount: "kv"
+
+sync:
+  interval: "5m"
+
+rules:
+  - name: gh
+    vault_key: "gh"
+    target:
+      path: "~/.config/gh/hosts.yml"
+      format: yaml
+
+enrolments:
+  jfrog:
+    engine: jfrog
+    settings:
+      url: "https://mycompany.jfrog.io"
+      token_ttl: "bogus"
+`
+	path := writeTemp(t, yaml)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for unparseable token_ttl")
+	}
+}
+
 func writeTemp(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -482,6 +482,9 @@ func TestParseDuration(t *testing.T) {
 		// Overflow guard: time.Duration is int64 ns ≈ 292 years max, so
 		// anything above ~106,751 days wraps. 200,000d comfortably overflows.
 		{"200000d", 0, true},
+		// Very large day count that overflows int64 at ParseInt — must
+		// surface a dedicated "exceeds range" error, not "unknown unit d".
+		{"99999999999999999999d", 0, true},
 	}
 	for _, tc := range cases {
 		got, err := ParseDuration(tc.in)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -479,6 +479,9 @@ func TestParseDuration(t *testing.T) {
 		{"bogus", 0, true},
 		{"", 0, true},
 		{"1w", 0, true}, // not supported
+		// Overflow guard: time.Duration is int64 ns ≈ 292 years max, so
+		// anything above ~106,751 days wraps. 200,000d comfortably overflows.
+		{"200000d", 0, true},
 	}
 	for _, tc := range cases {
 		got, err := ParseDuration(tc.in)

--- a/internal/enrol/engine.go
+++ b/internal/enrol/engine.go
@@ -2,6 +2,7 @@ package enrol
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -21,6 +22,26 @@ type Engine interface {
 	// Used to check whether enrolment is already complete.
 	Fields() []string
 }
+
+// Refresher is implemented by engines whose credentials expire and can be
+// rotated without user interaction. Today only JFrog implements it.
+type Refresher interface {
+	Engine
+
+	// Refresh takes the current Vault secret body and returns a replacement.
+	// The returned map overwrites the whole Vault secret (it must contain
+	// every field the engine still cares about, including a new expires_at).
+	//
+	// Returns ErrRevoked to signal the upstream credential is permanently
+	// gone (401/403) — caller wipes the Vault secret and flags for re-enrol.
+	// Any other error is transient; caller keeps the existing secret and
+	// retries with backoff.
+	Refresh(ctx context.Context, settings map[string]any, existing map[string]string) (map[string]string, error)
+}
+
+// ErrRevoked indicates the upstream credential is no longer valid and
+// cannot be recovered by refresh.
+var ErrRevoked = errors.New("credential revoked upstream")
 
 // BrowserOpener opens a URL in the user's default browser.
 type BrowserOpener func(url string) error

--- a/internal/enrol/engine.go
+++ b/internal/enrol/engine.go
@@ -39,6 +39,7 @@ var (
 	enginesMu sync.RWMutex
 	engines   = map[string]Engine{
 		"github": &GitHubEngine{},
+		"jfrog":  &JFrogEngine{},
 		"ssh":    &SSHEngine{},
 	}
 )

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -96,11 +96,14 @@ func resolveTokenTTL(settings map[string]any) (time.Duration, error) {
 }
 
 func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (map[string]string, error) {
-	platformURL, ok := settings["url"].(string)
-	if !ok || strings.TrimSpace(platformURL) == "" {
+	rawPlatformURL, ok := settings["url"].(string)
+	if !ok {
 		return nil, fmt.Errorf("jfrog enrolment requires a non-empty 'url' setting (your JFrog Platform URL, e.g. https://mycompany.jfrog.io)")
 	}
-	platformURL = ensureScheme(strings.TrimRight(platformURL, "/"))
+	platformURL, err := normalizeJFrogPlatformURL(rawPlatformURL)
+	if err != nil {
+		return nil, err
+	}
 
 	clientName := jfrogDefaultClientName
 	if v, ok := settings["client_name"].(string); ok && v != "" {
@@ -220,11 +223,14 @@ func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (
 // has been revoked upstream — callers should treat that as permanent and
 // force a fresh enrolment.
 func (e *JFrogEngine) Refresh(ctx context.Context, settings map[string]any, existing map[string]string) (map[string]string, error) {
-	platformURL, ok := settings["url"].(string)
-	if !ok || strings.TrimSpace(platformURL) == "" {
+	rawPlatformURL, ok := settings["url"].(string)
+	if !ok {
 		return nil, fmt.Errorf("jfrog refresh requires a non-empty 'url' setting")
 	}
-	platformURL = ensureScheme(strings.TrimRight(platformURL, "/"))
+	platformURL, err := normalizeJFrogPlatformURL(rawPlatformURL)
+	if err != nil {
+		return nil, err
+	}
 
 	access := existing["access_token"]
 	refresh := existing["refresh_token"]
@@ -281,6 +287,32 @@ func ensureScheme(u string) string {
 		return u
 	}
 	return "https://" + u
+}
+
+// normalizeJFrogPlatformURL parses `raw`, enforces that it is a
+// scheme+host-only URL (no path, query, or fragment), and returns the
+// canonical string form. JFrog API paths are concatenated directly onto
+// this value, so any embedded path would route requests incorrectly and
+// a query/fragment would appear verbatim in the stored template.
+func normalizeJFrogPlatformURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("jfrog enrolment requires a non-empty 'url' setting (your JFrog Platform URL, e.g. https://mycompany.jfrog.io)")
+	}
+	u, err := url.Parse(ensureScheme(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse jfrog url: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("jfrog url must include a host: %q", raw)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("jfrog url must not include a query or fragment: %q", raw)
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("jfrog url must be the platform base URL without a path (got %q)", raw)
+	}
+	return (&url.URL{Scheme: u.Scheme, Host: u.Host}).String(), nil
 }
 
 // deduceJFrogServerID extracts a short server identifier from the platform

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -472,12 +472,15 @@ func jfrogExchangeRefreshToken(ctx context.Context, client *http.Client, platfor
 	}
 }
 
-// truncate trims s to maxLen runes with an ellipsis, for error logs.
+// truncate trims s to maxLen runes with an ellipsis, for error logs. Rune-
+// aware rather than byte-aware so a truncated UTF-8 multi-byte sequence
+// doesn't emit mojibake in the log line.
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "…"
+	return string(runes[:maxLen]) + "…"
 }
 
 func readAndClose(resp *http.Response) ([]byte, error) {

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -549,11 +550,23 @@ func truncate(s string, maxLen int) string {
 	return string(runes[:maxLen]) + "…"
 }
 
+// readAndClose reads the response body (capped at 1 MB to limit exposure
+// to unexpectedly large payloads from a user-configured URL) and closes
+// the body. 1 MB is generous for any JFrog API response; legitimate
+// token responses are a few KB at most.
 func readAndClose(resp *http.Response) ([]byte, error) {
 	defer resp.Body.Close()
+	const maxBody = 1 << 20 // 1 MB
+	limited := io.LimitReader(resp.Body, maxBody+1)
 	buf := new(bytes.Buffer)
-	_, err := buf.ReadFrom(resp.Body)
-	return buf.Bytes(), err
+	n, err := buf.ReadFrom(limited)
+	if err != nil {
+		return nil, err
+	}
+	if n > maxBody {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxBody)
+	}
+	return buf.Bytes(), nil
 }
 
 // extractUsernameFromJWT parses a JFrog access token JWT and returns the

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -198,8 +198,8 @@ func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (
 		return nil, fmt.Errorf("mint jfrog access token: %w", err)
 	}
 	if minted.AccessToken == "" || minted.RefreshToken == "" {
-		return nil, fmt.Errorf("jfrog mint returned incomplete token pair (access=%q refresh present=%t)",
-			minted.AccessToken, minted.RefreshToken != "")
+		return nil, fmt.Errorf("jfrog mint returned incomplete token pair (access_token present=%t, refresh_token present=%t)",
+			minted.AccessToken != "", minted.RefreshToken != "")
 	}
 
 	user := extractUsernameFromJWT(minted.AccessToken)

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -289,8 +289,11 @@ func (e *JFrogEngine) Refresh(ctx context.Context, settings map[string]any, exis
 }
 
 // ensureScheme prepends https:// if the URL has no scheme.
+// The check is case-insensitive so that inputs like "HTTPS://host" are
+// recognized as having a scheme rather than getting https:// prepended.
 func ensureScheme(u string) string {
-	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+	lower := strings.ToLower(u)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
 		return u
 	}
 	return "https://" + u

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -385,7 +385,28 @@ func jfrogPollForToken(ctx context.Context, client *http.Client, platformURL, se
 	endpoint := fmt.Sprintf("%s/access/api/v2/authentication/jfrog_client_login/token/%s", platformURL, url.PathEscape(session))
 	deadline := time.Now().Add(max)
 
+	// Reusable timer avoids leaking a new timer on every loop iteration
+	// (each `time.After(interval)` allocates one that lives until it fires,
+	// even if we return early on ctx cancellation or a hard error).
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C // drain the initial fire so the first iteration goes straight to the HTTP call
+	}
+	defer timer.Stop()
+
+	first := true
 	for {
+		// On the first iteration, skip the wait and poll immediately.
+		if !first {
+			timer.Reset(interval)
+			select {
+			case <-ctx.Done():
+				return jfrogCommonTokenParams{}, ctx.Err()
+			case <-timer.C:
+			}
+		}
+		first = false
+
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
 			return jfrogCommonTokenParams{}, err
@@ -414,12 +435,6 @@ func jfrogPollForToken(ctx context.Context, client *http.Client, platformURL, se
 
 		if time.Now().After(deadline) {
 			return jfrogCommonTokenParams{}, fmt.Errorf("timed out waiting for jfrog web login after %s", max)
-		}
-
-		select {
-		case <-ctx.Done():
-			return jfrogCommonTokenParams{}, ctx.Err()
-		case <-time.After(interval):
 		}
 	}
 }

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/goodtune/dotvault/internal/config"
 )
 
 const (
@@ -26,24 +28,71 @@ const (
 const (
 	jfrogDefaultPollInterval = 3 * time.Second
 	jfrogDefaultMaxWait      = 5 * time.Minute
+	// jfrogDefaultTokenTTL is the default dotvault-minted access token
+	// lifetime. 60d is considerably shorter than JFrog's own 1-year default
+	// and reflects the assumption that dotvault users are more often admins
+	// who should see tighter rotation windows.
+	jfrogDefaultTokenTTL = 60 * 24 * time.Hour
 )
 
 // JFrogEngine performs a JFrog Platform browser-based web login exchange,
-// mirroring the flow used by `jf login` in jfrog-cli.
+// mirroring the flow used by `jf login` in jfrog-cli. After the web login
+// completes, the engine mints a second, dotvault-owned refreshable token
+// with a shorter TTL; the bootstrap token from the web login is discarded.
 type JFrogEngine struct {
 	// overridable for tests
 	httpClient   *http.Client
 	pollInterval time.Duration
 	maxWait      time.Duration
+	// now is injected for deterministic issued_at/expires_at timestamps.
+	now func() time.Time
 }
 
 func (e *JFrogEngine) Name() string { return "JFrog" }
 
-// Fields lists the Vault KV fields this engine writes. access_token is the
-// only strictly-required credential; the other fields are identity metadata
-// needed to render a jfrog-cli config file.
+// Fields lists the Vault KV fields this engine writes. All fields are
+// required for a complete enrolment: access_token drives the CLI config,
+// refresh_token powers the rotation cycle, url+server_id+user render the
+// jfrog-cli.conf.v6 template, and issued_at+expires_at drive the
+// half-life refresh decision.
 func (e *JFrogEngine) Fields() []string {
-	return []string{"access_token", "url", "server_id"}
+	return []string{
+		"access_token",
+		"refresh_token",
+		"url",
+		"server_id",
+		"user",
+		"issued_at",
+		"expires_at",
+	}
+}
+
+// clock returns the current time via the engine's injected clock (or
+// time.Now if none is set).
+func (e *JFrogEngine) clock() time.Time {
+	if e.now != nil {
+		return e.now()
+	}
+	return time.Now().UTC()
+}
+
+// resolveTokenTTL resolves the configured token_ttl setting against the
+// engine default. Returns an error for non-string or unparseable values.
+// The 10-minute floor is enforced at config-load time; here we just parse.
+func resolveTokenTTL(settings map[string]any) (time.Duration, error) {
+	raw, ok := settings["token_ttl"]
+	if !ok {
+		return jfrogDefaultTokenTTL, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return 0, fmt.Errorf("jfrog token_ttl must be a string, got %T", raw)
+	}
+	d, err := config.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("parse jfrog token_ttl %q: %w", s, err)
+	}
+	return d, nil
 }
 
 func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (map[string]string, error) {
@@ -61,6 +110,11 @@ func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (
 	clientCode := jfrogDefaultClientCode
 	if v, ok := settings["client_code"].(string); ok && v != "" {
 		clientCode = v
+	}
+
+	ttl, err := resolveTokenTTL(settings)
+	if err != nil {
+		return nil, err
 	}
 
 	serverID, err := deduceJFrogServerID(platformURL)
@@ -106,7 +160,7 @@ func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (
 		fmt.Fprintf(io.Out, "✓ Opened %s in browser\n", loginURL)
 	}
 
-	// Step 3: poll for the token.
+	// Step 3: poll for the bootstrap token.
 	pollInterval := e.pollInterval
 	if pollInterval == 0 {
 		pollInterval = jfrogDefaultPollInterval
@@ -117,38 +171,108 @@ func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (
 	}
 
 	fmt.Fprintf(io.Out, "⠼ Waiting for authentication...\n")
-	token, err := jfrogPollForToken(ctx, client, platformURL, session, pollInterval, maxWait)
+	bootstrap, err := jfrogPollForToken(ctx, client, platformURL, session, pollInterval, maxWait)
 	if err != nil {
 		return nil, err
 	}
-	if token.AccessToken == "" {
+	if bootstrap.AccessToken == "" {
 		return nil, fmt.Errorf("jfrog returned empty access token after web login")
 	}
 
-	user := extractUsernameFromJWT(token.AccessToken)
+	// Step 4: exchange the bootstrap token for a dotvault-owned,
+	// refreshable token with the configured TTL. The bootstrap token is
+	// discarded — it is never stored or reused.
+	fmt.Fprintf(io.Out, "⠼ Minting dotvault-owned access token (ttl=%s)...\n", ttl)
+	minted, err := jfrogMintRefreshableToken(ctx, client, platformURL, bootstrap.AccessToken, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("mint jfrog access token: %w", err)
+	}
+	if minted.AccessToken == "" || minted.RefreshToken == "" {
+		return nil, fmt.Errorf("jfrog mint returned incomplete token pair (access=%q refresh present=%t)",
+			minted.AccessToken, minted.RefreshToken != "")
+	}
 
+	user := extractUsernameFromJWT(minted.AccessToken)
+	if user == "" {
+		// Fall back to the bootstrap token's subject if the minted JWT
+		// doesn't carry a parseable username. This keeps compatibility
+		// with odd JFrog deployments while still preferring the minted
+		// identity when available.
+		user = extractUsernameFromJWT(bootstrap.AccessToken)
+	}
+
+	now := e.clock()
 	result := map[string]string{
-		"access_token": token.AccessToken,
-		"url":          platformURL,
-		"server_id":    serverID,
+		"access_token":  minted.AccessToken,
+		"refresh_token": minted.RefreshToken,
+		"url":           platformURL,
+		"server_id":     serverID,
+		"user":          user,
+		"issued_at":     now.UTC().Format(time.RFC3339),
+		"expires_at":    now.Add(ttl).UTC().Format(time.RFC3339),
 	}
-	if token.RefreshToken != "" {
-		result["refresh_token"] = token.RefreshToken
+	return result, nil
+}
+
+// Refresh rotates a dotvault-owned JFrog token pair. Returns the same 7
+// fields that Run returns so the caller can atomically replace the Vault
+// secret. A 401/403 from the access service means the refresh token itself
+// has been revoked upstream — callers should treat that as permanent and
+// force a fresh enrolment.
+func (e *JFrogEngine) Refresh(ctx context.Context, settings map[string]any, existing map[string]string) (map[string]string, error) {
+	platformURL, ok := settings["url"].(string)
+	if !ok || strings.TrimSpace(platformURL) == "" {
+		return nil, fmt.Errorf("jfrog refresh requires a non-empty 'url' setting")
 	}
-	if token.TokenType != "" {
-		result["token_type"] = token.TokenType
-	}
-	if token.Scope != "" {
-		result["scope"] = token.Scope
-	}
-	if token.ExpiresIn != nil {
-		result["expires_in"] = fmt.Sprintf("%d", *token.ExpiresIn)
-	}
-	if user != "" {
-		result["user"] = user
+	platformURL = ensureScheme(strings.TrimRight(platformURL, "/"))
+
+	access := existing["access_token"]
+	refresh := existing["refresh_token"]
+	if access == "" || refresh == "" {
+		return nil, fmt.Errorf("jfrog refresh requires both access_token and refresh_token in the existing secret")
 	}
 
-	return result, nil
+	ttl, err := resolveTokenTTL(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	serverID, err := deduceJFrogServerID(platformURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse jfrog url: %w", err)
+	}
+
+	client := e.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	rotated, err := jfrogExchangeRefreshToken(ctx, client, platformURL, access, refresh)
+	if err != nil {
+		return nil, err
+	}
+	if rotated.AccessToken == "" || rotated.RefreshToken == "" {
+		return nil, fmt.Errorf("jfrog refresh returned incomplete token pair")
+	}
+
+	user := extractUsernameFromJWT(rotated.AccessToken)
+	if user == "" {
+		// The refresh endpoint may return a reference (non-JWT) token;
+		// fall back to the username we already had on file rather than
+		// losing it on every rotation.
+		user = existing["user"]
+	}
+
+	now := e.clock()
+	return map[string]string{
+		"access_token":  rotated.AccessToken,
+		"refresh_token": rotated.RefreshToken,
+		"url":           platformURL,
+		"server_id":     serverID,
+		"user":          user,
+		"issued_at":     now.UTC().Format(time.RFC3339),
+		"expires_at":    now.Add(ttl).UTC().Format(time.RFC3339),
+	}, nil
 }
 
 // ensureScheme prepends https:// if the URL has no scheme.
@@ -253,6 +377,107 @@ func jfrogPollForToken(ctx context.Context, client *http.Client, platformURL, se
 		case <-time.After(interval):
 		}
 	}
+}
+
+// jfrogMintRefreshableToken exchanges the bootstrap access token produced
+// by the web-login flow for a dotvault-owned, refreshable token pair with
+// the caller-specified TTL. Called once at enrolment time; the bootstrap
+// token is discarded after this call returns.
+//
+// Endpoint: POST {platform}/access/api/v2/tokens with a bearer auth header.
+// Body: {"expires_in": <seconds>, "refreshable": true, "scope": "applied-permissions/user"}.
+//
+// Non-admin users can successfully mint refreshable tokens for themselves
+// with any non-zero TTL; the admin-only restriction in JFrog only applies
+// to expires_in=0 (never-expiring tokens), which we intentionally do not use.
+func jfrogMintRefreshableToken(ctx context.Context, client *http.Client, platformURL, bootstrapToken string, ttl time.Duration) (jfrogCommonTokenParams, error) {
+	endpoint := platformURL + "/access/api/v2/tokens"
+	body, err := json.Marshal(struct {
+		ExpiresIn   int64  `json:"expires_in"`
+		Refreshable bool   `json:"refreshable"`
+		Scope       string `json:"scope"`
+	}{
+		ExpiresIn:   int64(ttl.Seconds()),
+		Refreshable: true,
+		Scope:       "applied-permissions/user",
+	})
+	if err != nil {
+		return jfrogCommonTokenParams{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return jfrogCommonTokenParams{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+bootstrapToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return jfrogCommonTokenParams{}, err
+	}
+	respBody, _ := readAndClose(resp)
+	if resp.StatusCode != http.StatusOK {
+		return jfrogCommonTokenParams{}, fmt.Errorf("jfrog mint returned status %d: %s", resp.StatusCode, truncate(string(respBody), 200))
+	}
+	var token jfrogCommonTokenParams
+	if err := json.Unmarshal(respBody, &token); err != nil {
+		return jfrogCommonTokenParams{}, fmt.Errorf("decode jfrog mint response: %w", err)
+	}
+	return token, nil
+}
+
+// jfrogExchangeRefreshToken rotates an existing token pair. JFrog's
+// refresh endpoint ROTATES the refresh token on every successful call —
+// the old refresh_token is invalidated immediately, so callers must
+// persist the returned pair atomically before acknowledging success.
+//
+// Endpoint: POST {platform}/access/api/v1/tokens with form-urlencoded body
+// grant_type=refresh_token&access_token=<old>&refresh_token=<old>.
+//
+// 401/403 → ErrRevoked (token has been revoked upstream; caller should
+// discard the secret and force a fresh enrolment). Any other error is
+// transient and the caller should keep the existing secret for retry.
+func jfrogExchangeRefreshToken(ctx context.Context, client *http.Client, platformURL, accessToken, refreshToken string) (jfrogCommonTokenParams, error) {
+	endpoint := platformURL + "/access/api/v1/tokens"
+	form := url.Values{
+		"grant_type":    []string{"refresh_token"},
+		"access_token":  []string{accessToken},
+		"refresh_token": []string{refreshToken},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return jfrogCommonTokenParams{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return jfrogCommonTokenParams{}, err
+	}
+	respBody, _ := readAndClose(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var token jfrogCommonTokenParams
+		if err := json.Unmarshal(respBody, &token); err != nil {
+			return jfrogCommonTokenParams{}, fmt.Errorf("decode jfrog refresh response: %w", err)
+		}
+		return token, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return jfrogCommonTokenParams{}, fmt.Errorf("jfrog refresh rejected (status %d): %w", resp.StatusCode, ErrRevoked)
+	default:
+		return jfrogCommonTokenParams{}, fmt.Errorf("jfrog refresh returned status %d: %s", resp.StatusCode, truncate(string(respBody), 200))
+	}
+}
+
+// truncate trims s to maxLen runes with an ellipsis, for error logs.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
 }
 
 func readAndClose(resp *http.Response) ([]byte, error) {

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -303,7 +303,11 @@ func normalizeJFrogPlatformURL(raw string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse jfrog url: %w", err)
 	}
-	if u.Scheme == "" || u.Host == "" {
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("jfrog url must use http or https, got %q", raw)
+	}
+	if u.Host == "" {
 		return "", fmt.Errorf("jfrog url must include a host: %q", raw)
 	}
 	if u.RawQuery != "" || u.Fragment != "" {
@@ -312,7 +316,7 @@ func normalizeJFrogPlatformURL(raw string) (string, error) {
 	if u.Path != "" && u.Path != "/" {
 		return "", fmt.Errorf("jfrog url must be the platform base URL without a path (got %q)", raw)
 	}
-	return (&url.URL{Scheme: u.Scheme, Host: u.Host}).String(), nil
+	return (&url.URL{Scheme: scheme, Host: u.Host}).String(), nil
 }
 
 // deduceJFrogServerID extracts a short server identifier from the platform
@@ -384,7 +388,10 @@ func jfrogPollForToken(ctx context.Context, client *http.Client, platformURL, se
 		if err != nil {
 			return jfrogCommonTokenParams{}, err
 		}
-		body, _ := readAndClose(resp)
+		body, err := readAndClose(resp)
+		if err != nil {
+			return jfrogCommonTokenParams{}, fmt.Errorf("read jfrog token poll response: %w", err)
+		}
 
 		switch resp.StatusCode {
 		case http.StatusOK:
@@ -448,7 +455,10 @@ func jfrogMintRefreshableToken(ctx context.Context, client *http.Client, platfor
 	if err != nil {
 		return jfrogCommonTokenParams{}, err
 	}
-	respBody, _ := readAndClose(resp)
+	respBody, err := readAndClose(resp)
+	if err != nil {
+		return jfrogCommonTokenParams{}, fmt.Errorf("read jfrog mint response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return jfrogCommonTokenParams{}, fmt.Errorf("jfrog mint returned status %d: %s", resp.StatusCode, truncate(string(respBody), 200))
 	}
@@ -488,7 +498,10 @@ func jfrogExchangeRefreshToken(ctx context.Context, client *http.Client, platfor
 	if err != nil {
 		return jfrogCommonTokenParams{}, err
 	}
-	respBody, _ := readAndClose(resp)
+	respBody, err := readAndClose(resp)
+	if err != nil {
+		return jfrogCommonTokenParams{}, fmt.Errorf("read jfrog refresh response: %w", err)
+	}
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -50,18 +50,24 @@ type JFrogEngine struct {
 
 func (e *JFrogEngine) Name() string { return "JFrog" }
 
-// Fields lists the Vault KV fields this engine writes. All fields are
-// required for a complete enrolment: access_token drives the CLI config,
-// refresh_token powers the rotation cycle, url+server_id+user render the
-// jfrog-cli.conf.v6 template, and issued_at+expires_at drive the
-// half-life refresh decision.
+// Fields lists the Vault KV fields this engine requires for a complete
+// enrolment: access_token drives the CLI config, refresh_token powers
+// the rotation cycle, url+server_id render the jfrog-cli.conf.v6 template,
+// and issued_at+expires_at drive the half-life refresh decision.
+//
+// `user` is intentionally NOT listed: the engine writes it when it can be
+// extracted from the access-token JWT subject, but JFrog reference
+// (non-JWT) tokens don't expose a parseable subject. Making user
+// mandatory would have `enrol.Manager.HasAllFields` reject otherwise-good
+// enrolments with reference-token deployments. GitHub's engine takes the
+// same approach — its `user` value is written when available but isn't
+// required for `HasAllFields`.
 func (e *JFrogEngine) Fields() []string {
 	return []string{
 		"access_token",
 		"refresh_token",
 		"url",
 		"server_id",
-		"user",
 		"issued_at",
 		"expires_at",
 	}

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -1,0 +1,314 @@
+package enrol
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// jfrogDefaultClientName is the label JFrog CLI uses to identify itself
+	// to the JFrog Platform browser-based web login flow.
+	jfrogDefaultClientName = "JFrog-CLI"
+	// jfrogDefaultClientCode is the jfClientCode query parameter JFrog CLI
+	// always sends (a constant "1" in the upstream source).
+	jfrogDefaultClientCode = "1"
+)
+
+const (
+	jfrogDefaultPollInterval = 3 * time.Second
+	jfrogDefaultMaxWait      = 5 * time.Minute
+)
+
+// JFrogEngine performs a JFrog Platform browser-based web login exchange,
+// mirroring the flow used by `jf login` in jfrog-cli.
+type JFrogEngine struct {
+	// overridable for tests
+	httpClient   *http.Client
+	pollInterval time.Duration
+	maxWait      time.Duration
+}
+
+func (e *JFrogEngine) Name() string { return "JFrog" }
+
+// Fields lists the Vault KV fields this engine writes. access_token is the
+// only strictly-required credential; the other fields are identity metadata
+// needed to render a jfrog-cli config file.
+func (e *JFrogEngine) Fields() []string {
+	return []string{"access_token", "url", "server_id"}
+}
+
+func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (map[string]string, error) {
+	platformURL, ok := settings["url"].(string)
+	if !ok || strings.TrimSpace(platformURL) == "" {
+		return nil, fmt.Errorf("jfrog enrolment requires a non-empty 'url' setting (your JFrog Platform URL, e.g. https://mycompany.jfrog.io)")
+	}
+	platformURL = ensureScheme(strings.TrimRight(platformURL, "/"))
+
+	clientName := jfrogDefaultClientName
+	if v, ok := settings["client_name"].(string); ok && v != "" {
+		clientName = v
+	}
+
+	clientCode := jfrogDefaultClientCode
+	if v, ok := settings["client_code"].(string); ok && v != "" {
+		clientCode = v
+	}
+
+	serverID, err := deduceJFrogServerID(platformURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse jfrog url: %w", err)
+	}
+
+	session, err := newUUIDv4()
+	if err != nil {
+		return nil, fmt.Errorf("generate session uuid: %w", err)
+	}
+
+	client := e.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	// Step 1: tell the JFrog Access service we're about to start a web login.
+	if err := jfrogSendLoginRequest(ctx, client, platformURL, session); err != nil {
+		return nil, fmt.Errorf("initiate jfrog web login: %w", err)
+	}
+
+	// Step 2: present the URL to the user; they authenticate via the browser
+	// and enter the short confirmation code (last 4 chars of the UUID).
+	confirmCode := session[len(session)-4:]
+	loginURL := fmt.Sprintf(
+		"%s/ui/login?jfClientSession=%s&jfClientName=%s&jfClientCode=%s",
+		platformURL,
+		url.QueryEscape(session),
+		url.QueryEscape(clientName),
+		url.QueryEscape(clientCode),
+	)
+
+	copyToClipboard(confirmCode)
+	fmt.Fprintf(io.Out, "! First, copy your one-time code: %s\n", confirmCode)
+	fmt.Fprintf(io.Out, "  (you will be prompted for this after signing in)\n")
+	if io.Browser == nil {
+		fmt.Fprintf(io.Out, "- Please open %s in your browser.\n", loginURL)
+	} else if browseErr := io.Browser(loginURL); browseErr != nil {
+		fmt.Fprintf(io.Out, "  (could not open browser automatically: %v)\n", browseErr)
+		fmt.Fprintf(io.Out, "- Please open %s manually.\n", loginURL)
+	} else {
+		fmt.Fprintf(io.Out, "✓ Opened %s in browser\n", loginURL)
+	}
+
+	// Step 3: poll for the token.
+	pollInterval := e.pollInterval
+	if pollInterval == 0 {
+		pollInterval = jfrogDefaultPollInterval
+	}
+	maxWait := e.maxWait
+	if maxWait == 0 {
+		maxWait = jfrogDefaultMaxWait
+	}
+
+	fmt.Fprintf(io.Out, "⠼ Waiting for authentication...\n")
+	token, err := jfrogPollForToken(ctx, client, platformURL, session, pollInterval, maxWait)
+	if err != nil {
+		return nil, err
+	}
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("jfrog returned empty access token after web login")
+	}
+
+	user := extractUsernameFromJWT(token.AccessToken)
+
+	result := map[string]string{
+		"access_token": token.AccessToken,
+		"url":          platformURL,
+		"server_id":    serverID,
+	}
+	if token.RefreshToken != "" {
+		result["refresh_token"] = token.RefreshToken
+	}
+	if token.TokenType != "" {
+		result["token_type"] = token.TokenType
+	}
+	if token.Scope != "" {
+		result["scope"] = token.Scope
+	}
+	if token.ExpiresIn != nil {
+		result["expires_in"] = fmt.Sprintf("%d", *token.ExpiresIn)
+	}
+	if user != "" {
+		result["user"] = user
+	}
+
+	return result, nil
+}
+
+// ensureScheme prepends https:// if the URL has no scheme.
+func ensureScheme(u string) string {
+	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+		return u
+	}
+	return "https://" + u
+}
+
+// deduceJFrogServerID extracts a short server identifier from the platform
+// URL hostname, matching the logic in jfrog-cli-core/general/utils.go.
+// e.g. https://mycompany.jfrog.io/ -> "mycompany"; IP addresses -> "default-server".
+func deduceJFrogServerID(platformURL string) (string, error) {
+	u, err := url.Parse(platformURL)
+	if err != nil {
+		return "", err
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("platform url %q has no hostname", platformURL)
+	}
+	if net.ParseIP(host) != nil {
+		return "default-server", nil
+	}
+	return strings.Split(host, ".")[0], nil
+}
+
+// jfrogCommonTokenParams mirrors jfrog-client-go's auth.CommonTokenParams.
+type jfrogCommonTokenParams struct {
+	Scope        string `json:"scope,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	ExpiresIn    *uint  `json:"expires_in,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// jfrogSendLoginRequest performs the initial POST to the JFrog Access service
+// telling it to prepare a web login session for our UUID.
+func jfrogSendLoginRequest(ctx context.Context, client *http.Client, platformURL, session string) error {
+	endpoint := platformURL + "/access/api/v2/authentication/jfrog_client_login/request"
+	body, err := json.Marshal(struct {
+		Session string `json:"session"`
+	}{Session: session})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jfrog login request returned status %d (web login may be unavailable; requires Artifactory 7.64.0 or newer)", resp.StatusCode)
+	}
+	return nil
+}
+
+// jfrogPollForToken polls the token endpoint. A 400 means "not yet"; a 200
+// means we have the token. Any other status is a hard error.
+func jfrogPollForToken(ctx context.Context, client *http.Client, platformURL, session string, interval, max time.Duration) (jfrogCommonTokenParams, error) {
+	endpoint := fmt.Sprintf("%s/access/api/v2/authentication/jfrog_client_login/token/%s", platformURL, url.PathEscape(session))
+	deadline := time.Now().Add(max)
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return jfrogCommonTokenParams{}, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return jfrogCommonTokenParams{}, err
+		}
+		body, _ := readAndClose(resp)
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var token jfrogCommonTokenParams
+			if err := json.Unmarshal(body, &token); err != nil {
+				return jfrogCommonTokenParams{}, fmt.Errorf("decode jfrog token response: %w", err)
+			}
+			return token, nil
+		case http.StatusBadRequest:
+			// Not yet authenticated; keep polling.
+		default:
+			return jfrogCommonTokenParams{}, fmt.Errorf("jfrog token poll returned unexpected status %d", resp.StatusCode)
+		}
+
+		if time.Now().After(deadline) {
+			return jfrogCommonTokenParams{}, fmt.Errorf("timed out waiting for jfrog web login after %s", max)
+		}
+
+		select {
+		case <-ctx.Done():
+			return jfrogCommonTokenParams{}, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+func readAndClose(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(resp.Body)
+	return buf.Bytes(), err
+}
+
+// extractUsernameFromJWT parses a JFrog access token JWT and returns the
+// username portion of the subject claim, mirroring
+// jfrog-client-go/auth.ExtractUsernameFromAccessToken. Returns "" for
+// non-JWT tokens (e.g. reference tokens).
+func extractUsernameFromJWT(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// Try standard encoding as a fallback.
+		payload, err = base64.RawStdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return ""
+		}
+	}
+	var claims struct {
+		Subject string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	sub := claims.Subject
+	if sub == "" {
+		return ""
+	}
+	// Subjects like "jfrt@01g.../users/alice" or ".../users/alice" have the
+	// username as the final path segment.
+	if strings.HasPrefix(sub, "jfrt@") || strings.Contains(sub, "/users/") {
+		if idx := strings.LastIndex(sub, "/"); idx >= 0 {
+			return sub[idx+1:]
+		}
+	}
+	// Otherwise (OIDC-groups-scoped tokens etc.) the subject is the username.
+	return sub
+}
+
+// newUUIDv4 generates an RFC-4122 version-4 UUID without pulling in a
+// new dependency. Matches the format that jfrog-cli sends as jfClientSession.
+func newUUIDv4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -82,6 +82,45 @@ func TestEnsureScheme(t *testing.T) {
 	}
 }
 
+func TestNormalizeJFrogPlatformURL(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		// Accepted shapes — bare host, trailing slash, explicit scheme.
+		{"mycompany.jfrog.io", "https://mycompany.jfrog.io", false},
+		{"https://mycompany.jfrog.io", "https://mycompany.jfrog.io", false},
+		{"https://mycompany.jfrog.io/", "https://mycompany.jfrog.io", false},
+		{"http://127.0.0.1:8082", "http://127.0.0.1:8082", false},
+		{"http://127.0.0.1:8082/", "http://127.0.0.1:8082", false},
+
+		// Rejected: paths, queries, fragments, empty.
+		{"https://mycompany.jfrog.io/artifactory", "", true},
+		{"https://mycompany.jfrog.io/artifactory/", "", true},
+		{"https://mycompany.jfrog.io?foo=bar", "", true},
+		{"https://mycompany.jfrog.io#frag", "", true},
+		{"", "", true},
+		{"   ", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeJFrogPlatformURL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalizeJFrogPlatformURL(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeJFrogPlatformURL(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeJFrogPlatformURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestNewUUIDv4_Format(t *testing.T) {
 	u, err := newUUIDv4()
 	if err != nil {

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -23,9 +25,9 @@ func TestJFrogEngine_Name(t *testing.T) {
 func TestJFrogEngine_Fields(t *testing.T) {
 	e := &JFrogEngine{}
 	got := e.Fields()
-	want := []string{"access_token", "url", "server_id"}
+	want := []string{"access_token", "refresh_token", "url", "server_id", "user", "issued_at", "expires_at"}
 	if len(got) != len(want) {
-		t.Fatalf("Fields() len = %d, want %d", len(got), len(want))
+		t.Fatalf("Fields() = %v, want %v", got, want)
 	}
 	for i, f := range got {
 		if f != want[i] {
@@ -137,14 +139,26 @@ func TestJFrogEngine_Run_MissingURL(t *testing.T) {
 }
 
 func TestJFrogEngine_Run_FullFlow(t *testing.T) {
-	// Build a JWT whose subject decodes to "alice".
-	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
-	claims, _ := json.Marshal(map[string]string{"sub": "jfrt@01g.../users/alice"})
-	payload := base64.RawURLEncoding.EncodeToString(claims)
-	accessToken := header + "." + payload + ".sig"
+	// Build JWTs for both the bootstrap (web-login) and minted tokens. The
+	// minted token's subject is what we expect to appear in creds["user"].
+	mkToken := func(subject string) string {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+		claims, _ := json.Marshal(map[string]string{"sub": subject})
+		payload := base64.RawURLEncoding.EncodeToString(claims)
+		return header + "." + payload + ".sig"
+	}
+	// Distinct JWTs (subjects differ by issuer ID prefix) so we can tell
+	// them apart; both still decode to username "alice".
+	bootstrapAccess := mkToken("jfrt@bootstrap/users/alice")
+	mintedAccess := mkToken("jfrt@minted/users/alice")
 
-	var gotSession string
-	var requestHits, tokenHits int
+	var gotSession, gotBearer string
+	var gotMintBody struct {
+		ExpiresIn   int64  `json:"expires_in"`
+		Refreshable bool   `json:"refreshable"`
+		Scope       string `json:"scope"`
+	}
+	var requestHits, tokenHits, mintHits int
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -161,18 +175,30 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/access/api/v2/authentication/jfrog_client_login/token/"):
 			tokenHits++
-			// First call: "not yet". Subsequent calls: return the token.
+			// First call: "not yet". Subsequent calls: return the bootstrap token.
 			if tokenHits < 2 {
 				http.Error(w, "pending", http.StatusBadRequest)
 				return
 			}
 			exp := uint(3600)
 			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
-				AccessToken:  accessToken,
-				RefreshToken: "refresh-xyz",
+				AccessToken:  bootstrapAccess,
+				RefreshToken: "bootstrap-refresh-should-be-ignored",
 				TokenType:    "Bearer",
 				ExpiresIn:    &exp,
 				Scope:        "applied-permissions/user",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/access/api/v2/tokens":
+			mintHits++
+			gotBearer = r.Header.Get("Authorization")
+			if err := json.NewDecoder(r.Body).Decode(&gotMintBody); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
+				AccessToken:  mintedAccess,
+				RefreshToken: "dotvault-refresh-1",
+				TokenType:    "Bearer",
 			})
 		default:
 			http.NotFound(w, r)
@@ -187,33 +213,32 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 		return nil
 	}
 
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
 	e := &JFrogEngine{
 		httpClient:   srv.Client(),
 		pollInterval: 5 * time.Millisecond,
 		maxWait:      2 * time.Second,
+		now:          func() time.Time { return fixedNow },
 	}
-	creds, err := e.Run(context.Background(), map[string]any{"url": srv.URL}, io)
+	creds, err := e.Run(context.Background(), map[string]any{
+		"url":       srv.URL,
+		"token_ttl": "6h",
+	}, io)
 	if err != nil {
 		t.Fatalf("Run error: %v", err)
 	}
 
-	if creds["access_token"] != accessToken {
-		t.Errorf("access_token = %q, want %q", creds["access_token"], accessToken)
+	if creds["access_token"] != mintedAccess {
+		t.Errorf("access_token = %q, want minted token %q", creds["access_token"], mintedAccess)
 	}
-	if creds["refresh_token"] != "refresh-xyz" {
-		t.Errorf("refresh_token = %q, want %q", creds["refresh_token"], "refresh-xyz")
+	if creds["access_token"] == bootstrapAccess {
+		t.Error("access_token is the bootstrap token — should have been replaced by the minted token")
+	}
+	if creds["refresh_token"] != "dotvault-refresh-1" {
+		t.Errorf("refresh_token = %q, want %q", creds["refresh_token"], "dotvault-refresh-1")
 	}
 	if creds["user"] != "alice" {
 		t.Errorf("user = %q, want %q", creds["user"], "alice")
-	}
-	if creds["token_type"] != "Bearer" {
-		t.Errorf("token_type = %q, want %q", creds["token_type"], "Bearer")
-	}
-	if creds["expires_in"] != "3600" {
-		t.Errorf("expires_in = %q, want %q", creds["expires_in"], "3600")
-	}
-	if creds["scope"] != "applied-permissions/user" {
-		t.Errorf("scope = %q, want %q", creds["scope"], "applied-permissions/user")
 	}
 	if creds["url"] != srv.URL {
 		t.Errorf("url = %q, want %q", creds["url"], srv.URL)
@@ -221,12 +246,40 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 	if creds["server_id"] == "" {
 		t.Error("server_id is empty")
 	}
+	if creds["issued_at"] != "2026-04-17T12:00:00Z" {
+		t.Errorf("issued_at = %q, want 2026-04-17T12:00:00Z", creds["issued_at"])
+	}
+	if creds["expires_at"] != "2026-04-17T18:00:00Z" {
+		t.Errorf("expires_at = %q, want 2026-04-17T18:00:00Z", creds["expires_at"])
+	}
+
+	// Dropped fields must not leak into the stored secret.
+	for _, k := range []string{"token_type", "expires_in", "scope"} {
+		if _, ok := creds[k]; ok {
+			t.Errorf("creds should not contain %q in the new schema", k)
+		}
+	}
 
 	if requestHits != 1 {
 		t.Errorf("request endpoint hit %d times, want 1", requestHits)
 	}
 	if tokenHits < 2 {
 		t.Errorf("token endpoint hit %d times, want >= 2", tokenHits)
+	}
+	if mintHits != 1 {
+		t.Errorf("mint endpoint hit %d times, want 1", mintHits)
+	}
+	if gotBearer != "Bearer "+bootstrapAccess {
+		t.Errorf("mint authorization header = %q, want bearer of bootstrap token", gotBearer)
+	}
+	if gotMintBody.ExpiresIn != int64((6 * time.Hour).Seconds()) {
+		t.Errorf("mint expires_in = %d, want %d", gotMintBody.ExpiresIn, int64((6 * time.Hour).Seconds()))
+	}
+	if !gotMintBody.Refreshable {
+		t.Error("mint refreshable = false, want true")
+	}
+	if gotMintBody.Scope != "applied-permissions/user" {
+		t.Errorf("mint scope = %q, want %q", gotMintBody.Scope, "applied-permissions/user")
 	}
 	if gotSession == "" {
 		t.Error("server did not observe a session uuid")
@@ -284,6 +337,231 @@ func TestJFrogEngine_Run_Timeout(t *testing.T) {
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("error %q does not mention timeout", err)
 	}
+}
+
+func TestJFrogEngine_Run_DefaultTTL(t *testing.T) {
+	// When token_ttl is omitted, the engine should fall back to the 60d
+	// default and pass that value to POST /access/api/v2/tokens.
+	bootstrap := "bootstrap.token.sig"
+	minted := "minted.token.sig"
+
+	var gotMintBody struct {
+		ExpiresIn   int64 `json:"expires_in"`
+		Refreshable bool  `json:"refreshable"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/access/api/v2/authentication/jfrog_client_login/request":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/access/api/v2/authentication/jfrog_client_login/token/"):
+			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{AccessToken: bootstrap})
+		case r.Method == http.MethodPost && r.URL.Path == "/access/api/v2/tokens":
+			_ = json.NewDecoder(r.Body).Decode(&gotMintBody)
+			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{AccessToken: minted, RefreshToken: "r1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	e := &JFrogEngine{
+		httpClient:   srv.Client(),
+		pollInterval: time.Millisecond,
+		maxWait:      time.Second,
+		now:          func() time.Time { return time.Unix(0, 0).UTC() },
+	}
+	if _, err := e.Run(context.Background(), map[string]any{"url": srv.URL}, newTestIO()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	wantTTLSeconds := int64((60 * 24 * time.Hour).Seconds())
+	if gotMintBody.ExpiresIn != wantTTLSeconds {
+		t.Errorf("default mint ExpiresIn = %d, want %d (60d)", gotMintBody.ExpiresIn, wantTTLSeconds)
+	}
+}
+
+func TestJFrogEngine_Refresh_Success(t *testing.T) {
+	rotatedAccess := mkTestJWT(t, "jfrt@01g.../users/alice")
+	var gotForm url.Values
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/access/api/v1/tokens" {
+			hits++
+			_ = r.ParseForm()
+			gotForm = r.PostForm
+			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
+				AccessToken:  rotatedAccess,
+				RefreshToken: "new-refresh",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	e := &JFrogEngine{httpClient: srv.Client(), now: func() time.Time { return fixedNow }}
+	existing := map[string]string{
+		"access_token":  "old-access",
+		"refresh_token": "old-refresh",
+		"user":          "alice",
+	}
+	got, err := e.Refresh(context.Background(), map[string]any{
+		"url":       srv.URL,
+		"token_ttl": "6h",
+	}, existing)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	if got["access_token"] != rotatedAccess {
+		t.Errorf("access_token = %q, want rotated", got["access_token"])
+	}
+	if got["refresh_token"] != "new-refresh" {
+		t.Errorf("refresh_token = %q, want %q", got["refresh_token"], "new-refresh")
+	}
+	if got["user"] != "alice" {
+		t.Errorf("user = %q, want alice", got["user"])
+	}
+	if got["issued_at"] != "2026-04-17T12:00:00Z" {
+		t.Errorf("issued_at = %q, want 2026-04-17T12:00:00Z", got["issued_at"])
+	}
+	if got["expires_at"] != "2026-04-17T18:00:00Z" {
+		t.Errorf("expires_at = %q, want 2026-04-17T18:00:00Z", got["expires_at"])
+	}
+	if hits != 1 {
+		t.Errorf("refresh endpoint hit %d times, want 1", hits)
+	}
+	if gotForm.Get("grant_type") != "refresh_token" {
+		t.Errorf("form grant_type = %q, want refresh_token", gotForm.Get("grant_type"))
+	}
+	if gotForm.Get("access_token") != "old-access" {
+		t.Errorf("form access_token = %q, want old-access", gotForm.Get("access_token"))
+	}
+	if gotForm.Get("refresh_token") != "old-refresh" {
+		t.Errorf("form refresh_token = %q, want old-refresh", gotForm.Get("refresh_token"))
+	}
+}
+
+func TestJFrogEngine_Refresh_NonJWTKeepsUser(t *testing.T) {
+	// If the rotated token is a reference token (non-JWT), Refresh should
+	// preserve the existing user rather than wiping it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
+			AccessToken:  "cmVmZXJlbmNl-not-a-jwt",
+			RefreshToken: "new-refresh",
+		})
+	}))
+	defer srv.Close()
+
+	e := &JFrogEngine{httpClient: srv.Client(), now: func() time.Time { return time.Unix(0, 0).UTC() }}
+	got, err := e.Refresh(context.Background(), map[string]any{
+		"url":       srv.URL,
+		"token_ttl": "1h",
+	}, map[string]string{
+		"access_token":  "old",
+		"refresh_token": "old-refresh",
+		"user":          "alice",
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got["user"] != "alice" {
+		t.Errorf("user = %q, want alice (preserved from existing)", got["user"])
+	}
+}
+
+func TestJFrogEngine_Refresh_Revoked(t *testing.T) {
+	cases := []int{http.StatusUnauthorized, http.StatusForbidden}
+	for _, status := range cases {
+		status := status
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "revoked", status)
+			}))
+			defer srv.Close()
+
+			e := &JFrogEngine{httpClient: srv.Client(), now: func() time.Time { return time.Unix(0, 0).UTC() }}
+			_, err := e.Refresh(context.Background(), map[string]any{
+				"url":       srv.URL,
+				"token_ttl": "1h",
+			}, map[string]string{
+				"access_token":  "a",
+				"refresh_token": "r",
+			})
+			if err == nil {
+				t.Fatalf("expected error for status %d", status)
+			}
+			if !errors.Is(err, ErrRevoked) {
+				t.Errorf("status %d error = %v, want errors.Is(ErrRevoked) == true", status, err)
+			}
+		})
+	}
+}
+
+func TestJFrogEngine_Refresh_Transient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "kaboom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	e := &JFrogEngine{httpClient: srv.Client(), now: func() time.Time { return time.Unix(0, 0).UTC() }}
+	_, err := e.Refresh(context.Background(), map[string]any{
+		"url":       srv.URL,
+		"token_ttl": "1h",
+	}, map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+	})
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrRevoked) {
+		t.Errorf("500 should be transient, got ErrRevoked: %v", err)
+	}
+}
+
+func TestJFrogEngine_Refresh_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	e := &JFrogEngine{httpClient: srv.Client(), now: func() time.Time { return time.Unix(0, 0).UTC() }}
+	_, err := e.Refresh(context.Background(), map[string]any{
+		"url":       srv.URL,
+		"token_ttl": "1h",
+	}, map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed JSON response")
+	}
+	if errors.Is(err, ErrRevoked) {
+		t.Errorf("decode failure should not be ErrRevoked: %v", err)
+	}
+}
+
+func TestJFrogEngine_Refresh_MissingExisting(t *testing.T) {
+	e := &JFrogEngine{}
+	_, err := e.Refresh(context.Background(), map[string]any{"url": "https://example.com"}, map[string]string{
+		"access_token": "a",
+		// refresh_token missing
+	})
+	if err == nil {
+		t.Fatal("expected error when existing secret has no refresh_token")
+	}
+}
+
+func mkTestJWT(t *testing.T, subject string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	claims, _ := json.Marshal(map[string]string{"sub": subject})
+	payload := base64.RawURLEncoding.EncodeToString(claims)
+	return header + "." + payload + ".sig"
 }
 
 // newTestIO builds an IO suitable for unit tests: writes go to /dev/null,

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -25,7 +25,7 @@ func TestJFrogEngine_Name(t *testing.T) {
 func TestJFrogEngine_Fields(t *testing.T) {
 	e := &JFrogEngine{}
 	got := e.Fields()
-	want := []string{"access_token", "refresh_token", "url", "server_id", "user", "issued_at", "expires_at"}
+	want := []string{"access_token", "refresh_token", "url", "server_id", "issued_at", "expires_at"}
 	if len(got) != len(want) {
 		t.Fatalf("Fields() = %v, want %v", got, want)
 	}

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -1,0 +1,299 @@
+package enrol
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJFrogEngine_Name(t *testing.T) {
+	e := &JFrogEngine{}
+	if got := e.Name(); got != "JFrog" {
+		t.Errorf("Name() = %q, want %q", got, "JFrog")
+	}
+}
+
+func TestJFrogEngine_Fields(t *testing.T) {
+	e := &JFrogEngine{}
+	got := e.Fields()
+	want := []string{"access_token", "url", "server_id"}
+	if len(got) != len(want) {
+		t.Fatalf("Fields() len = %d, want %d", len(got), len(want))
+	}
+	for i, f := range got {
+		if f != want[i] {
+			t.Errorf("Fields()[%d] = %q, want %q", i, f, want[i])
+		}
+	}
+}
+
+func TestJFrogEngine_Registered(t *testing.T) {
+	e, ok := GetEngine("jfrog")
+	if !ok {
+		t.Fatal("jfrog engine not registered")
+	}
+	if _, ok := e.(*JFrogEngine); !ok {
+		t.Errorf("registered engine is %T, want *JFrogEngine", e)
+	}
+}
+
+func TestDeduceJFrogServerID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://mycompany.jfrog.io", "mycompany"},
+		{"https://mycompany.jfrog.io/", "mycompany"},
+		{"https://artifactory.example.com/", "artifactory"},
+		{"https://127.0.0.1:8082", "default-server"},
+		{"https://[::1]:8082", "default-server"},
+	}
+	for _, tc := range cases {
+		got, err := deduceJFrogServerID(tc.in)
+		if err != nil {
+			t.Errorf("deduceJFrogServerID(%q) error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("deduceJFrogServerID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEnsureScheme(t *testing.T) {
+	cases := map[string]string{
+		"mycompany.jfrog.io":          "https://mycompany.jfrog.io",
+		"https://mycompany.jfrog.io":  "https://mycompany.jfrog.io",
+		"http://localhost:8082":       "http://localhost:8082",
+	}
+	for in, want := range cases {
+		if got := ensureScheme(in); got != want {
+			t.Errorf("ensureScheme(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNewUUIDv4_Format(t *testing.T) {
+	u, err := newUUIDv4()
+	if err != nil {
+		t.Fatalf("newUUIDv4 error: %v", err)
+	}
+	if len(u) != 36 {
+		t.Errorf("uuid length = %d, want 36", len(u))
+	}
+	if u[8] != '-' || u[13] != '-' || u[18] != '-' || u[23] != '-' {
+		t.Errorf("uuid %q missing dashes in expected positions", u)
+	}
+	// Version nibble is position 14 (the 15th char), must be '4'.
+	if u[14] != '4' {
+		t.Errorf("uuid version nibble = %c, want '4' (got %q)", u[14], u)
+	}
+	// Variant nibble at position 19 must be one of 8,9,a,b.
+	switch u[19] {
+	case '8', '9', 'a', 'b':
+	default:
+		t.Errorf("uuid variant nibble = %c, want one of 8/9/a/b (got %q)", u[19], u)
+	}
+}
+
+func TestExtractUsernameFromJWT(t *testing.T) {
+	mkJWT := func(sub string) string {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+		claims, _ := json.Marshal(map[string]string{"sub": sub})
+		payload := base64.RawURLEncoding.EncodeToString(claims)
+		return header + "." + payload + ".sig"
+	}
+
+	cases := map[string]string{
+		mkJWT("jfrt@01g123/users/alice"): "alice",
+		mkJWT("some/users/bob"):          "bob",
+		mkJWT("carol"):                   "carol",
+		mkJWT(""):                        "",
+		"not-a-jwt":                      "",
+	}
+	for tok, want := range cases {
+		if got := extractUsernameFromJWT(tok); got != want {
+			t.Errorf("extractUsernameFromJWT(...) = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestJFrogEngine_Run_MissingURL(t *testing.T) {
+	e := &JFrogEngine{}
+	_, err := e.Run(context.Background(), map[string]any{}, newTestIO())
+	if err == nil {
+		t.Fatal("expected error when url setting is missing")
+	}
+	if !strings.Contains(err.Error(), "url") {
+		t.Errorf("error %q does not mention 'url'", err.Error())
+	}
+}
+
+func TestJFrogEngine_Run_FullFlow(t *testing.T) {
+	// Build a JWT whose subject decodes to "alice".
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	claims, _ := json.Marshal(map[string]string{"sub": "jfrt@01g.../users/alice"})
+	payload := base64.RawURLEncoding.EncodeToString(claims)
+	accessToken := header + "." + payload + ".sig"
+
+	var gotSession string
+	var requestHits, tokenHits int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/access/api/v2/authentication/jfrog_client_login/request":
+			requestHits++
+			var body struct {
+				Session string `json:"session"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			gotSession = body.Session
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/access/api/v2/authentication/jfrog_client_login/token/"):
+			tokenHits++
+			// First call: "not yet". Subsequent calls: return the token.
+			if tokenHits < 2 {
+				http.Error(w, "pending", http.StatusBadRequest)
+				return
+			}
+			exp := uint(3600)
+			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
+				AccessToken:  accessToken,
+				RefreshToken: "refresh-xyz",
+				TokenType:    "Bearer",
+				ExpiresIn:    &exp,
+				Scope:        "applied-permissions/user",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var browsed string
+	io := newTestIO()
+	io.Browser = func(u string) error {
+		browsed = u
+		return nil
+	}
+
+	e := &JFrogEngine{
+		httpClient:   srv.Client(),
+		pollInterval: 5 * time.Millisecond,
+		maxWait:      2 * time.Second,
+	}
+	creds, err := e.Run(context.Background(), map[string]any{"url": srv.URL}, io)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	if creds["access_token"] != accessToken {
+		t.Errorf("access_token = %q, want %q", creds["access_token"], accessToken)
+	}
+	if creds["refresh_token"] != "refresh-xyz" {
+		t.Errorf("refresh_token = %q, want %q", creds["refresh_token"], "refresh-xyz")
+	}
+	if creds["user"] != "alice" {
+		t.Errorf("user = %q, want %q", creds["user"], "alice")
+	}
+	if creds["token_type"] != "Bearer" {
+		t.Errorf("token_type = %q, want %q", creds["token_type"], "Bearer")
+	}
+	if creds["expires_in"] != "3600" {
+		t.Errorf("expires_in = %q, want %q", creds["expires_in"], "3600")
+	}
+	if creds["scope"] != "applied-permissions/user" {
+		t.Errorf("scope = %q, want %q", creds["scope"], "applied-permissions/user")
+	}
+	if creds["url"] != srv.URL {
+		t.Errorf("url = %q, want %q", creds["url"], srv.URL)
+	}
+	if creds["server_id"] == "" {
+		t.Error("server_id is empty")
+	}
+
+	if requestHits != 1 {
+		t.Errorf("request endpoint hit %d times, want 1", requestHits)
+	}
+	if tokenHits < 2 {
+		t.Errorf("token endpoint hit %d times, want >= 2", tokenHits)
+	}
+	if gotSession == "" {
+		t.Error("server did not observe a session uuid")
+	}
+	if !strings.Contains(browsed, "jfClientSession=") {
+		t.Errorf("browser URL %q missing jfClientSession", browsed)
+	}
+	if !strings.Contains(browsed, "jfClientName=JFrog-CLI") {
+		t.Errorf("browser URL %q missing default jfClientName", browsed)
+	}
+	if !strings.Contains(browsed, "jfClientCode=1") {
+		t.Errorf("browser URL %q missing default jfClientCode", browsed)
+	}
+}
+
+func TestJFrogEngine_Run_RequestEndpointFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not implemented", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	e := &JFrogEngine{
+		httpClient:   srv.Client(),
+		pollInterval: time.Millisecond,
+		maxWait:      100 * time.Millisecond,
+	}
+	_, err := e.Run(context.Background(), map[string]any{"url": srv.URL}, newTestIO())
+	if err == nil {
+		t.Fatal("expected error when request endpoint returns non-200")
+	}
+	if !strings.Contains(err.Error(), "initiate jfrog web login") {
+		t.Errorf("error %q missing expected prefix", err)
+	}
+}
+
+func TestJFrogEngine_Run_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Error(w, "pending", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	e := &JFrogEngine{
+		httpClient:   srv.Client(),
+		pollInterval: time.Millisecond,
+		maxWait:      20 * time.Millisecond,
+	}
+	_, err := e.Run(context.Background(), map[string]any{"url": srv.URL}, newTestIO())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error %q does not mention timeout", err)
+	}
+}
+
+// newTestIO builds an IO suitable for unit tests: writes go to /dev/null,
+// logs go to a buffer, the browser opener is a no-op.
+func newTestIO() IO {
+	return IO{
+		Out:      &bytes.Buffer{},
+		Log:      slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		Username: "testuser",
+		Browser:  func(string) error { return nil },
+	}
+}
+

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -71,9 +71,11 @@ func TestDeduceJFrogServerID(t *testing.T) {
 
 func TestEnsureScheme(t *testing.T) {
 	cases := map[string]string{
-		"mycompany.jfrog.io":          "https://mycompany.jfrog.io",
-		"https://mycompany.jfrog.io":  "https://mycompany.jfrog.io",
-		"http://localhost:8082":       "http://localhost:8082",
+		"mycompany.jfrog.io":           "https://mycompany.jfrog.io",
+		"https://mycompany.jfrog.io":   "https://mycompany.jfrog.io",
+		"http://localhost:8082":        "http://localhost:8082",
+		"HTTPS://mycompany.jfrog.io":   "HTTPS://mycompany.jfrog.io",
+		"HTTP://localhost:8082":        "HTTP://localhost:8082",
 	}
 	for in, want := range cases {
 		if got := ensureScheme(in); got != want {
@@ -94,6 +96,10 @@ func TestNormalizeJFrogPlatformURL(t *testing.T) {
 		{"https://mycompany.jfrog.io/", "https://mycompany.jfrog.io", false},
 		{"http://127.0.0.1:8082", "http://127.0.0.1:8082", false},
 		{"http://127.0.0.1:8082/", "http://127.0.0.1:8082", false},
+
+		// Uppercase scheme — normalizer should lower-case it.
+		{"HTTPS://mycompany.jfrog.io", "https://mycompany.jfrog.io", false},
+		{"HTTP://127.0.0.1:8082", "http://127.0.0.1:8082", false},
 
 		// Rejected: paths, queries, fragments, empty.
 		{"https://mycompany.jfrog.io/artifactory", "", true},

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -102,6 +102,11 @@ func TestNormalizeJFrogPlatformURL(t *testing.T) {
 		{"https://mycompany.jfrog.io#frag", "", true},
 		{"", "", true},
 		{"   ", "", true},
+		// Rejected: non-http schemes would later fail at http.Client.Do with
+		// a vague "unsupported protocol scheme" — easier to catch up front.
+		{"ftp://mycompany.jfrog.io", "", true},
+		{"file:///etc/passwd", "", true},
+		{"ssh://mycompany.jfrog.io", "", true},
 	}
 	for _, tc := range cases {
 		got, err := normalizeJFrogPlatformURL(tc.in)

--- a/internal/enrol/refresh.go
+++ b/internal/enrol/refresh.go
@@ -1,0 +1,269 @@
+package enrol
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/goodtune/dotvault/internal/config"
+	"github.com/goodtune/dotvault/internal/vault"
+)
+
+// Clock abstracts time.Now so refresh-manager unit tests can drive the
+// half-life calculation deterministically without sleeping.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
+// RefreshManager periodically scans configured enrolments, asks any whose
+// engines implement Refresher to rotate credentials past their half-life,
+// and writes the rotated secret back to Vault. Modeled on
+// auth.LifecycleManager — one goroutine, stateless between ticks, with
+// per-enrolment exponential backoff so a single flaky provider does not
+// stall the others.
+type RefreshManager struct {
+	client        *vault.Client
+	kvMount       string
+	userPrefix    string // e.g. "users/alice/"
+	checkInterval time.Duration
+	maxBackoff    time.Duration
+	clock         Clock
+
+	mu         sync.Mutex
+	enrolments map[string]config.Enrolment
+	backoffs   map[string]time.Duration // per-enrolment backoff state; cleared on success
+}
+
+// RefreshManagerOption configures a RefreshManager at construction time.
+type RefreshManagerOption func(*RefreshManager)
+
+// WithClock overrides the wall clock. Intended for tests.
+func WithClock(c Clock) RefreshManagerOption {
+	return func(m *RefreshManager) { m.clock = c }
+}
+
+// WithMaxBackoff overrides the backoff cap. Intended for tests.
+func WithMaxBackoff(d time.Duration) RefreshManagerOption {
+	return func(m *RefreshManager) { m.maxBackoff = d }
+}
+
+// NewRefreshManager constructs a RefreshManager. userPrefix must already
+// include the username and a trailing slash (e.g. "users/alice/"), matching
+// the convention used by the rest of the daemon.
+func NewRefreshManager(
+	client *vault.Client,
+	kvMount, userPrefix string,
+	enrolments map[string]config.Enrolment,
+	checkInterval time.Duration,
+	opts ...RefreshManagerOption,
+) *RefreshManager {
+	m := &RefreshManager{
+		client:        client,
+		kvMount:       kvMount,
+		userPrefix:    userPrefix,
+		checkInterval: checkInterval,
+		maxBackoff:    5 * time.Minute,
+		clock:         realClock{},
+		enrolments:    enrolments,
+		backoffs:      make(map[string]time.Duration),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// UpdateConfig replaces the enrolment map atomically. Called when the
+// daemon's background config-reload loop detects changes.
+func (m *RefreshManager) UpdateConfig(enrolments map[string]config.Enrolment) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.enrolments = enrolments
+	// Drop backoff state for any enrolment that was removed.
+	for key := range m.backoffs {
+		if _, ok := enrolments[key]; !ok {
+			delete(m.backoffs, key)
+		}
+	}
+}
+
+// Start launches the refresh goroutine. It stops when ctx is cancelled.
+func (m *RefreshManager) Start(ctx context.Context) {
+	go m.run(ctx)
+}
+
+func (m *RefreshManager) run(ctx context.Context) {
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
+
+	// Run an initial tick immediately so tokens past half-life at startup
+	// get refreshed without waiting a full interval.
+	m.tick(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.tick(ctx)
+		}
+	}
+}
+
+// tick iterates all enrolments and triggers a refresh for each Refresher
+// whose token is past half-life. Each enrolment is handled independently;
+// one failure does not block others.
+func (m *RefreshManager) tick(ctx context.Context) {
+	m.mu.Lock()
+	snapshot := make(map[string]config.Enrolment, len(m.enrolments))
+	for k, v := range m.enrolments {
+		snapshot[k] = v
+	}
+	m.mu.Unlock()
+
+	for key, enrolment := range snapshot {
+		if ctx.Err() != nil {
+			return
+		}
+		engine, ok := GetEngine(enrolment.Engine)
+		if !ok {
+			continue
+		}
+		refresher, ok := engine.(Refresher)
+		if !ok {
+			continue // engine doesn't rotate; nothing to do
+		}
+
+		m.refreshOne(ctx, key, enrolment, refresher)
+	}
+}
+
+// refreshOne handles a single enrolment: read Vault, check half-life, call
+// Refresh, write back. All errors are logged; the caller recovers state on
+// the next tick.
+func (m *RefreshManager) refreshOne(ctx context.Context, key string, enrolment config.Enrolment, engine Refresher) {
+	path := m.userPrefix + key
+	secret, err := m.client.ReadKVv2(ctx, m.kvMount, path)
+	if err != nil {
+		slog.Warn("refresh: failed to read secret", "key", key, "error", err)
+		m.bumpBackoff(key)
+		return
+	}
+	if secret == nil {
+		// No enrolment yet — not our problem; the enrolment wizard handles it.
+		return
+	}
+
+	existing := stringifyStringMap(secret.Data)
+
+	// Legacy pass-through: if there's no expires_at, this is a secret from
+	// a previous version of dotvault. Skip silently — re-enrolment is how
+	// users migrate.
+	expiresAtStr, ok := existing["expires_at"]
+	if !ok || expiresAtStr == "" {
+		return
+	}
+	issuedAtStr := existing["issued_at"]
+	if issuedAtStr == "" {
+		slog.Error("refresh: secret has expires_at but no issued_at, skipping", "key", key)
+		return
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+	if err != nil {
+		slog.Error("refresh: invalid expires_at, skipping", "key", key, "value", expiresAtStr, "error", err)
+		return
+	}
+	issuedAt, err := time.Parse(time.RFC3339, issuedAtStr)
+	if err != nil {
+		slog.Error("refresh: invalid issued_at, skipping", "key", key, "value", issuedAtStr, "error", err)
+		return
+	}
+
+	halfLife := issuedAt.Add(expiresAt.Sub(issuedAt) / 2)
+	now := m.clock.Now()
+	if now.Before(halfLife) {
+		return
+	}
+
+	slog.Info("refresh: rotating token past half-life", "key", key, "engine", enrolment.Engine, "half_life", halfLife, "expires_at", expiresAt)
+
+	rotated, err := engine.Refresh(ctx, enrolment.Settings, existing)
+	if err != nil {
+		if errors.Is(err, ErrRevoked) {
+			slog.Warn("refresh: upstream credential revoked, wiping vault secret so user can re-enrol", "key", key, "error", err)
+			if delErr := m.client.DeleteKVv2(ctx, m.kvMount, path); delErr != nil {
+				slog.Error("refresh: failed to delete revoked secret", "key", key, "error", delErr)
+			}
+			// No backoff on revocation — the state is terminal until re-enrol.
+			m.resetBackoff(key)
+			return
+		}
+		slog.Warn("refresh: transient failure, will retry", "key", key, "error", err)
+		m.bumpBackoff(key)
+		return
+	}
+
+	data := make(map[string]any, len(rotated))
+	for k, v := range rotated {
+		data[k] = v
+	}
+	if err := m.client.WriteKVv2(ctx, m.kvMount, path, data); err != nil {
+		slog.Warn("refresh: failed to write rotated secret", "key", key, "error", err)
+		m.bumpBackoff(key)
+		return
+	}
+
+	slog.Info("refresh: rotation complete", "key", key, "new_expires_at", rotated["expires_at"])
+	m.resetBackoff(key)
+}
+
+// bumpBackoff doubles this enrolment's pending retry delay, capped at
+// maxBackoff. Because tick() runs on a fixed ticker rather than rescheduling
+// against the backoff value, backoff in practice just means "don't retry
+// sooner than the next tick" — the data structure is in place so that
+// longer check intervals (or a future per-enrolment scheduler) can use it.
+func (m *RefreshManager) bumpBackoff(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current := m.backoffs[key]
+	if current == 0 {
+		current = m.checkInterval
+	} else {
+		current *= 2
+	}
+	if current > m.maxBackoff {
+		current = m.maxBackoff
+	}
+	m.backoffs[key] = current
+}
+
+func (m *RefreshManager) resetBackoff(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.backoffs, key)
+}
+
+// stringifyStringMap converts Vault's map[string]any data (where every
+// value is already a string in KVv2 secrets, but typed as `any`) into the
+// string→string map that engines expect. Non-string values are skipped,
+// which matches how findPending treats malformed secrets.
+func stringifyStringMap(data map[string]any) map[string]string {
+	out := make(map[string]string, len(data))
+	for k, v := range data {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// Compile-time check that the JFrog engine implements Refresher so the
+// refresh manager will route it through the rotation path.
+var _ Refresher = (*JFrogEngine)(nil)

--- a/internal/enrol/refresh.go
+++ b/internal/enrol/refresh.go
@@ -195,6 +195,9 @@ func (m *RefreshManager) refreshOne(ctx context.Context, key string, enrolment c
 	}
 	if secret == nil {
 		// No enrolment yet — not our problem; the enrolment wizard handles it.
+		// Clear any stale backoff from a previous attempt (e.g. the secret
+		// was deleted externally while we were in a backoff window).
+		m.resetBackoff(key)
 		return
 	}
 
@@ -226,6 +229,12 @@ func (m *RefreshManager) refreshOne(ctx context.Context, key string, enrolment c
 	issuedAt, err := time.Parse(time.RFC3339, issuedAtStr)
 	if err != nil {
 		slog.Error("refresh: invalid issued_at, skipping", "key", key, "value", issuedAtStr, "error", err)
+		m.bumpBackoff(key)
+		return
+	}
+
+	if !expiresAt.After(issuedAt) {
+		slog.Error("refresh: expires_at is not after issued_at, skipping", "key", key, "issued_at", issuedAtStr, "expires_at", expiresAtStr)
 		m.bumpBackoff(key)
 		return
 	}

--- a/internal/enrol/refresh.go
+++ b/internal/enrol/refresh.go
@@ -27,6 +27,10 @@ func (realClock) Now() time.Time { return time.Now().UTC() }
 // auth.LifecycleManager — one goroutine, stateless between ticks, with
 // per-enrolment exponential backoff so a single flaky provider does not
 // stall the others.
+// defaultRefreshInterval is the fallback cadence if a caller supplies a
+// non-positive checkInterval (which would otherwise panic time.NewTicker).
+const defaultRefreshInterval = time.Minute
+
 type RefreshManager struct {
 	client        *vault.Client
 	kvMount       string
@@ -37,7 +41,16 @@ type RefreshManager struct {
 
 	mu         sync.Mutex
 	enrolments map[string]config.Enrolment
-	backoffs   map[string]time.Duration // per-enrolment backoff state; cleared on success
+	// backoff state per-enrolment. `delay` is the current wait interval
+	// (doubled on each failure, capped at maxBackoff, cleared on success).
+	// `nextAttempt` is the clock time before which tick() skips this
+	// enrolment — this is what actually makes the backoff observable.
+	backoffs map[string]backoffState
+}
+
+type backoffState struct {
+	delay       time.Duration
+	nextAttempt time.Time
 }
 
 // RefreshManagerOption configures a RefreshManager at construction time.
@@ -55,7 +68,9 @@ func WithMaxBackoff(d time.Duration) RefreshManagerOption {
 
 // NewRefreshManager constructs a RefreshManager. userPrefix must already
 // include the username and a trailing slash (e.g. "users/alice/"), matching
-// the convention used by the rest of the daemon.
+// the convention used by the rest of the daemon. A non-positive
+// checkInterval is coerced to defaultRefreshInterval with a WARN log so
+// the ticker cannot panic.
 func NewRefreshManager(
 	client *vault.Client,
 	kvMount, userPrefix string,
@@ -63,6 +78,11 @@ func NewRefreshManager(
 	checkInterval time.Duration,
 	opts ...RefreshManagerOption,
 ) *RefreshManager {
+	if checkInterval <= 0 {
+		slog.Warn("refresh: invalid check_interval, using fallback",
+			"check_interval", checkInterval, "fallback", defaultRefreshInterval)
+		checkInterval = defaultRefreshInterval
+	}
 	m := &RefreshManager{
 		client:        client,
 		kvMount:       kvMount,
@@ -71,7 +91,7 @@ func NewRefreshManager(
 		maxBackoff:    5 * time.Minute,
 		clock:         realClock{},
 		enrolments:    enrolments,
-		backoffs:      make(map[string]time.Duration),
+		backoffs:      make(map[string]backoffState),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -118,7 +138,8 @@ func (m *RefreshManager) run(ctx context.Context) {
 
 // tick iterates all enrolments and triggers a refresh for each Refresher
 // whose token is past half-life. Each enrolment is handled independently;
-// one failure does not block others.
+// one failure does not block others. Enrolments whose previous attempt
+// failed are skipped until their backoff deadline has elapsed.
 func (m *RefreshManager) tick(ctx context.Context) {
 	m.mu.Lock()
 	snapshot := make(map[string]config.Enrolment, len(m.enrolments))
@@ -127,6 +148,7 @@ func (m *RefreshManager) tick(ctx context.Context) {
 	}
 	m.mu.Unlock()
 
+	now := m.clock.Now()
 	for key, enrolment := range snapshot {
 		if ctx.Err() != nil {
 			return
@@ -139,9 +161,25 @@ func (m *RefreshManager) tick(ctx context.Context) {
 		if !ok {
 			continue // engine doesn't rotate; nothing to do
 		}
+		if m.inBackoff(key, now) {
+			// Previous attempt failed; not yet time to retry.
+			continue
+		}
 
 		m.refreshOne(ctx, key, enrolment, refresher)
 	}
+}
+
+// inBackoff reports whether this enrolment is still inside its retry
+// cooldown window as of `now`.
+func (m *RefreshManager) inBackoff(key string, now time.Time) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.backoffs[key]
+	if !ok {
+		return false
+	}
+	return now.Before(s.nextAttempt)
 }
 
 // refreshOne handles a single enrolment: read Vault, check half-life, call
@@ -224,24 +262,25 @@ func (m *RefreshManager) refreshOne(ctx context.Context, key string, enrolment c
 	m.resetBackoff(key)
 }
 
-// bumpBackoff doubles this enrolment's pending retry delay, capped at
-// maxBackoff. Because tick() runs on a fixed ticker rather than rescheduling
-// against the backoff value, backoff in practice just means "don't retry
-// sooner than the next tick" — the data structure is in place so that
-// longer check intervals (or a future per-enrolment scheduler) can use it.
+// bumpBackoff records a failure for this enrolment and sets the next
+// allowed attempt time. Delay doubles on each consecutive failure,
+// capped at maxBackoff, and starts at checkInterval (so a transient
+// failure costs at least one tick before the next attempt). The
+// nextAttempt timestamp is the actual gate consulted by tick().
 func (m *RefreshManager) bumpBackoff(key string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	current := m.backoffs[key]
-	if current == 0 {
-		current = m.checkInterval
+	s := m.backoffs[key]
+	if s.delay == 0 {
+		s.delay = m.checkInterval
 	} else {
-		current *= 2
+		s.delay *= 2
 	}
-	if current > m.maxBackoff {
-		current = m.maxBackoff
+	if s.delay > m.maxBackoff {
+		s.delay = m.maxBackoff
 	}
-	m.backoffs[key] = current
+	s.nextAttempt = m.clock.Now().Add(s.delay)
+	m.backoffs[key] = s
 }
 
 func (m *RefreshManager) resetBackoff(key string) {

--- a/internal/enrol/refresh.go
+++ b/internal/enrol/refresh.go
@@ -237,9 +237,16 @@ func (m *RefreshManager) refreshOne(ctx context.Context, key string, enrolment c
 		if errors.Is(err, ErrRevoked) {
 			slog.Warn("refresh: upstream credential revoked, wiping vault secret so user can re-enrol", "key", key, "error", err)
 			if delErr := m.client.DeleteKVv2(ctx, m.kvMount, path); delErr != nil {
-				slog.Error("refresh: failed to delete revoked secret", "key", key, "error", delErr)
+				// Treat Vault cleanup failure as transient: keep backoff
+				// so we retry the delete on a later tick instead of
+				// re-calling Refresh against a known-revoked credential
+				// every cycle.
+				slog.Error("refresh: failed to delete revoked secret, will retry", "key", key, "error", delErr)
+				m.bumpBackoff(key)
+				return
 			}
-			// No backoff on revocation — the state is terminal until re-enrol.
+			// No backoff once the revoked secret has been wiped — the
+			// state is terminal until the user re-enrols.
 			m.resetBackoff(key)
 			return
 		}

--- a/internal/enrol/refresh.go
+++ b/internal/enrol/refresh.go
@@ -209,18 +209,24 @@ func (m *RefreshManager) refreshOne(ctx context.Context, key string, enrolment c
 	}
 	issuedAtStr := existing["issued_at"]
 	if issuedAtStr == "" {
+		// Bump backoff so a malformed secret doesn't re-log this ERROR
+		// every tick — the state is only fixable by re-enrolment or a
+		// manual Vault edit, and in both cases polling harder doesn't help.
 		slog.Error("refresh: secret has expires_at but no issued_at, skipping", "key", key)
+		m.bumpBackoff(key)
 		return
 	}
 
 	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
 	if err != nil {
 		slog.Error("refresh: invalid expires_at, skipping", "key", key, "value", expiresAtStr, "error", err)
+		m.bumpBackoff(key)
 		return
 	}
 	issuedAt, err := time.Parse(time.RFC3339, issuedAtStr)
 	if err != nil {
 		slog.Error("refresh: invalid issued_at, skipping", "key", key, "value", issuedAtStr, "error", err)
+		m.bumpBackoff(key)
 		return
 	}
 

--- a/internal/enrol/refresh_test.go
+++ b/internal/enrol/refresh_test.go
@@ -1,0 +1,543 @@
+package enrol
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goodtune/dotvault/internal/config"
+	"github.com/goodtune/dotvault/internal/vault"
+)
+
+// fakeRefresher is a Refresher test double whose Refresh implementation
+// is controlled per-call via a channel of responses.
+type fakeRefresher struct {
+	name   string
+	fields []string
+
+	mu       sync.Mutex
+	calls    []fakeRefresherCall
+	response func(call fakeRefresherCall) (map[string]string, error)
+}
+
+type fakeRefresherCall struct {
+	Settings map[string]any
+	Existing map[string]string
+}
+
+func (f *fakeRefresher) Name() string     { return f.name }
+func (f *fakeRefresher) Fields() []string { return f.fields }
+func (f *fakeRefresher) Run(ctx context.Context, settings map[string]any, io IO) (map[string]string, error) {
+	return nil, errors.New("fakeRefresher.Run should not be called in these tests")
+}
+func (f *fakeRefresher) Refresh(ctx context.Context, settings map[string]any, existing map[string]string) (map[string]string, error) {
+	f.mu.Lock()
+	call := fakeRefresherCall{Settings: settings, Existing: copyMap(existing)}
+	f.calls = append(f.calls, call)
+	resp := f.response
+	f.mu.Unlock()
+	if resp == nil {
+		return nil, errors.New("fakeRefresher has no response configured")
+	}
+	return resp(call)
+}
+
+func (f *fakeRefresher) Calls() []fakeRefresherCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeRefresherCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func copyMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// fakeVault is a minimal stand-in for Vault's KV-v2 HTTP API. It stores
+// secrets in-memory keyed by the KV mount path and supports read, write,
+// and delete-metadata operations, which is everything the RefreshManager
+// exercises.
+type fakeVault struct {
+	mu      sync.Mutex
+	mount   string                          // e.g. "kv"
+	secrets map[string]map[string]string    // path -> data
+	writes  []fakeVaultWrite
+	deletes []string
+}
+
+type fakeVaultWrite struct {
+	Path string
+	Data map[string]string
+}
+
+func newFakeVault(mount string) *fakeVault {
+	return &fakeVault{mount: mount, secrets: map[string]map[string]string{}}
+}
+
+// serve returns an httptest.Server speaking a KVv2 subset for this fake.
+func (fv *fakeVault) serve(t *testing.T) *vault.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(fv.handle))
+	t.Cleanup(srv.Close)
+	vc, err := vault.NewClient(vault.Config{Address: srv.URL})
+	if err != nil {
+		t.Fatalf("vault.NewClient: %v", err)
+	}
+	vc.SetToken("root") // token value is irrelevant for the fake
+	return vc
+}
+
+func (fv *fakeVault) handle(w http.ResponseWriter, r *http.Request) {
+	// KVv2 data path: /v1/<mount>/data/<path>
+	// KVv2 metadata path: /v1/<mount>/metadata/<path>
+	dataPrefix := "/v1/" + fv.mount + "/data/"
+	metaPrefix := "/v1/" + fv.mount + "/metadata/"
+
+	switch {
+	case strings.HasPrefix(r.URL.Path, dataPrefix):
+		path := strings.TrimPrefix(r.URL.Path, dataPrefix)
+		switch r.Method {
+		case http.MethodGet:
+			fv.mu.Lock()
+			data, ok := fv.secrets[path]
+			fv.mu.Unlock()
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			body, _ := json.Marshal(map[string]any{
+				"data": map[string]any{
+					"data":     stringMapToAny(data),
+					"metadata": map[string]any{"version": 1},
+				},
+			})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		case http.MethodPost, http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Data map[string]any `json:"data"`
+			}
+			if err := json.Unmarshal(body, &req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			data := make(map[string]string, len(req.Data))
+			for k, v := range req.Data {
+				if s, ok := v.(string); ok {
+					data[k] = s
+				}
+			}
+			fv.mu.Lock()
+			fv.secrets[path] = data
+			fv.writes = append(fv.writes, fakeVaultWrite{Path: path, Data: copyMap(data)})
+			fv.mu.Unlock()
+			_, _ = w.Write([]byte(`{"data":{"version":1}}`))
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case strings.HasPrefix(r.URL.Path, metaPrefix):
+		path := strings.TrimPrefix(r.URL.Path, metaPrefix)
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		fv.mu.Lock()
+		delete(fv.secrets, path)
+		fv.deletes = append(fv.deletes, path)
+		fv.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func stringMapToAny(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func (fv *fakeVault) seed(path string, data map[string]string) {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+	fv.secrets[path] = copyMap(data)
+}
+
+func (fv *fakeVault) secret(path string) map[string]string {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+	if s, ok := fv.secrets[path]; ok {
+		return copyMap(s)
+	}
+	return nil
+}
+
+func (fv *fakeVault) deleted() []string {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+	out := make([]string, len(fv.deletes))
+	copy(out, fv.deletes)
+	return out
+}
+
+// fixedClock is a deterministic Clock that returns a pinned time.
+type fixedClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fixedClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fixedClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// registerFake installs a fakeRefresher in the engine registry under the
+// given engine name and arranges for teardown when the test finishes.
+func registerFake(t *testing.T, engineName string, f *fakeRefresher) {
+	t.Helper()
+	RegisterEngine(engineName, f)
+	t.Cleanup(func() { UnregisterEngine(engineName) })
+}
+
+// ---------- tick(): happy / skip paths ----------
+
+func TestRefreshManager_SkipsWhenNoExpiresAt(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	// Legacy secret: no expires_at / issued_at fields at all.
+	fv.seed("users/alice/legacy", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+	})
+
+	fake := &fakeRefresher{name: "legacy-engine", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) {
+		return nil, errors.New("should not be called for legacy secrets")
+	}
+	registerFake(t, "legacy-engine", fake)
+
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"legacy": {Engine: "legacy-engine"},
+	}, time.Hour,
+		WithClock(&fixedClock{now: issued.Add(48 * time.Hour)}),
+	)
+	m.tick(context.Background())
+
+	if got := len(fake.Calls()); got != 0 {
+		t.Errorf("fake.Calls() = %d, want 0 (legacy secrets must be skipped)", got)
+	}
+}
+
+func TestRefreshManager_SkipsBeforeHalfLife(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) {
+		return nil, errors.New("should not be called before half-life")
+	}
+	registerFake(t, "jfrog-fake", fake)
+
+	// Now is 1h in — well before the 3h half-life.
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, time.Hour,
+		WithClock(&fixedClock{now: issued.Add(1 * time.Hour)}),
+	)
+	m.tick(context.Background())
+
+	if got := len(fake.Calls()); got != 0 {
+		t.Errorf("fake.Calls() = %d, want 0 (pre-half-life must be skipped)", got)
+	}
+}
+
+func TestRefreshManager_RotatesPastHalfLife(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "old-a",
+		"refresh_token": "old-r",
+		"url":           "http://jf",
+		"server_id":     "jf",
+		"user":          "alice",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	newIssued := issued.Add(4 * time.Hour)
+	newExpires := newIssued.Add(6 * time.Hour)
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(call fakeRefresherCall) (map[string]string, error) {
+		if call.Existing["access_token"] != "old-a" {
+			return nil, errors.New("engine saw wrong access_token")
+		}
+		if call.Existing["refresh_token"] != "old-r" {
+			return nil, errors.New("engine saw wrong refresh_token")
+		}
+		return map[string]string{
+			"access_token":  "new-a",
+			"refresh_token": "new-r",
+			"url":           "http://jf",
+			"server_id":     "jf",
+			"user":          "alice",
+			"issued_at":     newIssued.Format(time.RFC3339),
+			"expires_at":    newExpires.Format(time.RFC3339),
+		}, nil
+	}
+	registerFake(t, "jfrog-fake", fake)
+
+	// Now is 4h in — past the 3h half-life.
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, time.Hour,
+		WithClock(&fixedClock{now: newIssued}),
+	)
+	m.tick(context.Background())
+
+	calls := fake.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("fake.Calls() = %d, want 1", len(calls))
+	}
+
+	got := fv.secret("users/alice/jfrog")
+	if got["access_token"] != "new-a" {
+		t.Errorf("vault access_token = %q, want new-a", got["access_token"])
+	}
+	if got["refresh_token"] != "new-r" {
+		t.Errorf("vault refresh_token = %q, want new-r", got["refresh_token"])
+	}
+	if got["issued_at"] != newIssued.Format(time.RFC3339) {
+		t.Errorf("vault issued_at = %q, want %q", got["issued_at"], newIssued.Format(time.RFC3339))
+	}
+}
+
+func TestRefreshManager_ErrRevokedWipesSecret(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) { return nil, ErrRevoked }
+	registerFake(t, "jfrog-fake", fake)
+
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, time.Hour,
+		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+	)
+	m.tick(context.Background())
+
+	if got := fv.secret("users/alice/jfrog"); got != nil {
+		t.Errorf("secret still present after ErrRevoked: %v", got)
+	}
+	deleted := fv.deleted()
+	if len(deleted) != 1 || deleted[0] != "users/alice/jfrog" {
+		t.Errorf("deleted = %v, want [users/alice/jfrog]", deleted)
+	}
+}
+
+func TestRefreshManager_TransientErrorKeepsSecret(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) {
+		return nil, errors.New("network is down")
+	}
+	registerFake(t, "jfrog-fake", fake)
+
+	// Use a small checkInterval relative to maxBackoff so we can verify
+	// both the initial seed and the doubling step before saturation.
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, 10*time.Second,
+		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+		WithMaxBackoff(10*time.Minute),
+	)
+	m.tick(context.Background())
+
+	got := fv.secret("users/alice/jfrog")
+	if got == nil || got["access_token"] != "a" {
+		t.Errorf("secret should be untouched after transient error, got %v", got)
+	}
+
+	// Backoff state should have been bumped to checkInterval on first failure.
+	m.mu.Lock()
+	b := m.backoffs["jfrog"]
+	m.mu.Unlock()
+	if b != 10*time.Second {
+		t.Errorf("backoff after first failure = %v, want %v (checkInterval)", b, 10*time.Second)
+	}
+
+	// A second failure should double it.
+	m.tick(context.Background())
+	m.mu.Lock()
+	b2 := m.backoffs["jfrog"]
+	m.mu.Unlock()
+	if b2 != 20*time.Second {
+		t.Errorf("backoff after second failure = %v, want 20s (doubled)", b2)
+	}
+}
+
+func TestRefreshManager_BackoffCappedAtMax(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) {
+		return nil, errors.New("still down")
+	}
+	registerFake(t, "jfrog-fake", fake)
+
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, 30*time.Second,
+		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+		WithMaxBackoff(2*time.Minute),
+	)
+
+	// Hammer it; backoff should saturate at 2m.
+	for i := 0; i < 10; i++ {
+		m.tick(context.Background())
+	}
+	m.mu.Lock()
+	b := m.backoffs["jfrog"]
+	m.mu.Unlock()
+	if b != 2*time.Minute {
+		t.Errorf("saturated backoff = %v, want 2m", b)
+	}
+}
+
+func TestRefreshManager_SuccessResetsBackoff(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	callCount := 0
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) {
+		callCount++
+		if callCount == 1 {
+			return nil, errors.New("first call fails")
+		}
+		// Second call succeeds. Issue a brand new token pair.
+		n := issued.Add(4 * time.Hour)
+		return map[string]string{
+			"access_token":  "new",
+			"refresh_token": "new-r",
+			"url":           "http://jf",
+			"server_id":     "jf",
+			"user":          "alice",
+			"issued_at":     n.Format(time.RFC3339),
+			"expires_at":    n.Add(6 * time.Hour).Format(time.RFC3339),
+		}, nil
+	}
+	registerFake(t, "jfrog-fake", fake)
+
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, time.Hour,
+		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+	)
+	m.tick(context.Background())
+	m.mu.Lock()
+	first := m.backoffs["jfrog"]
+	m.mu.Unlock()
+	if first == 0 {
+		t.Fatal("backoff should be non-zero after failure")
+	}
+	m.tick(context.Background())
+	m.mu.Lock()
+	_, stillInBackoffs := m.backoffs["jfrog"]
+	m.mu.Unlock()
+	if stillInBackoffs {
+		t.Error("backoff entry should be cleared after a successful rotation")
+	}
+}
+
+func TestRefreshManager_NonRefresherEngineIgnored(t *testing.T) {
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+	fv.seed("users/alice/ssh", map[string]string{
+		"private_key": "blob",
+	})
+
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		// ssh is a real engine but does not implement Refresher.
+		"ssh": {Engine: "ssh"},
+	}, time.Hour,
+		WithClock(&fixedClock{now: time.Now()}),
+	)
+	// Should not panic or error; simply a no-op.
+	m.tick(context.Background())
+}

--- a/internal/enrol/refresh_test.go
+++ b/internal/enrol/refresh_test.go
@@ -71,10 +71,14 @@ func copyMap(in map[string]string) map[string]string {
 // exercises.
 type fakeVault struct {
 	mu      sync.Mutex
-	mount   string                          // e.g. "kv"
-	secrets map[string]map[string]string    // path -> data
+	mount   string                       // e.g. "kv"
+	secrets map[string]map[string]string // path -> data
 	writes  []fakeVaultWrite
 	deletes []string
+	// When non-zero, DELETE on the metadata endpoint returns this status
+	// code and leaves the secret in place. Used to exercise the
+	// refresh-manager's revocation-cleanup-failure path.
+	deleteStatus int
 }
 
 type fakeVaultWrite struct {
@@ -152,6 +156,13 @@ func (fv *fakeVault) handle(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, metaPrefix)
 		if r.Method != http.MethodDelete {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		fv.mu.Lock()
+		status := fv.deleteStatus
+		fv.mu.Unlock()
+		if status != 0 {
+			http.Error(w, "delete refused by fake", status)
 			return
 		}
 		fv.mu.Lock()
@@ -377,6 +388,54 @@ func TestRefreshManager_ErrRevokedWipesSecret(t *testing.T) {
 	deleted := fv.deleted()
 	if len(deleted) != 1 || deleted[0] != "users/alice/jfrog" {
 		t.Errorf("deleted = %v, want [users/alice/jfrog]", deleted)
+	}
+}
+
+func TestRefreshManager_ErrRevokedDeleteFailureBumpsBackoff(t *testing.T) {
+	// If the Vault cleanup for a revoked credential fails, the manager
+	// must NOT clear backoff — otherwise the next tick re-calls Refresh
+	// against a known-revoked token every cycle.
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+	fv.deleteStatus = http.StatusInternalServerError
+
+	issued := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	expires := issued.Add(6 * time.Hour)
+	fv.seed("users/alice/jfrog", map[string]string{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"issued_at":     issued.Format(time.RFC3339),
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+
+	fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+	fake.response = func(fakeRefresherCall) (map[string]string, error) { return nil, ErrRevoked }
+	registerFake(t, "jfrog-fake", fake)
+
+	clk := &fixedClock{now: issued.Add(4 * time.Hour)}
+	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+		"jfrog": {Engine: "jfrog-fake"},
+	}, 10*time.Second,
+		WithClock(clk),
+	)
+	m.tick(context.Background())
+
+	// Secret must still be present (delete failed).
+	if got := fv.secret("users/alice/jfrog"); got == nil {
+		t.Fatal("secret unexpectedly gone after failed delete")
+	}
+	// Backoff must be set so the next tick within the window skips Refresh.
+	m.mu.Lock()
+	b := m.backoffs["jfrog"]
+	m.mu.Unlock()
+	if b.delay == 0 {
+		t.Errorf("backoff delay should be set after failed delete, got %v", b)
+	}
+	callsBefore := len(fake.Calls())
+	m.tick(context.Background())
+	if len(fake.Calls()) != callsBefore {
+		t.Errorf("Refresh called %d additional times within backoff window, want 0",
+			len(fake.Calls())-callsBefore)
 	}
 }
 

--- a/internal/enrol/refresh_test.go
+++ b/internal/enrol/refresh_test.go
@@ -391,6 +391,72 @@ func TestRefreshManager_ErrRevokedWipesSecret(t *testing.T) {
 	}
 }
 
+func TestRefreshManager_MalformedSecretBumpsBackoff(t *testing.T) {
+	// A secret that has expires_at but is otherwise malformed (missing
+	// issued_at, unparseable RFC3339, etc.) must bump backoff so the ERROR
+	// doesn't re-log every tick.
+	cases := []struct {
+		name string
+		data map[string]string
+	}{
+		{
+			name: "MissingIssuedAt",
+			data: map[string]string{
+				"access_token":  "a",
+				"refresh_token": "r",
+				"expires_at":    "2026-04-17T12:00:00Z",
+				// issued_at absent
+			},
+		},
+		{
+			name: "BadExpiresAt",
+			data: map[string]string{
+				"access_token":  "a",
+				"refresh_token": "r",
+				"issued_at":     "2026-04-17T00:00:00Z",
+				"expires_at":    "not-an-rfc3339-timestamp",
+			},
+		},
+		{
+			name: "BadIssuedAt",
+			data: map[string]string{
+				"access_token":  "a",
+				"refresh_token": "r",
+				"issued_at":     "not-an-rfc3339-timestamp",
+				"expires_at":    "2026-04-17T12:00:00Z",
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fv := newFakeVault("kv")
+			vc := fv.serve(t)
+			fv.seed("users/alice/jfrog", tc.data)
+
+			fake := &fakeRefresher{name: "jfrog", fields: []string{"access_token"}}
+			fake.response = func(fakeRefresherCall) (map[string]string, error) {
+				return nil, errors.New("should not be called for malformed secret")
+			}
+			registerFake(t, "jfrog-fake", fake)
+
+			m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
+				"jfrog": {Engine: "jfrog-fake"},
+			}, 10*time.Second,
+				WithClock(&fixedClock{now: time.Date(2026, 4, 17, 10, 0, 0, 0, time.UTC)}),
+			)
+			m.tick(context.Background())
+
+			m.mu.Lock()
+			b := m.backoffs["jfrog"]
+			m.mu.Unlock()
+			if b.delay == 0 {
+				t.Errorf("backoff delay should be set after malformed-secret skip, got %v", b)
+			}
+		})
+	}
+}
+
 func TestRefreshManager_ErrRevokedDeleteFailureBumpsBackoff(t *testing.T) {
 	// If the Vault cleanup for a revoked credential fails, the manager
 	// must NOT clear backoff — otherwise the next tick re-calls Refresh

--- a/internal/enrol/refresh_test.go
+++ b/internal/enrol/refresh_test.go
@@ -401,10 +401,11 @@ func TestRefreshManager_TransientErrorKeepsSecret(t *testing.T) {
 
 	// Use a small checkInterval relative to maxBackoff so we can verify
 	// both the initial seed and the doubling step before saturation.
+	clk := &fixedClock{now: issued.Add(4 * time.Hour)}
 	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
 		"jfrog": {Engine: "jfrog-fake"},
 	}, 10*time.Second,
-		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+		WithClock(clk),
 		WithMaxBackoff(10*time.Minute),
 	)
 	m.tick(context.Background())
@@ -418,17 +419,30 @@ func TestRefreshManager_TransientErrorKeepsSecret(t *testing.T) {
 	m.mu.Lock()
 	b := m.backoffs["jfrog"]
 	m.mu.Unlock()
-	if b != 10*time.Second {
-		t.Errorf("backoff after first failure = %v, want %v (checkInterval)", b, 10*time.Second)
+	if b.delay != 10*time.Second {
+		t.Errorf("backoff delay after first failure = %v, want %v (checkInterval)", b.delay, 10*time.Second)
+	}
+	wantDeadline := clk.Now().Add(10 * time.Second)
+	if !b.nextAttempt.Equal(wantDeadline) {
+		t.Errorf("nextAttempt after first failure = %v, want %v", b.nextAttempt, wantDeadline)
 	}
 
-	// A second failure should double it.
+	// A tick *inside* the backoff window must not call Refresh again.
+	callsBefore := len(fake.Calls())
+	m.tick(context.Background())
+	if len(fake.Calls()) != callsBefore {
+		t.Errorf("Refresh called %d times within backoff window, want 0 additional calls",
+			len(fake.Calls())-callsBefore)
+	}
+
+	// Advance past the deadline; next tick should bump delay from 10s to 20s.
+	clk.Advance(11 * time.Second)
 	m.tick(context.Background())
 	m.mu.Lock()
 	b2 := m.backoffs["jfrog"]
 	m.mu.Unlock()
-	if b2 != 20*time.Second {
-		t.Errorf("backoff after second failure = %v, want 20s (doubled)", b2)
+	if b2.delay != 20*time.Second {
+		t.Errorf("backoff delay after second failure = %v, want 20s (doubled)", b2.delay)
 	}
 }
 
@@ -451,22 +465,27 @@ func TestRefreshManager_BackoffCappedAtMax(t *testing.T) {
 	}
 	registerFake(t, "jfrog-fake", fake)
 
+	clk := &fixedClock{now: issued.Add(4 * time.Hour)}
 	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
 		"jfrog": {Engine: "jfrog-fake"},
 	}, 30*time.Second,
-		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+		WithClock(clk),
 		WithMaxBackoff(2*time.Minute),
 	)
 
-	// Hammer it; backoff should saturate at 2m.
+	// Advance time past the current backoff window each iteration so the
+	// rotation actually runs; otherwise the backoff gate would skip it.
+	// Delay sequence: 30s → 60s → 120s (cap). A big enough jump forces
+	// saturation regardless of the exact doubling count.
 	for i := 0; i < 10; i++ {
 		m.tick(context.Background())
+		clk.Advance(5 * time.Minute)
 	}
 	m.mu.Lock()
 	b := m.backoffs["jfrog"]
 	m.mu.Unlock()
-	if b != 2*time.Minute {
-		t.Errorf("saturated backoff = %v, want 2m", b)
+	if b.delay != 2*time.Minute {
+		t.Errorf("saturated backoff delay = %v, want 2m", b.delay)
 	}
 }
 
@@ -504,24 +523,42 @@ func TestRefreshManager_SuccessResetsBackoff(t *testing.T) {
 	}
 	registerFake(t, "jfrog-fake", fake)
 
+	clk := &fixedClock{now: issued.Add(4 * time.Hour)}
 	m := NewRefreshManager(vc, "kv", "users/alice/", map[string]config.Enrolment{
 		"jfrog": {Engine: "jfrog-fake"},
-	}, time.Hour,
-		WithClock(&fixedClock{now: issued.Add(4 * time.Hour)}),
+	}, 10*time.Second,
+		WithClock(clk),
 	)
 	m.tick(context.Background())
 	m.mu.Lock()
 	first := m.backoffs["jfrog"]
 	m.mu.Unlock()
-	if first == 0 {
-		t.Fatal("backoff should be non-zero after failure")
+	if first.delay == 0 {
+		t.Fatal("backoff delay should be non-zero after failure")
 	}
+	// Advance past the backoff deadline so the next tick actually runs.
+	clk.Advance(11 * time.Second)
 	m.tick(context.Background())
 	m.mu.Lock()
 	_, stillInBackoffs := m.backoffs["jfrog"]
 	m.mu.Unlock()
 	if stillInBackoffs {
 		t.Error("backoff entry should be cleared after a successful rotation")
+	}
+}
+
+func TestNewRefreshManager_InvalidCheckInterval(t *testing.T) {
+	// A non-positive checkInterval must be coerced to the fallback so
+	// Start's time.NewTicker doesn't panic. Construct with zero and with
+	// a negative duration; both should yield a usable manager.
+	fv := newFakeVault("kv")
+	vc := fv.serve(t)
+	for _, d := range []time.Duration{0, -time.Second} {
+		m := NewRefreshManager(vc, "kv", "users/alice/", nil, d)
+		if m.checkInterval != defaultRefreshInterval {
+			t.Errorf("NewRefreshManager(checkInterval=%v) kept it as-is; want coerced to %v",
+				d, defaultRefreshInterval)
+		}
 	}
 }
 

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -154,6 +154,21 @@ func (c *Client) WriteKVv2(ctx context.Context, mount, path string, data map[str
 	return nil
 }
 
+// DeleteKVv2 deletes all versions of a KVv2 secret (the full metadata
+// record, not just a soft-delete of the latest version). Used by the
+// refresh manager when the upstream credential has been permanently
+// revoked and the local state needs to be wiped so the user can re-enrol.
+func (c *Client) DeleteKVv2(ctx context.Context, mount, path string) error {
+	if err := c.raw.KVv2(mount).DeleteMetadata(ctx, path); err != nil {
+		// A not-found metadata entry is fine (race with another cleanup).
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete kv %s/%s: %w", mount, path, err)
+	}
+	return nil
+}
+
 // LookupSelf returns the current token's metadata, or an error if invalid.
 func (c *Client) LookupSelf(ctx context.Context) (*vaultapi.Secret, error) {
 	secret, err := c.raw.Auth().Token().LookupSelfWithContext(ctx)


### PR DESCRIPTION
## Summary

This PR lands three connected pieces of work:

### 1. JFrog enrolment engine

- New `JFrogEngine` in `internal/enrol/jfrog.go` mirrors the `jf login` browser-based web login flow from `jfrog-cli` — POSTs a UUID session to the Access service, opens the platform UI with `jfClientSession` / `jfClientName` / `jfClientCode` query params, then polls for the token
- Deduces `server_id` from the platform hostname (prefix before the first `.`, or `default-server` for IP addresses) and extracts `user` from the access-token JWT subject
- Defaults (`client_name=JFrog-CLI`, `client_code=1`) mirror the upstream `jfrog-cli-core` constants; the platform URL is required since no universal default exists
- Requires JFrog Artifactory 7.64.0+ on the remote side

### 2. dotvault owns the JFrog token lifecycle

After enrolment, dotvault immediately exchanges the web-login bootstrap token for a **refreshable, dotvault-owned token** with a configurable, shorter-than-default TTL, then periodically rotates it before expiry. This resolves a correctness hazard in the original approach: JFrog rotates `refresh_token` on every successful refresh, so letting `jf` own refresh would race the sync engine's file clobber and invalidate itself.

- New `Refresher` sub-interface and `ErrRevoked` sentinel in `internal/enrol/engine.go` — engines that rotate their own credentials implement it; others are silently skipped
- New `RefreshManager` (`internal/enrol/refresh.go`), modelled on `auth.LifecycleManager`: ticks every 5 minutes, iterates Refresher-capable enrolments, skips ones before half-life, calls `Refresh`, writes the new secret back to Vault. Per-enrolment exponential backoff (capped at 5 min) so one flaky provider doesn't stall others. `Clock` interface injected for deterministic unit tests
- `JFrogEngine.Refresh` POSTs `grant_type=refresh_token` to `/access/api/v1/tokens`; 401/403 → `ErrRevoked` → manager calls `DeleteKVv2` so the web UI surfaces a fresh enrolment card
- New Vault schema (7 fields): `access_token`, `refresh_token`, `url`, `server_id`, `user`, `issued_at` (RFC3339), `expires_at` (RFC3339). Drops `token_type`/`expires_in`/`scope` — redundant or informational
- New `token_ttl` enrolment setting: default `60d`, dev stack `6h`. `config.ParseDuration` adds `Nd` support on top of `time.ParseDuration`; 10-minute floor validated at config-load time
- Rendered `jfrog-cli.conf.v6` now contains only `accessToken` — `refreshToken` and `webLogin: true` removed so `jf` never attempts its own refresh
- `vault.Client.DeleteKVv2` added for the revocation path

### 3. Opt-in local Artifactory dev stack

- Three new services in `docker-compose.yaml` under `profiles: [\"jfrog\"]` so plain `docker compose up -d` is unaffected:
  - `artifactory` (Artifactory JCR 7.98.9, port 8082)
  - `artifactory-db` (Postgres 16 — Artifactory 7.78+ dropped the embedded Derby DB, so Postgres is required even for single-node dev)
  - Master/join keys pinned to dev fixtures because Artifactory's auto-generation is unreliable on Docker Desktop volumes
- `config.dev.yaml` points `enrolments.jfrog.settings.url` at `http://127.0.0.1:8082`, sets `token_ttl: 6h`, and renders the minimal `jfrog-cli.conf.v6` template

## Test plan

- [x] `go test ./internal/enrol/` — covers engine name/fields/registration, `deduceJFrogServerID` (hostnames, IPv4, IPv6), `ensureScheme`, UUIDv4 format, JWT subject extraction, full enrolment flow (including the new mint-on-enrol step with TTL assertion), request-endpoint failure, poll timeout, `Refresh` happy path, non-JWT token preserves existing user, 401/403 → `ErrRevoked`, 500/malformed-JSON stays transient, missing existing fields, `RefreshManager` skips legacy (no `expires_at`), skips pre-half-life, rotates past half-life, revocation wipes secret, transient error keeps secret + bumps backoff, backoff saturates at cap, success resets backoff, non-Refresher engines ignored
- [x] `go test ./internal/config/` — `ParseDuration` cases (60d, 6h, 1d, 1h30m, 45s, -5d, 1.5d, bogus, \"\"), `token_ttl` validation (floor, happy path, unparseable)
- [x] `go build ./...` + `go vet ./...` — clean
- [x] Live E2E verified against the new local Artifactory JCR + Postgres stack: dotvault → Start JFrog enrolment → captured 4-char confirmation code → signed in to Artifactory at `admin`/`password` → entered the code on the Verify Extension screen → dotvault polled the token endpoint, minted a dotvault-owned token pair, sync rule rendered a valid `jfrog-cli.conf.v6` at mode 0600, and the minted JWT was accepted by `GET /artifactory/api/repositories`
- [ ] Live refresh verification (requires letting the 6 h dev-stack token age past its 3 h half-life, or temporarily setting `token_ttl: 10m` in a local-only branch) — manual