### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /internal/web/frontend
+    schedule:
+      interval: weekly
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,3 +311,13 @@ All pure Go. No CGO dependencies.
 - **Integration tests** in `test/integration/` against a real Vault dev server (via docker-compose)
 - Engine interface allows mock injection for enrolment tests without real OAuth providers
 - `go test ./...` runs all unit tests; integration tests require the docker-compose environment
+
+## Dependency Updates
+
+Dependabot is configured in `.github/dependabot.yml` and currently covers:
+
+- `gomod` at repo root
+- `npm` at `internal/web/frontend`
+- `github-actions` at repo root
+
+When introducing a new package ecosystem (e.g. a second npm workspace, a Dockerfile, a Python tool directory), extend `.github/dependabot.yml` with a matching `updates:` entry so the new manifests are kept up to date. Use the same weekly schedule and grouped-updates pattern as the existing entries unless there is a reason to diverge.


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly grouped updates for `gomod` (repo root), `npm` (`internal/web/frontend`), and `github-actions`.
- Documents the configured ecosystems in `CLAUDE.md` and instructs future contributors to extend `.github/dependabot.yml` whenever a new package ecosystem is introduced.

## Test plan

- [ ] Confirm Dependabot picks up the new configuration and opens grouped PRs on the next scheduled run.