### PR TITLE
feat(auth): add disable_token_renewal config option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\dotva
 
 ### Config Sections
 
-- **`vault`** — address (required), auth_method, auth_mount, auth_role, kv_mount (default `"kv"`), user_prefix (default `"users/"`, trailing slash enforced), ca_cert, tls_skip_verify
+- **`vault`** — address (required), auth_method, auth_mount, auth_role, kv_mount (default `"kv"`), user_prefix (default `"users/"`, trailing slash enforced), ca_cert, tls_skip_verify, disable_token_renewal (default false — set true to prevent the daemon from calling RenewSelf; TTL expiry still triggers re-auth)
 - **`sync`** — interval as Go duration string (default `15m`)
 - **`web`** — enabled (default false), listen (loopback only, hard invariant), login_text (markdown), secret_view_text (markdown)
 - **`rules`** — array of sync rules (name, vault_key, target.path, target.format, target.template, target.merge)

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -241,7 +241,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	}
 
 	// Start token lifecycle manager.
-	lm := auth.NewLifecycleManager(vc, 5*time.Minute)
+	lm := auth.NewLifecycleManager(vc, 5*time.Minute, cfg.Vault.DisableTokenRenewal)
 	lifecycleErrCh := lm.Start(ctx)
 
 	// Start refresh manager for any enrolment whose engine rotates its own

--- a/internal/auth/lifecycle.go
+++ b/internal/auth/lifecycle.go
@@ -12,22 +12,26 @@ import (
 
 // LifecycleManager manages token TTL checks and renewal.
 type LifecycleManager struct {
-	client        *vault.Client
-	checkInterval time.Duration
-	needsReauth   atomic.Bool
+	client         *vault.Client
+	checkInterval  time.Duration
+	disableRenewal bool
+	needsReauth    atomic.Bool
 
 	// Exponential backoff state for check failures.
 	currentDelay time.Duration
 	maxDelay     time.Duration
 }
 
-// NewLifecycleManager creates a new token lifecycle manager.
-func NewLifecycleManager(client *vault.Client, checkInterval time.Duration) *LifecycleManager {
+// NewLifecycleManager creates a new token lifecycle manager. When
+// disableRenewal is true the manager still monitors TTL and signals re-auth
+// when the token expires, but never calls RenewSelf.
+func NewLifecycleManager(client *vault.Client, checkInterval time.Duration, disableRenewal bool) *LifecycleManager {
 	return &LifecycleManager{
-		client:        client,
-		checkInterval: checkInterval,
-		currentDelay:  checkInterval,
-		maxDelay:      5 * time.Minute,
+		client:         client,
+		checkInterval:  checkInterval,
+		disableRenewal: disableRenewal,
+		currentDelay:   checkInterval,
+		maxDelay:       5 * time.Minute,
 	}
 }
 
@@ -121,9 +125,9 @@ func (lm *LifecycleManager) checkAndRenew(ctx context.Context) error {
 	renewableRaw, _ := secret.Data["renewable"]
 	renewable, _ := renewableRaw.(bool)
 
-	// Renew at 75% of TTL (i.e., when only 25% remains)
+	// Renew at 75% of TTL (i.e., when only 25% remains), unless renewal is disabled.
 	renewThreshold := ttl / 4
-	if ttl <= renewThreshold && renewable {
+	if ttl <= renewThreshold && renewable && !lm.disableRenewal {
 		slog.Info("renewing token", "ttl_remaining", ttl)
 		_, err := lm.client.RenewSelf(ctx, 0)
 		if err != nil {

--- a/internal/auth/lifecycle_test.go
+++ b/internal/auth/lifecycle_test.go
@@ -17,7 +17,7 @@ func TestLifecycleManager_Start(t *testing.T) {
 	vc := mustVaultClient(t)
 	vc.SetToken("dev-root-token")
 
-	lm := NewLifecycleManager(vc, 1*time.Second)
+	lm := NewLifecycleManager(vc, 1*time.Second, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
@@ -41,7 +41,7 @@ func TestLifecycleManager_NeedsReauth(t *testing.T) {
 	vc := mustVaultClient(t)
 	vc.SetToken("dev-root-token")
 
-	lm := NewLifecycleManager(vc, 1*time.Second)
+	lm := NewLifecycleManager(vc, 1*time.Second, false)
 
 	// With a valid root token, should not need reauth
 	if lm.NeedsReauth() {
@@ -68,7 +68,7 @@ func TestLifecycleManager_403TriggersReauth(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	lm := NewLifecycleManager(vc, 50*time.Millisecond)
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -85,6 +85,45 @@ func TestLifecycleManager_403TriggersReauth(t *testing.T) {
 
 	if !lm.NeedsReauth() {
 		t.Error("NeedsReauth() = false, want true after 403")
+	}
+}
+
+func TestLifecycleManager_DisableRenewalSkipsRenewCall(t *testing.T) {
+	renewCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/v1/auth/token/lookup-self" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"ttl":       json.Number("30"), // well within renewal threshold
+					"renewable": true,
+					"expire_time": "2099-01-01T00:00:00Z",
+				},
+			})
+		case r.URL.Path == "/v1/auth/token/renew-self" && r.Method == http.MethodPut:
+			renewCalled = true
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"auth": map[string]any{"client_token": "tok"}})
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+
+	vc, err := vault.NewClient(vault.Config{Address: ts.URL, Token: "some-token"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, true)
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	<-lm.Start(ctx)
+
+	if renewCalled {
+		t.Error("RenewSelf was called despite disable_token_renewal=true")
 	}
 }
 
@@ -107,7 +146,7 @@ func TestLifecycleManager_TransientErrorNoReauth(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	lm := NewLifecycleManager(vc, 50*time.Millisecond)
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,14 +93,15 @@ type Enrolment struct {
 
 // VaultConfig holds Vault connection settings.
 type VaultConfig struct {
-	Address       string `yaml:"address"`
-	CACert        string `yaml:"ca_cert"`
-	TLSSkipVerify bool   `yaml:"tls_skip_verify"`
-	KVMount       string `yaml:"kv_mount"`
-	UserPrefix    string `yaml:"user_prefix"`
-	AuthMethod    string `yaml:"auth_method"`
-	AuthRole      string `yaml:"auth_role"`
-	AuthMount     string `yaml:"auth_mount"`
+	Address              string `yaml:"address"`
+	CACert               string `yaml:"ca_cert"`
+	TLSSkipVerify        bool   `yaml:"tls_skip_verify"`
+	KVMount              string `yaml:"kv_mount"`
+	UserPrefix           string `yaml:"user_prefix"`
+	AuthMethod           string `yaml:"auth_method"`
+	AuthRole             string `yaml:"auth_role"`
+	AuthMount            string `yaml:"auth_mount"`
+	DisableTokenRenewal  bool   `yaml:"disable_token_renewal"`
 }
 
 // SyncConfig holds sync settings.

--- a/internal/config/registry_windows.go
+++ b/internal/config/registry_windows.go
@@ -60,14 +60,15 @@ func loadFromRegistry() (*Config, bool, error) {
 // registryLayer holds the flat values read from a single registry hive.
 type registryLayer struct {
 	// Vault
-	VaultAddress       string
-	VaultCACert        string
-	VaultTLSSkipVerify *uint32
-	VaultKVMount       string
-	VaultUserPrefix    string
-	VaultAuthMethod    string
-	VaultAuthRole      string
-	VaultAuthMount     string
+	VaultAddress            string
+	VaultCACert             string
+	VaultTLSSkipVerify      *uint32
+	VaultKVMount            string
+	VaultUserPrefix         string
+	VaultAuthMethod         string
+	VaultAuthRole           string
+	VaultAuthMount          string
+	VaultDisableTokenRenewal *uint32
 
 	// Sync
 	SyncInterval string
@@ -107,6 +108,7 @@ func readRegistryLayer(root registry.Key) (registryLayer, bool, error) {
 		layer.VaultAuthMethod, _ = readRegString(vk, "AuthMethod")
 		layer.VaultAuthRole, _ = readRegString(vk, "AuthRole")
 		layer.VaultAuthMount, _ = readRegString(vk, "AuthMount")
+		layer.VaultDisableTokenRenewal = readRegDWORD(vk, "DisableTokenRenewal")
 	}
 
 	// Read Sync subkey.
@@ -159,6 +161,9 @@ func applyRegistryLayer(cfg *Config, layer registryLayer) {
 	}
 	if layer.VaultAuthMount != "" {
 		cfg.Vault.AuthMount = layer.VaultAuthMount
+	}
+	if layer.VaultDisableTokenRenewal != nil {
+		cfg.Vault.DisableTokenRenewal = *layer.VaultDisableTokenRenewal != 0
 	}
 	if layer.SyncInterval != "" {
 		cfg.Sync.RawInterval = layer.SyncInterval


### PR DESCRIPTION
## Summary

- Adds `vault.disable_token_renewal` (bool, default `false`) to the YAML config and Windows GPO registry layer
- When `true`, `LifecycleManager` skips `RenewSelf` but continues TTL monitoring — token expiry still triggers re-auth
- New test `TestLifecycleManager_DisableRenewalSkipsRenewCall` verifies no renew call is made when the flag is set

Closes TOU-86.

## Test plan

- [ ] `go test ./internal/auth/...` — existing tests pass, new `DisableRenewalSkipsRenewCall` test passes
- [ ] `go test ./internal/config/...` — config struct change is backward-compatible (zero value = renewal enabled)
- [ ] Smoke test with `config.dev.yaml`: daemon renews token normally without the flag; set `disable_token_renewal: true` and confirm no renewal occurs (check logs for absence of "renewing token" messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)