### PR TITLE
feat(cli): add `reg-export` to convert YAML configs to `.reg` files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,12 @@ dotvault reg-export Convert a YAML config to a Windows .reg file
 
 `reg-export` reads and validates the YAML config, then emits a `Windows
 Registry Editor Version 5.00` file targeting `HKLM\SOFTWARE\Policies\dotvault`
-to stdout (or `--output <path>`). Default encoding is UTF-16LE with BOM;
-`--ascii` produces an unencoded plain-text variant of the same v5 format.
-Multi-line values such as Go templates round-trip via `hex(1):` (UTF-16LE
-bytes). Rendering is in `internal/regfile/`.
+to stdout (or `--output <path>`, written with 0600 permissions). Default
+encoding is UTF-16LE with BOM; `--ascii` produces an unencoded plain-text
+variant of the same v5 format. Multi-line values such as Go templates
+round-trip via `hex(1):` (UTF-16LE bytes). Optional string fields are
+emitted as `""` even when empty so re-importing clears stale registry
+values. Rendering is in `internal/regfile/`.
 
 Flags: `--config <path>`, `--log-level debug|info|warn|error`, `--dry-run`, `--once` (redirects to sync from within runDaemon).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,9 @@ dotvault reg-export Convert a YAML config to a Windows .reg file
 `reg-export` reads and validates the YAML config, then emits a `Windows
 Registry Editor Version 5.00` file targeting `HKLM\SOFTWARE\Policies\dotvault`
 to stdout (or `--output <path>`). Default encoding is UTF-16LE with BOM;
-`--ascii` produces a plain-text variant. Multi-line values such as Go
-templates round-trip via `hex(1):` (UTF-16LE bytes). Rendering is in
-`internal/regfile/`.
+`--ascii` produces an unencoded plain-text variant of the same v5 format.
+Multi-line values such as Go templates round-trip via `hex(1):` (UTF-16LE
+bytes). Rendering is in `internal/regfile/`.
 
 Flags: `--config <path>`, `--log-level debug|info|warn|error`, `--dry-run`, `--once` (redirects to sync from within runDaemon).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,12 +93,20 @@ On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\dotva
 ## CLI
 
 ```
-dotvault          Run daemon (default command)
-dotvault run      Explicit daemon mode (same as bare invocation)
-dotvault sync     One-shot sync cycle, then exit
-dotvault status   Display auth state, token TTL, per-rule sync state
-dotvault version  Print build version
+dotvault            Run daemon (default command)
+dotvault run        Explicit daemon mode (same as bare invocation)
+dotvault sync       One-shot sync cycle, then exit
+dotvault status     Display auth state, token TTL, per-rule sync state
+dotvault version    Print build version
+dotvault reg-export Convert a YAML config to a Windows .reg file
 ```
+
+`reg-export` reads and validates the YAML config, then emits a `Windows
+Registry Editor Version 5.00` file targeting `HKLM\SOFTWARE\Policies\dotvault`
+to stdout (or `--output <path>`). Default encoding is UTF-16LE with BOM;
+`--ascii` produces a plain-text variant. Multi-line values such as Go
+templates round-trip via `hex(1):` (UTF-16LE bytes). Rendering is in
+`internal/regfile/`.
 
 Flags: `--config <path>`, `--log-level debug|info|warn|error`, `--dry-run`, `--once` (redirects to sync from within runDaemon).
 

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -471,10 +471,14 @@ func authenticate(ctx context.Context, cfg *config.Config) (string, *vault.Clien
 
 func newRegExportCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reg-export <config.yaml>",
+		Use:   "reg-export [config.yaml]",
 		Short: "Convert a YAML config to a Windows .reg file",
 		Long: `Convert a dotvault YAML configuration file into a Windows Registry
 .reg file targeting HKLM\SOFTWARE\Policies\dotvault.
+
+The input config path may be supplied as a positional argument or via the
+inherited --config flag; the positional argument takes precedence when
+both are given.
 
 The resulting file can be applied with regedit.exe /s, deployed via Group
 Policy Preferences, or imported manually. By default the output is encoded
@@ -484,7 +488,7 @@ through other tools.
 
 The YAML file is fully validated before conversion; conversion errors out
 on any problem the daemon would normally reject at load time.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: runRegExport,
 	}
 	cmd.Flags().StringVarP(&flagRegOutput, "output", "o", "", "write to file instead of stdout")
@@ -495,7 +499,15 @@ on any problem the daemon would normally reject at load time.`,
 func runRegExport(cmd *cobra.Command, args []string) error {
 	setupLogging()
 
-	cfg, err := config.Load(args[0])
+	path := flagConfig
+	if len(args) == 1 {
+		path = args[0]
+	}
+	if path == "" {
+		return fmt.Errorf("provide a YAML config path as a positional argument or via --config")
+	}
+
+	cfg, err := config.Load(path)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -497,7 +497,8 @@ func newRegExportCmd() *cobra.Command {
 
 The input config path may be supplied as a positional argument or via the
 inherited --config flag; the positional argument takes precedence when
-both are given.
+both are given. If neither is supplied the platform-specific system
+config path is used, matching the other dotvault subcommands.
 
 The resulting file can be applied with regedit.exe /s, deployed via Group
 Policy Preferences, or imported manually. By default the output is encoded
@@ -523,9 +524,12 @@ func runRegExport(cmd *cobra.Command, args []string) error {
 		path = args[0]
 	}
 	if path == "" {
-		return fmt.Errorf("provide a YAML config path as a positional argument or via --config")
+		path = paths.SystemConfigPath()
 	}
 
+	// reg-export deliberately reads the YAML file, not the registry, so we
+	// use config.Load rather than config.LoadSystem (the latter would
+	// short-circuit to the registry on Windows when GPO keys are present).
 	cfg, err := config.Load(path)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -493,6 +493,8 @@ on any problem the daemon would normally reject at load time.`,
 }
 
 func runRegExport(cmd *cobra.Command, args []string) error {
+	setupLogging()
+
 	cfg, err := config.Load(args[0])
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -488,7 +488,7 @@ on any problem the daemon would normally reject at load time.`,
 		RunE: runRegExport,
 	}
 	cmd.Flags().StringVarP(&flagRegOutput, "output", "o", "", "write to file instead of stdout")
-	cmd.Flags().BoolVar(&flagRegASCII, "ascii", false, "emit ASCII text instead of UTF-16LE")
+	cmd.Flags().BoolVar(&flagRegASCII, "ascii", false, "emit unencoded plain text instead of UTF-16LE")
 	return cmd
 }
 
@@ -519,7 +519,10 @@ func runRegExport(cmd *cobra.Command, args []string) error {
 		_, err := os.Stdout.Write(data)
 		return err
 	}
-	return os.WriteFile(flagRegOutput, data, 0644)
+	// Match the 0600 convention used by other dotvault-managed files: the
+	// rendered .reg can include enrolment settings or other potentially
+	// sensitive material that should not be world-readable.
+	return os.WriteFile(flagRegOutput, data, 0600)
 }
 
 func isTerminal() bool {

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/goodtune/dotvault/internal/config"
 	"github.com/goodtune/dotvault/internal/enrol"
 	"github.com/goodtune/dotvault/internal/paths"
+	"github.com/goodtune/dotvault/internal/regfile"
 	"github.com/goodtune/dotvault/internal/sync"
 	"github.com/goodtune/dotvault/internal/vault"
 	"github.com/goodtune/dotvault/internal/web"
@@ -26,9 +27,11 @@ import (
 var version = "dev"
 
 var (
-	flagConfig   string
-	flagLogLevel string
-	flagDryRun   bool
+	flagConfig    string
+	flagLogLevel  string
+	flagDryRun    bool
+	flagRegOutput string
+	flagRegASCII  bool
 )
 
 func main() {
@@ -65,6 +68,7 @@ func main() {
 				fmt.Println(version)
 			},
 		},
+		newRegExportCmd(),
 	)
 
 	// --once as alias for sync
@@ -292,9 +296,9 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	} else {
 		// CLI mode: terminal-based wizard (unchanged).
 		enrolIO := enrol.IO{
-			Out:     os.Stderr,
-			Browser: browser.OpenURL,
-			Log:     slog.Default(),
+			Out:      os.Stderr,
+			Browser:  browser.OpenURL,
+			Log:      slog.Default(),
 			Username: username,
 			PromptSecret: func(label string) (string, error) {
 				fd := int(os.Stdin.Fd())
@@ -463,6 +467,49 @@ func authenticate(ctx context.Context, cfg *config.Config) (string, *vault.Clien
 	}
 
 	return username, vc, nil
+}
+
+func newRegExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reg-export <config.yaml>",
+		Short: "Convert a YAML config to a Windows .reg file",
+		Long: `Convert a dotvault YAML configuration file into a Windows Registry
+.reg file targeting HKLM\SOFTWARE\Policies\dotvault.
+
+The resulting file can be applied with regedit.exe /s, deployed via Group
+Policy Preferences, or imported manually. By default the output is encoded
+as UTF-16LE with BOM, matching the canonical format produced by regedit.exe.
+Pass --ascii for a plain-text REGEDIT4-compatible variant suitable for
+diffing or piping through other tools.
+
+The YAML file is fully validated before conversion; conversion errors out
+on any problem the daemon would normally reject at load time.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runRegExport,
+	}
+	cmd.Flags().StringVarP(&flagRegOutput, "output", "o", "", "write to file instead of stdout")
+	cmd.Flags().BoolVar(&flagRegASCII, "ascii", false, "emit ASCII text instead of UTF-16LE")
+	return cmd
+}
+
+func runRegExport(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(args[0])
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	var data []byte
+	if flagRegASCII {
+		data = []byte(regfile.GenerateText(cfg))
+	} else {
+		data = regfile.Generate(cfg)
+	}
+
+	if flagRegOutput == "" || flagRegOutput == "-" {
+		_, err := os.Stdout.Write(data)
+		return err
+	}
+	return os.WriteFile(flagRegOutput, data, 0644)
 }
 
 func isTerminal() bool {

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -479,8 +479,8 @@ func newRegExportCmd() *cobra.Command {
 The resulting file can be applied with regedit.exe /s, deployed via Group
 Policy Preferences, or imported manually. By default the output is encoded
 as UTF-16LE with BOM, matching the canonical format produced by regedit.exe.
-Pass --ascii for a plain-text REGEDIT4-compatible variant suitable for
-diffing or piping through other tools.
+Pass --ascii for a plain-text variant suitable for diffing or piping
+through other tools.
 
 The YAML file is fully validated before conversion; conversion errors out
 on any problem the daemon would normally reject at load time.`,
@@ -500,9 +500,17 @@ func runRegExport(cmd *cobra.Command, args []string) error {
 
 	var data []byte
 	if flagRegASCII {
-		data = []byte(regfile.GenerateText(cfg))
+		text, err := regfile.GenerateText(cfg)
+		if err != nil {
+			return fmt.Errorf("render reg file: %w", err)
+		}
+		data = []byte(text)
 	} else {
-		data = regfile.Generate(cfg)
+		out, err := regfile.Generate(cfg)
+		if err != nil {
+			return fmt.Errorf("render reg file: %w", err)
+		}
+		data = out
 	}
 
 	if flagRegOutput == "" || flagRegOutput == "-" {

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -75,6 +75,14 @@ func (e *emitter) writeKey(path string) {
 	fmt.Fprintf(&e.b, "[%s]\r\n", path)
 }
 
+// writeKeyDeletion emits a `[-PATH]` stanza which instructs registry
+// import to delete the given key (and all subkeys/values). Used to make
+// the export idempotent for sections where the set of subkeys is
+// determined dynamically by the YAML.
+func (e *emitter) writeKeyDeletion(path string) {
+	fmt.Fprintf(&e.b, "[-%s]\r\n\r\n", path)
+}
+
 func (e *emitter) writeVault(v config.VaultConfig) {
 	e.writeKey(rootKey + `\Vault`)
 	e.writeString("Address", v.Address)
@@ -110,7 +118,15 @@ func (e *emitter) writeWeb(w config.WebConfig) {
 }
 
 func (e *emitter) writeRules(rules []config.Rule) {
+	// Delete the whole Rules subtree before re-creating it. Because the
+	// registry loader enumerates every subkey under Rules, an additive
+	// export would let rules removed from YAML keep syncing secrets on
+	// machines where they were previously imported. Pre-deleting makes
+	// the .reg file an idempotent statement of intent rather than a
+	// merge against existing state.
+	e.writeKeyDeletion(rootKey + `\Rules`)
 	if len(rules) == 0 {
+		// No rules to re-create; the deletion stanza alone wipes the subtree.
 		return
 	}
 	e.writeKey(rootKey + `\Rules`)
@@ -154,6 +170,10 @@ func (e *emitter) writeRule(r config.Rule) {
 }
 
 func (e *emitter) writeEnrolments(enrolments map[string]config.Enrolment) {
+	// Same idempotency story as writeRules: wipe the Enrolments subtree
+	// first so enrolments (and their Settings) removed from YAML are also
+	// removed from the registry on re-import.
+	e.writeKeyDeletion(rootKey + `\Enrolments`)
 	if len(enrolments) == 0 {
 		return
 	}

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -1,0 +1,289 @@
+// Package regfile renders a dotvault configuration as a Windows
+// Registry (.reg) file targeting HKLM\SOFTWARE\Policies\dotvault.
+//
+// The output is the canonical "Windows Registry Editor Version 5.00"
+// format encoded as UTF-16LE with a BOM, matching what regedit.exe
+// produces and what Group Policy tooling expects.
+package regfile
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/goodtune/dotvault/internal/config"
+)
+
+const (
+	rootKey    = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault`
+	header     = "Windows Registry Editor Version 5.00\r\n\r\n"
+	maxLineLen = 76
+)
+
+// Generate produces .reg file content for cfg encoded as UTF-16LE with BOM.
+func Generate(cfg *config.Config) []byte {
+	return encodeUTF16LE(GenerateText(cfg))
+}
+
+// GenerateText produces .reg file content for cfg as plain ASCII text.
+// Useful for tests and for callers that want to emit a REGEDIT4-compatible
+// file without UTF-16 encoding.
+func GenerateText(cfg *config.Config) string {
+	var b strings.Builder
+	b.WriteString(header)
+
+	writeKey(&b, rootKey)
+	b.WriteString("\r\n")
+
+	writeVault(&b, cfg.Vault)
+	writeSync(&b, cfg.Sync)
+	writeWeb(&b, cfg.Web)
+	writeRules(&b, cfg.Rules)
+	writeEnrolments(&b, cfg.Enrolments)
+
+	return b.String()
+}
+
+func writeVault(b *strings.Builder, v config.VaultConfig) {
+	writeKey(b, rootKey+`\Vault`)
+	writeString(b, "Address", v.Address)
+	writeString(b, "AuthMethod", v.AuthMethod)
+	writeString(b, "AuthMount", v.AuthMount)
+	writeString(b, "AuthRole", v.AuthRole)
+	writeString(b, "CACert", v.CACert)
+	writeString(b, "KVMount", v.KVMount)
+	writeString(b, "UserPrefix", v.UserPrefix)
+	writeBool(b, "DisableTokenRenewal", v.DisableTokenRenewal)
+	writeBool(b, "TLSSkipVerify", v.TLSSkipVerify)
+	b.WriteString("\r\n")
+}
+
+func writeSync(b *strings.Builder, s config.SyncConfig) {
+	interval := s.RawInterval
+	if interval == "" && s.Interval > 0 {
+		interval = s.Interval.String()
+	}
+	if interval == "" {
+		return
+	}
+	writeKey(b, rootKey+`\Sync`)
+	writeString(b, "Interval", interval)
+	b.WriteString("\r\n")
+}
+
+func writeWeb(b *strings.Builder, w config.WebConfig) {
+	writeKey(b, rootKey+`\Web`)
+	writeBool(b, "Enabled", w.Enabled)
+	writeString(b, "Listen", w.Listen)
+	b.WriteString("\r\n")
+}
+
+func writeRules(b *strings.Builder, rules []config.Rule) {
+	if len(rules) == 0 {
+		return
+	}
+	writeKey(b, rootKey+`\Rules`)
+	b.WriteString("\r\n")
+
+	sorted := append([]config.Rule(nil), rules...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	for _, r := range sorted {
+		writeRule(b, r)
+	}
+}
+
+func writeRule(b *strings.Builder, r config.Rule) {
+	rulePath := rootKey + `\Rules\` + r.Name
+	writeKey(b, rulePath)
+	writeString(b, "Description", r.Description)
+	writeString(b, "TargetFormat", r.Target.Format)
+	writeString(b, "TargetMerge", r.Target.Merge)
+	writeString(b, "TargetPath", r.Target.Path)
+	writeString(b, "TargetTemplate", r.Target.Template)
+	writeString(b, "VaultKey", r.VaultKey)
+	b.WriteString("\r\n")
+
+	if r.OAuth == nil {
+		return
+	}
+	writeKey(b, rulePath+`\OAuth`)
+	writeString(b, "EnginePath", r.OAuth.EnginePath)
+	writeString(b, "Provider", r.OAuth.Provider)
+	if len(r.OAuth.Scopes) > 0 {
+		writeMultiString(b, "Scopes", r.OAuth.Scopes)
+	}
+	b.WriteString("\r\n")
+}
+
+func writeEnrolments(b *strings.Builder, enrolments map[string]config.Enrolment) {
+	if len(enrolments) == 0 {
+		return
+	}
+	writeKey(b, rootKey+`\Enrolments`)
+	b.WriteString("\r\n")
+
+	names := make([]string, 0, len(enrolments))
+	for n := range enrolments {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		writeEnrolment(b, n, enrolments[n])
+	}
+}
+
+func writeEnrolment(b *strings.Builder, name string, e config.Enrolment) {
+	enrolPath := rootKey + `\Enrolments\` + name
+	writeKey(b, enrolPath)
+	writeString(b, "Engine", e.Engine)
+	b.WriteString("\r\n")
+
+	if len(e.Settings) == 0 {
+		return
+	}
+	writeKey(b, enrolPath+`\Settings`)
+
+	keys := make([]string, 0, len(e.Settings))
+	for k := range e.Settings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeSetting(b, k, e.Settings[k])
+	}
+	b.WriteString("\r\n")
+}
+
+// writeSetting emits a single enrolment setting. Strings become REG_SZ;
+// slices of strings become REG_MULTI_SZ. Other types are skipped because
+// the registry reader only knows how to deserialise these two kinds.
+func writeSetting(b *strings.Builder, name string, value any) {
+	switch v := value.(type) {
+	case string:
+		writeString(b, name, v)
+	case []string:
+		if len(v) > 0 {
+			writeMultiString(b, name, v)
+		}
+	case []any:
+		strs := make([]string, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return
+			}
+			strs = append(strs, s)
+		}
+		if len(strs) > 0 {
+			writeMultiString(b, name, strs)
+		}
+	}
+}
+
+func writeKey(b *strings.Builder, path string) {
+	fmt.Fprintf(b, "[%s]\r\n", path)
+}
+
+// writeString emits a REG_SZ value. Plain ASCII without control characters
+// is emitted in quoted form; anything else falls through to hex(1) so that
+// templates with embedded newlines round-trip correctly.
+func writeString(b *strings.Builder, name, value string) {
+	if value == "" {
+		return
+	}
+	if needsHex(value) {
+		writeHexValue(b, name, 1, utf16Bytes([]string{value}))
+		return
+	}
+	fmt.Fprintf(b, "\"%s\"=%s\r\n", name, quoteREGSZ(value))
+}
+
+func writeBool(b *strings.Builder, name string, value bool) {
+	v := uint32(0)
+	if value {
+		v = 1
+	}
+	fmt.Fprintf(b, "\"%s\"=dword:%08x\r\n", name, v)
+}
+
+func writeMultiString(b *strings.Builder, name string, values []string) {
+	writeHexValue(b, name, 7, utf16Bytes(values))
+}
+
+// utf16Bytes encodes one or more strings as a contiguous UTF-16LE byte
+// sequence terminated as expected by the corresponding registry type:
+//
+//   - REG_SZ (single string): trailing NUL.
+//   - REG_MULTI_SZ (slice of strings): each string NUL-terminated, plus
+//     a final NUL terminator on the empty trailing string.
+func utf16Bytes(values []string) []byte {
+	var runes []uint16
+	for _, s := range values {
+		runes = append(runes, utf16.Encode([]rune(s))...)
+		runes = append(runes, 0)
+	}
+	if len(values) > 1 {
+		runes = append(runes, 0)
+	}
+	out := make([]byte, 2*len(runes))
+	for i, r := range runes {
+		binary.LittleEndian.PutUint16(out[2*i:], r)
+	}
+	return out
+}
+
+// writeHexValue emits a hex(<kind>):... value, wrapping at maxLineLen
+// using the standard backslash continuation that regedit.exe produces.
+func writeHexValue(b *strings.Builder, name string, kind int, data []byte) {
+	head := fmt.Sprintf("\"%s\"=hex(%d):", name, kind)
+	cur := head
+	for i, by := range data {
+		token := fmt.Sprintf("%02x", by)
+		sep := ","
+		if i == 0 {
+			sep = ""
+		}
+		// Reserve one column for the trailing backslash on continuation.
+		if len(cur)+len(sep)+len(token) > maxLineLen-1 {
+			b.WriteString(cur + sep + "\\\r\n  ")
+			cur = token
+			continue
+		}
+		cur += sep + token
+	}
+	b.WriteString(cur + "\r\n")
+}
+
+// quoteREGSZ wraps s in double quotes and escapes the only two characters
+// that have special meaning inside a quoted REG_SZ value.
+func quoteREGSZ(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+// needsHex reports whether s contains characters that cannot appear in a
+// quoted REG_SZ value. The .reg quoted form only supports printable ASCII;
+// anything else (newlines, tabs, non-ASCII) must use hex(1).
+func needsHex(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r > 0x7E {
+			return true
+		}
+	}
+	return false
+}
+
+// encodeUTF16LE prepends a UTF-16LE BOM and encodes s as UTF-16 little-endian.
+func encodeUTF16LE(s string) []byte {
+	runes := utf16.Encode([]rune(s))
+	out := make([]byte, 2+2*len(runes))
+	out[0] = 0xFF
+	out[1] = 0xFE
+	for i, r := range runes {
+		binary.LittleEndian.PutUint16(out[2+2*i:], r)
+	}
+	return out
+}

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -233,13 +233,17 @@ func (e *emitter) writeSetting(enrolment, name string, value any) {
 // is emitted in quoted form; anything else falls through to hex(1) so that
 // templates with embedded newlines round-trip correctly.
 //
-// Empty strings are emitted explicitly as `""=""` rather than omitted, so
-// that re-importing an exported .reg clears any value previously configured
-// for the same name. Without this, removing an optional field from YAML
-// would leave stale registry data on machines where the policy was
-// previously applied.
+// Empty strings are emitted explicitly as `"<Name>"=""` rather than
+// omitted, so that re-importing an exported .reg clears any value
+// previously configured for the same name. Without this, removing an
+// optional field from YAML would leave stale registry data on machines
+// where the policy was previously applied.
 func (e *emitter) writeString(name, value string) {
 	if err := validateValueName(name); err != nil {
+		e.fail("%w", err)
+		return
+	}
+	if err := rejectEmbeddedNUL(name, value); err != nil {
 		e.fail("%w", err)
 		return
 	}
@@ -266,6 +270,14 @@ func (e *emitter) writeMultiString(name string, values []string) {
 	if err := validateValueName(name); err != nil {
 		e.fail("%w", err)
 		return
+	}
+	// Embedded NUL in a list element would split or truncate the entry on
+	// import because REG_MULTI_SZ uses NUL as the element delimiter.
+	for i, v := range values {
+		if strings.IndexByte(v, 0) >= 0 {
+			e.fail("registry value %q list element [%d] contains an embedded NUL byte; REG_MULTI_SZ uses NUL as a delimiter and cannot represent it", name, i)
+			return
+		}
 	}
 	e.writeHexValue(name, 7, utf16MultiStringBytes(values))
 }
@@ -355,6 +367,18 @@ func escapeREGString(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	return s
+}
+
+// rejectEmbeddedNUL returns an error if value contains a NUL byte (\x00).
+// REG_SZ and REG_MULTI_SZ both use NUL as a terminator, so an embedded NUL
+// would be truncated or split when the value is read back on import,
+// breaking round-trip. We surface this as a clear error rather than
+// silently corrupt the export.
+func rejectEmbeddedNUL(name, value string) error {
+	if strings.IndexByte(value, 0) >= 0 {
+		return fmt.Errorf("registry value %q contains an embedded NUL byte; REG_SZ cannot represent it", name)
+	}
+	return nil
 }
 
 // validateValueName rejects names that cannot be safely represented inside

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -232,10 +232,13 @@ func (e *emitter) writeSetting(enrolment, name string, value any) {
 // writeString emits a REG_SZ value. Plain ASCII without control characters
 // is emitted in quoted form; anything else falls through to hex(1) so that
 // templates with embedded newlines round-trip correctly.
+//
+// Empty strings are emitted explicitly as `""=""` rather than omitted, so
+// that re-importing an exported .reg clears any value previously configured
+// for the same name. Without this, removing an optional field from YAML
+// would leave stale registry data on machines where the policy was
+// previously applied.
 func (e *emitter) writeString(name, value string) {
-	if value == "" {
-		return
-	}
 	if err := validateValueName(name); err != nil {
 		e.fail("%w", err)
 		return
@@ -354,35 +357,37 @@ func escapeREGString(s string) string {
 	return s
 }
 
-// validateValueName rejects names containing characters that cannot be
-// safely represented inside a quoted .reg value name. We require printable
-// ASCII so the same renderer output is valid in both UTF-16LE and ASCII
-// modes; the .reg format has no escape mechanism for control characters
-// inside quoted strings.
+// validateValueName rejects names that cannot be safely represented inside
+// a quoted .reg value name. The .reg format has no escape mechanism for
+// control characters or NUL inside quoted strings, so we error out rather
+// than silently corrupt the output. Unicode characters are allowed: the
+// default UTF-16LE output encodes them faithfully, and the --ascii output
+// stays valid UTF-8.
 func validateValueName(name string) error {
 	if name == "" {
 		return fmt.Errorf("registry value name must not be empty")
 	}
 	for _, r := range name {
-		if r < 0x20 || r > 0x7E {
-			return fmt.Errorf("registry value name %q contains non-printable-ASCII character U+%04X", name, r)
+		if r < 0x20 || r == 0x7F {
+			return fmt.Errorf("registry value name %q contains control character U+%04X", name, r)
 		}
 	}
 	return nil
 }
 
 // validateKeyName rejects names that cannot appear as a single registry
-// key path segment. In addition to the printable-ASCII rule used for
-// value names, key segments must not contain `\` (segment separator),
-// `[` or `]` (key-line delimiters), so they cannot break out of the
-// path or invalidate the surrounding `.reg` syntax.
+// key path segment. Key segments may contain Unicode because the default
+// .reg output is UTF-16LE and can represent it; however they must not
+// contain control characters, `\` (segment separator), or `[`/`]`
+// (key-line delimiters) so they cannot break out of the path or
+// invalidate the surrounding `.reg` syntax.
 func validateKeyName(name string) error {
 	if name == "" {
 		return fmt.Errorf("registry key name must not be empty")
 	}
 	for _, r := range name {
-		if r < 0x20 || r > 0x7E {
-			return fmt.Errorf("registry key name %q contains non-printable-ASCII character U+%04X", name, r)
+		if r < 0x20 || r == 0x7F {
+			return fmt.Errorf("registry key name %q contains control character U+%04X", name, r)
 		}
 		switch r {
 		case '\\', '[', ']':

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -123,6 +123,10 @@ func (e *emitter) writeRules(rules []config.Rule) {
 }
 
 func (e *emitter) writeRule(r config.Rule) {
+	if err := validateKeyName(r.Name); err != nil {
+		e.fail("rule %q: %w", r.Name, err)
+		return
+	}
 	rulePath := rootKey + `\Rules\` + r.Name
 	e.writeKey(rulePath)
 	e.writeString("Description", r.Description)
@@ -139,7 +143,10 @@ func (e *emitter) writeRule(r config.Rule) {
 	e.writeKey(rulePath + `\OAuth`)
 	e.writeString("EnginePath", r.OAuth.EnginePath)
 	e.writeString("Provider", r.OAuth.Provider)
-	if len(r.OAuth.Scopes) > 0 {
+	// Emit Scopes whenever the slice is non-nil so an explicit empty list
+	// (`scopes: []` in YAML) round-trips as an empty REG_MULTI_SZ rather
+	// than being silently dropped.
+	if r.OAuth.Scopes != nil {
 		e.writeMultiString("Scopes", r.OAuth.Scopes)
 	}
 	e.WriteString("\r\n")
@@ -163,6 +170,10 @@ func (e *emitter) writeEnrolments(enrolments map[string]config.Enrolment) {
 }
 
 func (e *emitter) writeEnrolment(name string, en config.Enrolment) {
+	if err := validateKeyName(name); err != nil {
+		e.fail("enrolment %q: %w", name, err)
+		return
+	}
 	enrolPath := rootKey + `\Enrolments\` + name
 	e.writeKey(enrolPath)
 	e.writeString("Engine", en.Engine)
@@ -189,12 +200,17 @@ func (e *emitter) writeEnrolment(name string, en config.Enrolment) {
 // how to deserialise these two kinds, so any other value type is treated
 // as an error rather than silently dropped: a partial export that
 // disagrees with the source YAML is worse than a hard failure.
+//
+// Empty lists are preserved as empty REG_MULTI_SZ rather than dropped:
+// in YAML an explicit `[]` differs from an absent key, and engines that
+// override defaults from the presence of a list (e.g. GitHub's `scopes`)
+// rely on that distinction.
 func (e *emitter) writeSetting(enrolment, name string, value any) {
 	switch v := value.(type) {
 	case string:
 		e.writeString(name, v)
 	case []string:
-		if len(v) > 0 {
+		if v != nil {
 			e.writeMultiString(name, v)
 		}
 	case []any:
@@ -207,9 +223,7 @@ func (e *emitter) writeSetting(enrolment, name string, value any) {
 			}
 			strs = append(strs, s)
 		}
-		if len(strs) > 0 {
-			e.writeMultiString(name, strs)
-		}
+		e.writeMultiString(name, strs)
 	default:
 		e.fail("enrolments[%q].settings[%q]: cannot represent %T in registry; only strings and string lists are supported", enrolment, name, value)
 	}
@@ -329,24 +343,48 @@ func escapeREGString(s string) string {
 }
 
 // validateValueName rejects names containing characters that cannot be
-// safely represented inside a quoted .reg value name. The .reg format
-// has no escape mechanism for control characters or NUL inside quoted
-// strings, so we error out rather than silently corrupt the output.
+// safely represented inside a quoted .reg value name. We require printable
+// ASCII so the same renderer output is valid in both UTF-16LE and ASCII
+// modes; the .reg format has no escape mechanism for control characters
+// inside quoted strings.
 func validateValueName(name string) error {
 	if name == "" {
 		return fmt.Errorf("registry value name must not be empty")
 	}
 	for _, r := range name {
-		if r < 0x20 || r == 0x7F {
-			return fmt.Errorf("registry value name %q contains control character U+%04X", name, r)
+		if r < 0x20 || r > 0x7E {
+			return fmt.Errorf("registry value name %q contains non-printable-ASCII character U+%04X", name, r)
 		}
 	}
 	return nil
 }
 
-// needsHex reports whether s contains characters that cannot appear in a
-// quoted REG_SZ value. The .reg quoted form only supports printable ASCII;
-// anything else (newlines, tabs, non-ASCII) must use hex(1).
+// validateKeyName rejects names that cannot appear as a single registry
+// key path segment. In addition to the printable-ASCII rule used for
+// value names, key segments must not contain `\` (segment separator),
+// `[` or `]` (key-line delimiters), so they cannot break out of the
+// path or invalidate the surrounding `.reg` syntax.
+func validateKeyName(name string) error {
+	if name == "" {
+		return fmt.Errorf("registry key name must not be empty")
+	}
+	for _, r := range name {
+		if r < 0x20 || r > 0x7E {
+			return fmt.Errorf("registry key name %q contains non-printable-ASCII character U+%04X", name, r)
+		}
+		switch r {
+		case '\\', '[', ']':
+			return fmt.Errorf("registry key name %q contains reserved character %q", name, r)
+		}
+	}
+	return nil
+}
+
+// needsHex reports whether this renderer should emit s as hex(1) instead
+// of a quoted REG_SZ value. Although .reg v5 files can represent Unicode
+// in quoted strings when encoded as UTF-16LE, this renderer keeps quoted
+// output to printable ASCII so text-oriented output stays plain text;
+// anything else (newlines, tabs, non-ASCII) is emitted as hex(1).
 func needsHex(s string) bool {
 	for _, r := range s {
 		if r < 0x20 || r > 0x7E {

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -98,15 +98,13 @@ func (e *emitter) writeVault(v config.VaultConfig) {
 }
 
 func (e *emitter) writeSync(s config.SyncConfig) {
-	interval := s.RawInterval
-	if interval == "" && s.Interval > 0 {
-		interval = s.Interval.String()
-	}
-	if interval == "" {
-		return
-	}
+	// Emit RawInterval as the user wrote it (or empty if they relied on
+	// the daemon's 15m default). Avoid s.Interval.String() because Go's
+	// time.Duration formatter produces verbose forms like "15m0s" for
+	// what the YAML expressed as "15m"; that round-trip is technically
+	// valid but pollutes diffs of exported .reg files.
 	e.writeKey(rootKey + `\Sync`)
-	e.writeString("Interval", interval)
+	e.writeString("Interval", s.RawInterval)
 	e.WriteString("\r\n")
 }
 

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/goodtune/dotvault/internal/config"
 )
@@ -292,28 +293,37 @@ func (e *emitter) writeMultiString(name string, values []string) {
 // If the head plus first byte cannot fit (excluding any later wrap budget),
 // generation fails with an explicit error rather than emitting malformed
 // output.
+//
+// Lengths are measured in runes rather than bytes so Unicode value names
+// don't trigger spurious wraps or false "too long" errors. Hex tokens
+// (`,XX`) and the indent are pure ASCII, so rune count matches column
+// count for everything we append.
 func (e *emitter) writeHexValue(name string, kind int, data []byte) {
 	head := fmt.Sprintf("%s=hex(%d):", quoteREGName(name), kind)
+	headLen := utf8.RuneCountInString(head)
 	if len(data) == 0 {
 		e.b.WriteString(head + "\r\n")
 		return
 	}
 	firstToken := fmt.Sprintf("%02x", data[0])
 	// Reserve two columns for the trailing ",\\" if a continuation is needed.
-	if len(head)+len(firstToken) > maxLineLen-2 {
+	if headLen+len(firstToken) > maxLineLen-2 {
 		e.fail("registry value name %q is too long to encode as hex(%d) within %d columns", name, kind, maxLineLen)
 		return
 	}
 	cur := head + firstToken
+	curLen := headLen + len(firstToken)
 	for _, by := range data[1:] {
 		token := fmt.Sprintf("%02x", by)
 		// Reserve two columns for the trailing ",\\" on a continuation line.
-		if len(cur)+1+len(token) > maxLineLen-2 {
+		if curLen+1+len(token) > maxLineLen-2 {
 			e.b.WriteString(cur + ",\\\r\n")
 			cur = "  " + token
+			curLen = 2 + len(token)
 			continue
 		}
 		cur += "," + token
+		curLen += 1 + len(token)
 	}
 	e.b.WriteString(cur + "\r\n")
 }

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -23,44 +23,72 @@ const (
 )
 
 // Generate produces .reg file content for cfg encoded as UTF-16LE with BOM.
-func Generate(cfg *config.Config) []byte {
-	return encodeUTF16LE(GenerateText(cfg))
+func Generate(cfg *config.Config) ([]byte, error) {
+	text, err := GenerateText(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return encodeUTF16LE(text), nil
 }
 
-// GenerateText produces .reg file content for cfg as plain ASCII text.
-// Useful for tests and for callers that want to emit a REGEDIT4-compatible
-// file without UTF-16 encoding.
-func GenerateText(cfg *config.Config) string {
-	var b strings.Builder
-	b.WriteString(header)
+// GenerateText produces .reg file content for cfg as plain text using the
+// same Windows Registry Editor Version 5.00 format as Generate, but without
+// UTF-16LE encoding. Useful for tests and for callers that want to inspect
+// or post-process the output.
+func GenerateText(cfg *config.Config) (string, error) {
+	e := &emitter{}
+	e.WriteString(header)
 
-	writeKey(&b, rootKey)
-	b.WriteString("\r\n")
+	e.writeKey(rootKey)
+	e.WriteString("\r\n")
 
-	writeVault(&b, cfg.Vault)
-	writeSync(&b, cfg.Sync)
-	writeWeb(&b, cfg.Web)
-	writeRules(&b, cfg.Rules)
-	writeEnrolments(&b, cfg.Enrolments)
+	e.writeVault(cfg.Vault)
+	e.writeSync(cfg.Sync)
+	e.writeWeb(cfg.Web)
+	e.writeRules(cfg.Rules)
+	e.writeEnrolments(cfg.Enrolments)
 
-	return b.String()
+	if e.err != nil {
+		return "", e.err
+	}
+	return e.b.String(), nil
 }
 
-func writeVault(b *strings.Builder, v config.VaultConfig) {
-	writeKey(b, rootKey+`\Vault`)
-	writeString(b, "Address", v.Address)
-	writeString(b, "AuthMethod", v.AuthMethod)
-	writeString(b, "AuthMount", v.AuthMount)
-	writeString(b, "AuthRole", v.AuthRole)
-	writeString(b, "CACert", v.CACert)
-	writeString(b, "KVMount", v.KVMount)
-	writeString(b, "UserPrefix", v.UserPrefix)
-	writeBool(b, "DisableTokenRenewal", v.DisableTokenRenewal)
-	writeBool(b, "TLSSkipVerify", v.TLSSkipVerify)
-	b.WriteString("\r\n")
+// emitter is a strings.Builder wrapper that captures the first error
+// encountered so the rendering walk can carry on without if/return
+// noise at every call site.
+type emitter struct {
+	b   strings.Builder
+	err error
 }
 
-func writeSync(b *strings.Builder, s config.SyncConfig) {
+func (e *emitter) WriteString(s string) { e.b.WriteString(s) }
+
+func (e *emitter) fail(format string, args ...any) {
+	if e.err == nil {
+		e.err = fmt.Errorf(format, args...)
+	}
+}
+
+func (e *emitter) writeKey(path string) {
+	fmt.Fprintf(&e.b, "[%s]\r\n", path)
+}
+
+func (e *emitter) writeVault(v config.VaultConfig) {
+	e.writeKey(rootKey + `\Vault`)
+	e.writeString("Address", v.Address)
+	e.writeString("AuthMethod", v.AuthMethod)
+	e.writeString("AuthMount", v.AuthMount)
+	e.writeString("AuthRole", v.AuthRole)
+	e.writeString("CACert", v.CACert)
+	e.writeString("KVMount", v.KVMount)
+	e.writeString("UserPrefix", v.UserPrefix)
+	e.writeBool("DisableTokenRenewal", v.DisableTokenRenewal)
+	e.writeBool("TLSSkipVerify", v.TLSSkipVerify)
+	e.WriteString("\r\n")
+}
+
+func (e *emitter) writeSync(s config.SyncConfig) {
 	interval := s.RawInterval
 	if interval == "" && s.Interval > 0 {
 		interval = s.Interval.String()
@@ -68,61 +96,61 @@ func writeSync(b *strings.Builder, s config.SyncConfig) {
 	if interval == "" {
 		return
 	}
-	writeKey(b, rootKey+`\Sync`)
-	writeString(b, "Interval", interval)
-	b.WriteString("\r\n")
+	e.writeKey(rootKey + `\Sync`)
+	e.writeString("Interval", interval)
+	e.WriteString("\r\n")
 }
 
-func writeWeb(b *strings.Builder, w config.WebConfig) {
-	writeKey(b, rootKey+`\Web`)
-	writeBool(b, "Enabled", w.Enabled)
-	writeString(b, "Listen", w.Listen)
-	b.WriteString("\r\n")
+func (e *emitter) writeWeb(w config.WebConfig) {
+	e.writeKey(rootKey + `\Web`)
+	e.writeBool("Enabled", w.Enabled)
+	e.writeString("Listen", w.Listen)
+	e.WriteString("\r\n")
 }
 
-func writeRules(b *strings.Builder, rules []config.Rule) {
+func (e *emitter) writeRules(rules []config.Rule) {
 	if len(rules) == 0 {
 		return
 	}
-	writeKey(b, rootKey+`\Rules`)
-	b.WriteString("\r\n")
+	e.writeKey(rootKey + `\Rules`)
+	e.WriteString("\r\n")
 
 	sorted := append([]config.Rule(nil), rules...)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
 	for _, r := range sorted {
-		writeRule(b, r)
+		e.writeRule(r)
 	}
 }
 
-func writeRule(b *strings.Builder, r config.Rule) {
+func (e *emitter) writeRule(r config.Rule) {
 	rulePath := rootKey + `\Rules\` + r.Name
-	writeKey(b, rulePath)
-	writeString(b, "Description", r.Description)
-	writeString(b, "TargetFormat", r.Target.Format)
-	writeString(b, "TargetMerge", r.Target.Merge)
-	writeString(b, "TargetPath", r.Target.Path)
-	writeString(b, "TargetTemplate", r.Target.Template)
-	writeString(b, "VaultKey", r.VaultKey)
-	b.WriteString("\r\n")
+	e.writeKey(rulePath)
+	e.writeString("Description", r.Description)
+	e.writeString("TargetFormat", r.Target.Format)
+	e.writeString("TargetMerge", r.Target.Merge)
+	e.writeString("TargetPath", r.Target.Path)
+	e.writeString("TargetTemplate", r.Target.Template)
+	e.writeString("VaultKey", r.VaultKey)
+	e.WriteString("\r\n")
 
 	if r.OAuth == nil {
 		return
 	}
-	writeKey(b, rulePath+`\OAuth`)
-	writeString(b, "EnginePath", r.OAuth.EnginePath)
-	writeString(b, "Provider", r.OAuth.Provider)
+	e.writeKey(rulePath + `\OAuth`)
+	e.writeString("EnginePath", r.OAuth.EnginePath)
+	e.writeString("Provider", r.OAuth.Provider)
 	if len(r.OAuth.Scopes) > 0 {
-		writeMultiString(b, "Scopes", r.OAuth.Scopes)
+		e.writeMultiString("Scopes", r.OAuth.Scopes)
 	}
-	b.WriteString("\r\n")
+	e.WriteString("\r\n")
 }
 
-func writeEnrolments(b *strings.Builder, enrolments map[string]config.Enrolment) {
+func (e *emitter) writeEnrolments(enrolments map[string]config.Enrolment) {
 	if len(enrolments) == 0 {
 		return
 	}
-	writeKey(b, rootKey+`\Enrolments`)
-	b.WriteString("\r\n")
+	e.writeKey(rootKey + `\Enrolments`)
+	e.WriteString("\r\n")
 
 	names := make([]string, 0, len(enrolments))
 	for n := range enrolments {
@@ -130,114 +158,107 @@ func writeEnrolments(b *strings.Builder, enrolments map[string]config.Enrolment)
 	}
 	sort.Strings(names)
 	for _, n := range names {
-		writeEnrolment(b, n, enrolments[n])
+		e.writeEnrolment(n, enrolments[n])
 	}
 }
 
-func writeEnrolment(b *strings.Builder, name string, e config.Enrolment) {
+func (e *emitter) writeEnrolment(name string, en config.Enrolment) {
 	enrolPath := rootKey + `\Enrolments\` + name
-	writeKey(b, enrolPath)
-	writeString(b, "Engine", e.Engine)
-	b.WriteString("\r\n")
+	e.writeKey(enrolPath)
+	e.writeString("Engine", en.Engine)
+	e.WriteString("\r\n")
 
-	if len(e.Settings) == 0 {
+	if len(en.Settings) == 0 {
 		return
 	}
-	writeKey(b, enrolPath+`\Settings`)
+	e.writeKey(enrolPath + `\Settings`)
 
-	keys := make([]string, 0, len(e.Settings))
-	for k := range e.Settings {
+	keys := make([]string, 0, len(en.Settings))
+	for k := range en.Settings {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		writeSetting(b, k, e.Settings[k])
+		e.writeSetting(name, k, en.Settings[k])
 	}
-	b.WriteString("\r\n")
+	e.WriteString("\r\n")
 }
 
 // writeSetting emits a single enrolment setting. Strings become REG_SZ;
-// slices of strings become REG_MULTI_SZ. Other types are skipped because
-// the registry reader only knows how to deserialise these two kinds.
-func writeSetting(b *strings.Builder, name string, value any) {
+// slices of strings become REG_MULTI_SZ. The registry reader only knows
+// how to deserialise these two kinds, so any other value type is treated
+// as an error rather than silently dropped: a partial export that
+// disagrees with the source YAML is worse than a hard failure.
+func (e *emitter) writeSetting(enrolment, name string, value any) {
 	switch v := value.(type) {
 	case string:
-		writeString(b, name, v)
+		e.writeString(name, v)
 	case []string:
 		if len(v) > 0 {
-			writeMultiString(b, name, v)
+			e.writeMultiString(name, v)
 		}
 	case []any:
 		strs := make([]string, 0, len(v))
-		for _, item := range v {
+		for i, item := range v {
 			s, ok := item.(string)
 			if !ok {
+				e.fail("enrolments[%q].settings[%q][%d]: cannot represent %T in registry; only strings are supported", enrolment, name, i, item)
 				return
 			}
 			strs = append(strs, s)
 		}
 		if len(strs) > 0 {
-			writeMultiString(b, name, strs)
+			e.writeMultiString(name, strs)
 		}
+	default:
+		e.fail("enrolments[%q].settings[%q]: cannot represent %T in registry; only strings and string lists are supported", enrolment, name, value)
 	}
-}
-
-func writeKey(b *strings.Builder, path string) {
-	fmt.Fprintf(b, "[%s]\r\n", path)
 }
 
 // writeString emits a REG_SZ value. Plain ASCII without control characters
 // is emitted in quoted form; anything else falls through to hex(1) so that
 // templates with embedded newlines round-trip correctly.
-func writeString(b *strings.Builder, name, value string) {
+func (e *emitter) writeString(name, value string) {
 	if value == "" {
 		return
 	}
-	if needsHex(value) {
-		writeHexValue(b, name, 1, utf16Bytes([]string{value}))
+	if err := validateValueName(name); err != nil {
+		e.fail("%w", err)
 		return
 	}
-	fmt.Fprintf(b, "\"%s\"=%s\r\n", name, quoteREGSZ(value))
+	if needsHex(value) {
+		e.writeHexValue(name, 1, utf16StringBytes(value))
+		return
+	}
+	fmt.Fprintf(&e.b, "%s=%s\r\n", quoteREGName(name), quoteREGSZ(value))
 }
 
-func writeBool(b *strings.Builder, name string, value bool) {
+func (e *emitter) writeBool(name string, value bool) {
+	if err := validateValueName(name); err != nil {
+		e.fail("%w", err)
+		return
+	}
 	v := uint32(0)
 	if value {
 		v = 1
 	}
-	fmt.Fprintf(b, "\"%s\"=dword:%08x\r\n", name, v)
+	fmt.Fprintf(&e.b, "%s=dword:%08x\r\n", quoteREGName(name), v)
 }
 
-func writeMultiString(b *strings.Builder, name string, values []string) {
-	writeHexValue(b, name, 7, utf16Bytes(values))
-}
-
-// utf16Bytes encodes one or more strings as a contiguous UTF-16LE byte
-// sequence terminated as expected by the corresponding registry type:
-//
-//   - REG_SZ (single string): trailing NUL.
-//   - REG_MULTI_SZ (slice of strings): each string NUL-terminated, plus
-//     a final NUL terminator on the empty trailing string.
-func utf16Bytes(values []string) []byte {
-	var runes []uint16
-	for _, s := range values {
-		runes = append(runes, utf16.Encode([]rune(s))...)
-		runes = append(runes, 0)
+func (e *emitter) writeMultiString(name string, values []string) {
+	if err := validateValueName(name); err != nil {
+		e.fail("%w", err)
+		return
 	}
-	if len(values) > 1 {
-		runes = append(runes, 0)
-	}
-	out := make([]byte, 2*len(runes))
-	for i, r := range runes {
-		binary.LittleEndian.PutUint16(out[2*i:], r)
-	}
-	return out
+	e.writeHexValue(name, 7, utf16MultiStringBytes(values))
 }
 
 // writeHexValue emits a hex(<kind>):... value, wrapping at maxLineLen
 // using the standard backslash continuation that regedit.exe produces.
-func writeHexValue(b *strings.Builder, name string, kind int, data []byte) {
-	head := fmt.Sprintf("\"%s\"=hex(%d):", name, kind)
+// Continuation lines are prefixed with two spaces; that indent is included
+// in the running length so emitted lines do not exceed maxLineLen.
+func (e *emitter) writeHexValue(name string, kind int, data []byte) {
+	head := fmt.Sprintf("%s=hex(%d):", quoteREGName(name), kind)
 	cur := head
 	for i, by := range data {
 		token := fmt.Sprintf("%02x", by)
@@ -245,23 +266,82 @@ func writeHexValue(b *strings.Builder, name string, kind int, data []byte) {
 		if i == 0 {
 			sep = ""
 		}
-		// Reserve one column for the trailing backslash on continuation.
-		if len(cur)+len(sep)+len(token) > maxLineLen-1 {
-			b.WriteString(cur + sep + "\\\r\n  ")
-			cur = token
+		// Reserve two columns for the trailing ",\\" on a continuation line.
+		if len(cur)+len(sep)+len(token) > maxLineLen-2 {
+			e.b.WriteString(cur + sep + "\\\r\n")
+			cur = "  " + token
 			continue
 		}
 		cur += sep + token
 	}
-	b.WriteString(cur + "\r\n")
+	e.b.WriteString(cur + "\r\n")
+}
+
+// utf16StringBytes encodes a single string as UTF-16LE bytes terminated
+// by a single NUL (0x00 0x00).
+func utf16StringBytes(s string) []byte {
+	runes := utf16.Encode([]rune(s))
+	runes = append(runes, 0)
+	return runesToLE(runes)
+}
+
+// utf16MultiStringBytes encodes a REG_MULTI_SZ as a contiguous UTF-16LE
+// byte sequence: each string NUL-terminated, plus a final NUL terminator
+// (the empty trailing string) when the slice is non-empty. An empty slice
+// produces a single NUL pair, matching how regedit.exe emits an empty
+// REG_MULTI_SZ.
+func utf16MultiStringBytes(values []string) []byte {
+	var runes []uint16
+	for _, s := range values {
+		runes = append(runes, utf16.Encode([]rune(s))...)
+		runes = append(runes, 0)
+	}
+	runes = append(runes, 0)
+	return runesToLE(runes)
+}
+
+func runesToLE(runes []uint16) []byte {
+	out := make([]byte, 2*len(runes))
+	for i, r := range runes {
+		binary.LittleEndian.PutUint16(out[2*i:], r)
+	}
+	return out
 }
 
 // quoteREGSZ wraps s in double quotes and escapes the only two characters
 // that have special meaning inside a quoted REG_SZ value.
 func quoteREGSZ(s string) string {
+	return `"` + escapeREGString(s) + `"`
+}
+
+// quoteREGName quotes a value name with the same escape rules as REG_SZ
+// values. Value names accepted by Windows are very permissive; the rest
+// of the renderer guards against unrepresentable cases via
+// validateValueName before calling here.
+func quoteREGName(name string) string {
+	return `"` + escapeREGString(name) + `"`
+}
+
+func escapeREGString(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
+	return s
+}
+
+// validateValueName rejects names containing characters that cannot be
+// safely represented inside a quoted .reg value name. The .reg format
+// has no escape mechanism for control characters or NUL inside quoted
+// strings, so we error out rather than silently corrupt the output.
+func validateValueName(name string) error {
+	if name == "" {
+		return fmt.Errorf("registry value name must not be empty")
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7F {
+			return fmt.Errorf("registry value name %q contains control character U+%04X", name, r)
+		}
+	}
+	return nil
 }
 
 // needsHex reports whether s contains characters that cannot appear in a

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -271,22 +271,34 @@ func (e *emitter) writeMultiString(name string, values []string) {
 // using the standard backslash continuation that regedit.exe produces.
 // Continuation lines are prefixed with two spaces; that indent is included
 // in the running length so emitted lines do not exceed maxLineLen.
+//
+// The first byte is always emitted on the same line as the head so we never
+// produce a degenerate first line of just `<head>\` with no payload byte.
+// If the head plus first byte cannot fit (excluding any later wrap budget),
+// generation fails with an explicit error rather than emitting malformed
+// output.
 func (e *emitter) writeHexValue(name string, kind int, data []byte) {
 	head := fmt.Sprintf("%s=hex(%d):", quoteREGName(name), kind)
-	cur := head
-	for i, by := range data {
+	if len(data) == 0 {
+		e.b.WriteString(head + "\r\n")
+		return
+	}
+	firstToken := fmt.Sprintf("%02x", data[0])
+	// Reserve two columns for the trailing ",\\" if a continuation is needed.
+	if len(head)+len(firstToken) > maxLineLen-2 {
+		e.fail("registry value name %q is too long to encode as hex(%d) within %d columns", name, kind, maxLineLen)
+		return
+	}
+	cur := head + firstToken
+	for _, by := range data[1:] {
 		token := fmt.Sprintf("%02x", by)
-		sep := ","
-		if i == 0 {
-			sep = ""
-		}
 		// Reserve two columns for the trailing ",\\" on a continuation line.
-		if len(cur)+len(sep)+len(token) > maxLineLen-2 {
-			e.b.WriteString(cur + sep + "\\\r\n")
+		if len(cur)+1+len(token) > maxLineLen-2 {
+			e.b.WriteString(cur + ",\\\r\n")
 			cur = "  " + token
 			continue
 		}
-		cur += sep + token
+		cur += "," + token
 	}
 	e.b.WriteString(cur + "\r\n")
 }

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -8,13 +8,22 @@ import (
 	"github.com/goodtune/dotvault/internal/config"
 )
 
+func mustGenerate(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	return got
+}
+
 func TestGenerateMinimal(t *testing.T) {
 	cfg := &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
 		Sync:  config.SyncConfig{RawInterval: "15m"},
 	}
 
-	got := GenerateText(cfg)
+	got := mustGenerate(t, cfg)
 
 	wantContains := []string{
 		"Windows Registry Editor Version 5.00\r\n",
@@ -55,7 +64,7 @@ func TestGenerateRulesAndOAuth(t *testing.T) {
 		},
 	}
 
-	got := GenerateText(cfg)
+	got := mustGenerate(t, cfg)
 
 	wantContains := []string{
 		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules]\r\n",
@@ -94,7 +103,7 @@ func TestGenerateMultilineTemplate(t *testing.T) {
 		},
 	}
 
-	got := GenerateText(cfg)
+	got := mustGenerate(t, cfg)
 
 	if !strings.Contains(got, "\"TargetTemplate\"=hex(1):") {
 		t.Errorf("multi-line template should be emitted as hex(1):\n%s", got)
@@ -130,7 +139,7 @@ func TestGenerateEnrolments(t *testing.T) {
 		},
 	}
 
-	got := GenerateText(cfg)
+	got := mustGenerate(t, cfg)
 
 	wantContains := []string{
 		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments]\r\n",
@@ -154,6 +163,82 @@ func TestGenerateEnrolments(t *testing.T) {
 	sshIdx := strings.Index(got, `\Enrolments\ssh]`)
 	if ghIdx == -1 || sshIdx == -1 || ghIdx > sshIdx {
 		t.Errorf("expected gh before ssh in sorted output; gh=%d ssh=%d", ghIdx, sshIdx)
+	}
+}
+
+func TestGenerateUnsupportedSettingTypeErrors(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"port": 22, // ints are not representable
+				},
+			},
+		},
+	}
+	_, err := GenerateText(cfg)
+	if err == nil {
+		t.Fatalf("expected error for unsupported setting type")
+	}
+	if !strings.Contains(err.Error(), "port") || !strings.Contains(err.Error(), "int") {
+		t.Errorf("error should mention the offending setting and type; got: %v", err)
+	}
+}
+
+func TestGenerateMixedListErrors(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"scopes": []any{"repo", 42}, // mixed list
+				},
+			},
+		},
+	}
+	_, err := GenerateText(cfg)
+	if err == nil {
+		t.Fatalf("expected error for mixed-type list")
+	}
+}
+
+func TestGenerateRejectsControlCharsInName(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"bad\nname": "value",
+				},
+			},
+		},
+	}
+	_, err := GenerateText(cfg)
+	if err == nil {
+		t.Fatalf("expected error for control char in setting name")
+	}
+}
+
+func TestGenerateEscapesQuoteAndBackslashInName(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					`weird"name\path`: "value",
+				},
+			},
+		},
+	}
+	got := mustGenerate(t, cfg)
+	// Both " and \ in the name must be backslash-escaped on the wire.
+	if !strings.Contains(got, `"weird\"name\\path"="value"`) {
+		t.Errorf("setting name not escaped correctly; got:\n%s", got)
 	}
 }
 
@@ -193,21 +278,40 @@ func TestNeedsHex(t *testing.T) {
 	}
 }
 
-func TestUTF16BytesSingle(t *testing.T) {
-	// "A" -> 41,00 plus NUL terminator 00,00
-	got := utf16Bytes([]string{"A"})
+func TestUTF16StringBytes(t *testing.T) {
+	// "A" -> 41,00 plus NUL terminator 00,00.
+	got := utf16StringBytes("A")
 	want := []byte{0x41, 0x00, 0x00, 0x00}
 	if !bytes.Equal(got, want) {
-		t.Errorf("utf16Bytes([\"A\"]) = % x, want % x", got, want)
+		t.Errorf("utf16StringBytes(\"A\") = % x, want % x", got, want)
 	}
 }
 
-func TestUTF16BytesMulti(t *testing.T) {
-	// ["A", "B"] -> 41,00,00,00,42,00,00,00 plus final terminator 00,00
-	got := utf16Bytes([]string{"A", "B"})
+func TestUTF16MultiStringBytesSingle(t *testing.T) {
+	// REG_MULTI_SZ for ["A"]: "A"\0\0
+	// As UTF-16LE bytes: 41,00,00,00,00,00 (single string + double-NUL terminator)
+	got := utf16MultiStringBytes([]string{"A"})
+	want := []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("utf16MultiStringBytes([\"A\"]) = % x, want % x", got, want)
+	}
+}
+
+func TestUTF16MultiStringBytesMulti(t *testing.T) {
+	// ["A", "B"] -> 41,00,00,00,42,00,00,00,00,00
+	got := utf16MultiStringBytes([]string{"A", "B"})
 	want := []byte{0x41, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00}
 	if !bytes.Equal(got, want) {
-		t.Errorf("utf16Bytes = % x, want % x", got, want)
+		t.Errorf("utf16MultiStringBytes = % x, want % x", got, want)
+	}
+}
+
+func TestUTF16MultiStringBytesEmpty(t *testing.T) {
+	// Empty MULTI_SZ is just the trailing NUL pair.
+	got := utf16MultiStringBytes(nil)
+	want := []byte{0x00, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("utf16MultiStringBytes(nil) = % x, want % x", got, want)
 	}
 }
 
@@ -224,7 +328,10 @@ func TestGenerateProducesUTF16LEWithBOM(t *testing.T) {
 	cfg := &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
 	}
-	got := Generate(cfg)
+	got, err := Generate(cfg)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
 	if len(got) < 2 || got[0] != 0xFF || got[1] != 0xFE {
 		t.Errorf("Generate output missing UTF-16LE BOM; first bytes = % x", got[:min(8, len(got))])
 	}
@@ -235,7 +342,7 @@ func TestGenerateProducesUTF16LEWithBOM(t *testing.T) {
 }
 
 func TestHexLineWrapping(t *testing.T) {
-	// Build a value long enough to force at least one continuation.
+	// Build a value long enough to force multiple continuations.
 	value := strings.Repeat("a", 200)
 	cfg := &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
@@ -251,15 +358,16 @@ func TestHexLineWrapping(t *testing.T) {
 			},
 		},
 	}
-	got := GenerateText(cfg)
+	got := mustGenerate(t, cfg)
 
 	if !strings.Contains(got, ",\\\r\n  ") {
 		t.Errorf("expected backslash continuation in wrapped hex value; got:\n%s", got)
 	}
-	// Each non-last continuation line should end with ",\".
+	// Now that wrapping accounts for the two-space continuation indent,
+	// no emitted line should exceed maxLineLen characters.
 	for _, line := range strings.Split(got, "\r\n") {
-		if len(line) > maxLineLen+5 { // small slack for the leading "  "
-			t.Errorf("line exceeds wrap limit (%d): %q", len(line), line)
+		if len(line) > maxLineLen {
+			t.Errorf("line exceeds wrap limit (%d > %d): %q", len(line), maxLineLen, line)
 		}
 	}
 }

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -1,0 +1,265 @@
+package regfile
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/goodtune/dotvault/internal/config"
+)
+
+func TestGenerateMinimal(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Sync:  config.SyncConfig{RawInterval: "15m"},
+	}
+
+	got := GenerateText(cfg)
+
+	wantContains := []string{
+		"Windows Registry Editor Version 5.00\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Vault]\r\n",
+		"\"Address\"=\"https://vault.example.com:8200\"\r\n",
+		"\"DisableTokenRenewal\"=dword:00000000\r\n",
+		"\"TLSSkipVerify\"=dword:00000000\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Sync]\r\n",
+		"\"Interval\"=\"15m\"\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Web]\r\n",
+		"\"Enabled\"=dword:00000000\r\n",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateRulesAndOAuth(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:        "gh",
+				Description: "GitHub host config",
+				VaultKey:    "gh",
+				Target: config.Target{
+					Path:   "~/.config/gh/hosts.yml",
+					Format: "yaml",
+				},
+				OAuth: &config.OAuthConfig{
+					Provider: "github",
+					Scopes:   []string{"repo", "read:org"},
+				},
+			},
+		},
+	}
+
+	got := GenerateText(cfg)
+
+	wantContains := []string{
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\gh]\r\n",
+		"\"Description\"=\"GitHub host config\"\r\n",
+		"\"TargetFormat\"=\"yaml\"\r\n",
+		"\"TargetPath\"=\"~/.config/gh/hosts.yml\"\r\n",
+		"\"VaultKey\"=\"gh\"\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\gh\\OAuth]\r\n",
+		"\"Provider\"=\"github\"\r\n",
+		// REG_MULTI_SZ for ["repo", "read:org"]: "repo"\0"read:org"\0\0
+		// As UTF-16LE bytes the value starts with the prefix below; the
+		// rest may be on a continuation line because of line wrapping.
+		"\"Scopes\"=hex(7):72,00,65,00,70,00,6f,00,00,00,",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateMultilineTemplate(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:     "gh",
+				VaultKey: "gh",
+				Target: config.Target{
+					Path:     "~/.config/gh/hosts.yml",
+					Format:   "yaml",
+					Template: "github.com:\n  oauth_token: \"x\"\n",
+				},
+			},
+		},
+	}
+
+	got := GenerateText(cfg)
+
+	if !strings.Contains(got, "\"TargetTemplate\"=hex(1):") {
+		t.Errorf("multi-line template should be emitted as hex(1):\n%s", got)
+	}
+	// First two characters of the template are 'g' (0x67) and 'i' (0x69)
+	// in UTF-16LE: 67,00,69,00.
+	if !strings.Contains(got, "67,00,69,00") {
+		t.Errorf("expected UTF-16LE bytes for template start; got:\n%s", got)
+	}
+	// Newline (0x0A) should appear in the hex bytes.
+	if !strings.Contains(got, "0a,00") {
+		t.Errorf("expected UTF-16LE LF byte (0a,00); got:\n%s", got)
+	}
+}
+
+func TestGenerateEnrolments(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"host":   "github.com",
+					"scopes": []any{"repo", "gist"},
+				},
+			},
+			"ssh": {
+				Engine: "ssh",
+				Settings: map[string]any{
+					"passphrase": "recommended",
+				},
+			},
+		},
+	}
+
+	got := GenerateText(cfg)
+
+	wantContains := []string{
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh]\r\n",
+		"\"Engine\"=\"github\"\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh\\Settings]\r\n",
+		"\"host\"=\"github.com\"\r\n",
+		"\"scopes\"=hex(7):",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\ssh]\r\n",
+		"\"Engine\"=\"ssh\"\r\n",
+		"\"passphrase\"=\"recommended\"\r\n",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+
+	// gh should appear before ssh (sorted output).
+	ghIdx := strings.Index(got, `\Enrolments\gh]`)
+	sshIdx := strings.Index(got, `\Enrolments\ssh]`)
+	if ghIdx == -1 || sshIdx == -1 || ghIdx > sshIdx {
+		t.Errorf("expected gh before ssh in sorted output; gh=%d ssh=%d", ghIdx, sshIdx)
+	}
+}
+
+func TestQuoteREGSZ(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{`hello`, `"hello"`},
+		{`with"quote`, `"with\"quote"`},
+		{`back\slash`, `"back\\slash"`},
+		{`C:\Program Files\foo`, `"C:\\Program Files\\foo"`},
+	}
+	for _, tt := range tests {
+		got := quoteREGSZ(tt.in)
+		if got != tt.want {
+			t.Errorf("quoteREGSZ(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestNeedsHex(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"hello", false},
+		{"with\nnewline", true},
+		{"with\ttab", true},
+		{"unicode é", true},
+		{"all printable !@#$%^&*()", false},
+	}
+	for _, tt := range tests {
+		got := needsHex(tt.in)
+		if got != tt.want {
+			t.Errorf("needsHex(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestUTF16BytesSingle(t *testing.T) {
+	// "A" -> 41,00 plus NUL terminator 00,00
+	got := utf16Bytes([]string{"A"})
+	want := []byte{0x41, 0x00, 0x00, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("utf16Bytes([\"A\"]) = % x, want % x", got, want)
+	}
+}
+
+func TestUTF16BytesMulti(t *testing.T) {
+	// ["A", "B"] -> 41,00,00,00,42,00,00,00 plus final terminator 00,00
+	got := utf16Bytes([]string{"A", "B"})
+	want := []byte{0x41, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("utf16Bytes = % x, want % x", got, want)
+	}
+}
+
+func TestEncodeUTF16LE(t *testing.T) {
+	got := encodeUTF16LE("A")
+	// BOM + A in UTF-16LE
+	want := []byte{0xFF, 0xFE, 0x41, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("encodeUTF16LE = % x, want % x", got, want)
+	}
+}
+
+func TestGenerateProducesUTF16LEWithBOM(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+	}
+	got := Generate(cfg)
+	if len(got) < 2 || got[0] != 0xFF || got[1] != 0xFE {
+		t.Errorf("Generate output missing UTF-16LE BOM; first bytes = % x", got[:min(8, len(got))])
+	}
+	// First payload character is 'W' from "Windows Registry...".
+	if len(got) < 4 || got[2] != 'W' || got[3] != 0x00 {
+		t.Errorf("Generate output not UTF-16LE encoded; bytes 2-3 = % x", got[2:4])
+	}
+}
+
+func TestHexLineWrapping(t *testing.T) {
+	// Build a value long enough to force at least one continuation.
+	value := strings.Repeat("a", 200)
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:     "r",
+				VaultKey: "k",
+				Target: config.Target{
+					Path:     "/tmp/x",
+					Format:   "text",
+					Template: "\n" + value, // leading newline forces hex(1)
+				},
+			},
+		},
+	}
+	got := GenerateText(cfg)
+
+	if !strings.Contains(got, ",\\\r\n  ") {
+		t.Errorf("expected backslash continuation in wrapped hex value; got:\n%s", got)
+	}
+	// Each non-last continuation line should end with ",\".
+	for _, line := range strings.Split(got, "\r\n") {
+		if len(line) > maxLineLen+5 { // small slack for the leading "  "
+			t.Errorf("line exceeds wrap limit (%d): %q", len(line), line)
+		}
+	}
+}

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -352,6 +352,63 @@ func TestRejectsNonASCIIValueName(t *testing.T) {
 	}
 }
 
+func TestHexValueLongHeadStillEmitsByteOnFirstLine(t *testing.T) {
+	// Build a setting name long enough that head + first byte sits well
+	// past 50 chars but still fits within the wrap budget. The first
+	// emitted line must contain at least one hex byte rather than a bare
+	// `head\` with no payload.
+	longName := strings.Repeat("a", 50) // legal printable ASCII
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					longName: "value\nwith newline", // forces hex(1)
+				},
+			},
+		},
+	}
+	got := mustGenerate(t, cfg)
+	// Find the first hex line for this setting and confirm it contains
+	// at least one byte token before any backslash continuation.
+	prefix := `"` + longName + `"=hex(1):`
+	idx := strings.Index(got, prefix)
+	if idx == -1 {
+		t.Fatalf("hex value not present in output:\n%s", got)
+	}
+	firstLineEnd := strings.Index(got[idx:], "\r\n")
+	if firstLineEnd == -1 {
+		t.Fatalf("no CRLF after hex value start")
+	}
+	firstLine := got[idx : idx+firstLineEnd]
+	// The body after `hex(1):` must contain at least one two-hex-digit byte.
+	body := strings.TrimSuffix(strings.TrimPrefix(firstLine, prefix), `\`)
+	if len(body) < 2 {
+		t.Errorf("first hex line has no payload byte: %q", firstLine)
+	}
+}
+
+func TestHexValueRejectsImpossiblyLongName(t *testing.T) {
+	// A name so long that head + first byte cannot fit within maxLineLen
+	// must error rather than produce malformed output.
+	tooLong := strings.Repeat("a", 200)
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					tooLong: "value\nwith newline",
+				},
+			},
+		},
+	}
+	if _, err := GenerateText(cfg); err == nil {
+		t.Fatalf("expected error for impossibly long value name")
+	}
+}
+
 func TestQuoteREGSZ(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -19,10 +19,13 @@ func mustGenerate(t *testing.T, cfg *config.Config) string {
 }
 
 // validBaseConfig returns a minimally valid Config — one that
-// `config.(*Config).validate()` would accept — for tests that only
-// exercise renderer-level behavior and don't otherwise care about rule
-// content. This keeps tests aligned with the real-world inputs the CLI
-// passes to Generate*, since callers always come through config.Load.
+// `config.(*Config).validate()` would accept — for tests that want a
+// realistic baseline matching what the CLI passes to Generate*.
+//
+// regfile.Generate* itself does not require validation; many tests in
+// this file deliberately construct partial configs to exercise specific
+// renderer paths in isolation. End-to-end coverage for the
+// load-and-render path lives in TestGenerateOnLoadedConfig.
 func validBaseConfig() *config.Config {
 	return &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
@@ -262,6 +265,44 @@ func TestGenerateEscapesQuoteAndBackslashInName(t *testing.T) {
 	// Both " and \ in the name must be backslash-escaped on the wire.
 	if !strings.Contains(got, `"weird\"name\\path"="value"`) {
 		t.Errorf("setting name not escaped correctly; got:\n%s", got)
+	}
+}
+
+func TestSyncIntervalDefaultedYAMLEmitsEmpty(t *testing.T) {
+	// When the YAML omits sync.interval, config.Load fills Interval with
+	// the 15m default but leaves RawInterval empty. Exporting must NOT
+	// fall back to time.Duration.String() ("15m0s"), which would pollute
+	// diffs and round-trip through registry/validate to the same default
+	// anyway. The export emits an empty REG_SZ; the registry-side load
+	// then re-applies the default during validate.
+	yaml := `vault:
+  address: "https://vault.example.com:8200"
+rules:
+  - name: r
+    vault_key: r
+    target:
+      path: /tmp/r
+      format: text
+`
+	dir := t.TempDir()
+	yamlPath := dir + "/config.yaml"
+	if err := os.WriteFile(yamlPath, []byte(yaml), 0600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	cfg, err := config.Load(yamlPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	if strings.Contains(got, "15m0s") {
+		t.Errorf("output should not contain Go-format duration \"15m0s\":\n%s", got)
+	}
+	if !strings.Contains(got, `"Interval"=""`) {
+		t.Errorf("expected empty REG_SZ for unset interval; got:\n%s", got)
 	}
 }
 

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -2,6 +2,7 @@ package regfile
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -17,11 +18,33 @@ func mustGenerate(t *testing.T, cfg *config.Config) string {
 	return got
 }
 
-func TestGenerateMinimal(t *testing.T) {
-	cfg := &config.Config{
+// validBaseConfig returns a minimally valid Config — one that
+// `config.(*Config).validate()` would accept — for tests that only
+// exercise renderer-level behavior and don't otherwise care about rule
+// content. This keeps tests aligned with the real-world inputs the CLI
+// passes to Generate*, since callers always come through config.Load.
+func validBaseConfig() *config.Config {
+	return &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
-		Sync:  config.SyncConfig{RawInterval: "15m"},
+		Rules: []config.Rule{
+			{
+				Name:     "minimal",
+				VaultKey: "minimal",
+				Target: config.Target{
+					Path:   "~/.dotvault/minimal",
+					Format: "text",
+				},
+			},
+		},
 	}
+}
+
+func TestGenerateMinimal(t *testing.T) {
+	// Use a config that would actually pass config.(*Config).validate().
+	// The CLI always feeds Generate* a validated config, so tests should
+	// mirror that.
+	cfg := validBaseConfig()
+	cfg.Sync = config.SyncConfig{RawInterval: "15m"}
 
 	got := mustGenerate(t, cfg)
 
@@ -602,6 +625,75 @@ func TestGenerateProducesUTF16LEWithBOM(t *testing.T) {
 	// First payload character is 'W' from "Windows Registry...".
 	if len(got) < 4 || got[2] != 'W' || got[3] != 0x00 {
 		t.Errorf("Generate output not UTF-16LE encoded; bytes 2-3 = % x", got[2:4])
+	}
+}
+
+func TestGenerateOnLoadedConfig(t *testing.T) {
+	// Round-trip: load a YAML through config.Load (which runs validate)
+	// and confirm Generate accepts the result. This exercises the actual
+	// path the CLI uses.
+	yamlBody := `vault:
+  address: "https://vault.example.com:8200"
+  auth_method: "oidc"
+sync:
+  interval: "15m"
+rules:
+  - name: gh
+    vault_key: gh
+    target:
+      path: "~/.config/gh/hosts.yml"
+      format: yaml
+      template: |
+        github.com:
+          oauth_token: "{{ .oauth_token }}"
+enrolments:
+  gh:
+    engine: github
+`
+	dir := t.TempDir()
+	yamlPath := dir + "/config.yaml"
+	if err := os.WriteFile(yamlPath, []byte(yamlBody), 0600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	cfg, err := config.Load(yamlPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	for _, want := range []string{
+		"Windows Registry Editor Version 5.00",
+		`\Rules\gh]`,
+		`"VaultKey"="gh"`,
+		`\Enrolments\gh]`,
+		`"Engine"="github"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("loaded-config output missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestHexValueAcceptsLongUnicodeName(t *testing.T) {
+	// A name made entirely of multi-byte runes that exceeds maxLineLen
+	// when measured in bytes but fits when measured in runes. Without
+	// rune-aware length tracking, writeHexValue would (incorrectly)
+	// reject this as "too long to encode within 76 columns".
+	longUnicode := strings.Repeat("é", 40) // 40 runes, 80 UTF-8 bytes
+	cfg := validBaseConfig()
+	cfg.Enrolments = map[string]config.Enrolment{
+		"gh": {
+			Engine: "github",
+			Settings: map[string]any{
+				longUnicode: "value\nforces hex(1)",
+			},
+		},
+	}
+	if _, err := GenerateText(cfg); err != nil {
+		t.Errorf("Unicode name should be accepted with rune-length tracking: %v", err)
 	}
 }
 

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -382,6 +382,48 @@ func TestAcceptsUnicodeValueName(t *testing.T) {
 	}
 }
 
+func TestRejectsNULInStringValue(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"key": "before\x00after",
+				},
+			},
+		},
+	}
+	_, err := GenerateText(cfg)
+	if err == nil {
+		t.Fatal("expected error for embedded NUL in string value")
+	}
+	if !strings.Contains(err.Error(), "NUL") {
+		t.Errorf("error should mention NUL; got: %v", err)
+	}
+}
+
+func TestRejectsNULInMultiStringElement(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:     "gh",
+				VaultKey: "k",
+				Target:   config.Target{Path: "/tmp/x", Format: "text"},
+				OAuth: &config.OAuthConfig{
+					Provider: "github",
+					Scopes:   []string{"ok", "bad\x00scope"},
+				},
+			},
+		},
+	}
+	_, err := GenerateText(cfg)
+	if err == nil {
+		t.Fatal("expected error for embedded NUL in multi-string element")
+	}
+}
+
 func TestEmptyStringEmittedExplicitly(t *testing.T) {
 	cfg := &config.Config{
 		Vault: config.VaultConfig{

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -304,7 +304,10 @@ func TestEmptyEnrolmentListSettingEmitsEmptyMultiSZ(t *testing.T) {
 }
 
 func TestRejectsBadRuleName(t *testing.T) {
-	for _, bad := range []string{`with\backslash`, `with]bracket`, `with[bracket`, "with\nnewline", "with é"} {
+	// Names containing path/structural delimiters or control chars must be
+	// rejected. Unicode names are NOT in this list because they're allowed
+	// (UTF-16LE output represents them faithfully).
+	for _, bad := range []string{`with\backslash`, `with]bracket`, `with[bracket`, "with\nnewline"} {
 		cfg := &config.Config{
 			Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
 			Rules: []config.Rule{
@@ -318,6 +321,26 @@ func TestRejectsBadRuleName(t *testing.T) {
 		if _, err := GenerateText(cfg); err == nil {
 			t.Errorf("expected error for rule name %q", bad)
 		}
+	}
+}
+
+func TestAcceptsUnicodeRuleName(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:     "café",
+				VaultKey: "k",
+				Target:   config.Target{Path: "/tmp/x", Format: "text"},
+			},
+		},
+	}
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("Unicode rule name should be accepted: %v", err)
+	}
+	if !strings.Contains(got, `\Rules\café]`) {
+		t.Errorf("Unicode rule name not present in key path:\n%s", got)
 	}
 }
 
@@ -335,7 +358,10 @@ func TestRejectsBadEnrolmentName(t *testing.T) {
 	}
 }
 
-func TestRejectsNonASCIIValueName(t *testing.T) {
+func TestAcceptsUnicodeValueName(t *testing.T) {
+	// Unicode characters in value names are allowed: the default UTF-16LE
+	// output represents them faithfully and the --ascii output stays
+	// valid UTF-8.
 	cfg := &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
 		Enrolments: map[string]config.Enrolment{
@@ -347,8 +373,37 @@ func TestRejectsNonASCIIValueName(t *testing.T) {
 			},
 		},
 	}
-	if _, err := GenerateText(cfg); err == nil {
-		t.Fatalf("expected error for non-ASCII setting name")
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("Unicode value name should be accepted: %v", err)
+	}
+	if !strings.Contains(got, `"naïve"="value"`) {
+		t.Errorf("Unicode value name not present:\n%s", got)
+	}
+}
+
+func TestEmptyStringEmittedExplicitly(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{
+			Address: "https://vault.example.com:8200",
+			// CACert/AuthMethod/etc. are empty — should be emitted as ""
+			// so re-import clears any previously-set value.
+		},
+		Sync: config.SyncConfig{RawInterval: "15m"},
+	}
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	for _, want := range []string{
+		`"AuthMethod"=""`,
+		`"AuthMount"=""`,
+		`"AuthRole"=""`,
+		`"CACert"=""`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output (clearing semantics):\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -242,6 +242,116 @@ func TestGenerateEscapesQuoteAndBackslashInName(t *testing.T) {
 	}
 }
 
+func TestEmptyOAuthScopesEmitsEmptyMultiSZ(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:     "gh",
+				VaultKey: "gh",
+				Target:   config.Target{Path: "~/x", Format: "yaml"},
+				OAuth: &config.OAuthConfig{
+					Provider: "github",
+					Scopes:   []string{}, // explicit empty list
+				},
+			},
+		},
+	}
+	got := mustGenerate(t, cfg)
+	// Empty REG_MULTI_SZ is just the trailing NUL pair: 00,00.
+	if !strings.Contains(got, `"Scopes"=hex(7):00,00`) {
+		t.Errorf("expected empty REG_MULTI_SZ for empty scopes; got:\n%s", got)
+	}
+}
+
+func TestNilOAuthScopesOmitted(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Rules: []config.Rule{
+			{
+				Name:     "gh",
+				VaultKey: "gh",
+				Target:   config.Target{Path: "~/x", Format: "yaml"},
+				OAuth: &config.OAuthConfig{
+					Provider: "github",
+					// Scopes is nil — key absent in YAML, omit from output
+				},
+			},
+		},
+	}
+	got := mustGenerate(t, cfg)
+	if strings.Contains(got, `"Scopes"=`) {
+		t.Errorf("nil scopes should be omitted from output; got:\n%s", got)
+	}
+}
+
+func TestEmptyEnrolmentListSettingEmitsEmptyMultiSZ(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"scopes": []any{}, // explicit empty list from YAML
+				},
+			},
+		},
+	}
+	got := mustGenerate(t, cfg)
+	if !strings.Contains(got, `"scopes"=hex(7):00,00`) {
+		t.Errorf("expected empty REG_MULTI_SZ for empty scopes setting; got:\n%s", got)
+	}
+}
+
+func TestRejectsBadRuleName(t *testing.T) {
+	for _, bad := range []string{`with\backslash`, `with]bracket`, `with[bracket`, "with\nnewline", "with é"} {
+		cfg := &config.Config{
+			Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+			Rules: []config.Rule{
+				{
+					Name:     bad,
+					VaultKey: "k",
+					Target:   config.Target{Path: "/tmp/x", Format: "text"},
+				},
+			},
+		}
+		if _, err := GenerateText(cfg); err == nil {
+			t.Errorf("expected error for rule name %q", bad)
+		}
+	}
+}
+
+func TestRejectsBadEnrolmentName(t *testing.T) {
+	for _, bad := range []string{`with\backslash`, `with]bracket`, "with\tcontrol"} {
+		cfg := &config.Config{
+			Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+			Enrolments: map[string]config.Enrolment{
+				bad: {Engine: "github"},
+			},
+		}
+		if _, err := GenerateText(cfg); err == nil {
+			t.Errorf("expected error for enrolment name %q", bad)
+		}
+	}
+}
+
+func TestRejectsNonASCIIValueName(t *testing.T) {
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+		Enrolments: map[string]config.Enrolment{
+			"gh": {
+				Engine: "github",
+				Settings: map[string]any{
+					"naïve": "value",
+				},
+			},
+		},
+	}
+	if _, err := GenerateText(cfg); err == nil {
+		t.Fatalf("expected error for non-ASCII setting name")
+	}
+}
+
 func TestQuoteREGSZ(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -265,6 +265,56 @@ func TestGenerateEscapesQuoteAndBackslashInName(t *testing.T) {
 	}
 }
 
+func TestRulesAndEnrolmentsAreDeletedBeforeRecreate(t *testing.T) {
+	// Re-importing an exported .reg should be idempotent: rules or
+	// enrolments removed from YAML must also disappear from the registry,
+	// so the export emits a deletion stanza for each dynamic subtree
+	// before the recreation block.
+	cfg := validBaseConfig()
+	cfg.Enrolments = map[string]config.Enrolment{
+		"gh": {Engine: "github"},
+	}
+	got := mustGenerate(t, cfg)
+
+	rulesDel := `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`
+	rulesKey := `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`
+	enrolDel := `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Enrolments]`
+	enrolKey := `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Enrolments]`
+
+	for _, want := range []string{rulesDel, rulesKey, enrolDel, enrolKey} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+	// Deletion must come before recreation so the .reg processor wipes
+	// the subtree first.
+	if strings.Index(got, rulesDel) > strings.Index(got, rulesKey) {
+		t.Errorf("Rules deletion stanza must precede recreation")
+	}
+	if strings.Index(got, enrolDel) > strings.Index(got, enrolKey) {
+		t.Errorf("Enrolments deletion stanza must precede recreation")
+	}
+}
+
+func TestEmptyRulesEmitsOnlyDeletion(t *testing.T) {
+	// A config with no rules should still emit `[-...\Rules]` so an
+	// import wipes any previously-defined rules.
+	cfg := &config.Config{
+		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},
+	}
+	got, err := GenerateText(cfg)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	if !strings.Contains(got, `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`) {
+		t.Errorf("expected Rules deletion stanza even with no rules:\n%s", got)
+	}
+	// And no recreation key for Rules (no rules to put under it).
+	if strings.Contains(got, `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`+"\r\n") {
+		t.Errorf("did not expect Rules recreation when no rules present:\n%s", got)
+	}
+}
+
 func TestEmptyOAuthScopesEmitsEmptyMultiSZ(t *testing.T) {
 	cfg := &config.Config{
 		Vault: config.VaultConfig{Address: "https://vault.example.com:8200"},

--- a/packaging/windows/dotvault.admx
+++ b/packaging/windows/dotvault.admx
@@ -16,8 +16,9 @@
   present, dotvault ignores file-based configuration entirely.
 
   Rules (sync rules) are complex multi-field objects that cannot be
-  fully expressed as ADMX policies. Configure rules via Group Policy
-  Preferences > Registry, targeting:
+  fully expressed as ADMX policies. Author them as a YAML config and
+  convert with `dotvault reg-export config.yaml -o dotvault.reg`, or
+  configure them by hand via Group Policy Preferences > Registry, targeting:
     SOFTWARE\Policies\dotvault\Rules\<rule-name>\VaultKey      (REG_SZ)
     SOFTWARE\Policies\dotvault\Rules\<rule-name>\TargetPath    (REG_SZ)
     SOFTWARE\Policies\dotvault\Rules\<rule-name>\TargetFormat  (REG_SZ)


### PR DESCRIPTION
## Summary

- New `dotvault reg-export <config.yaml>` subcommand that validates a YAML config (via the existing loader) and emits a Windows Registry `.reg` file targeting `HKLM\SOFTWARE\Policies\dotvault`. The config path may be supplied positionally, via the inherited `--config` flag, or fall back to the platform-specific system config path.
- Encoding: UTF-16LE with BOM by default (matches `regedit.exe`); `--ascii` switches to plain-text REGEDIT4-compatible output for diffing or piping. `--output <path>` writes the file at 0600 to match the convention used by other dotvault-managed files.
- Multi-line values such as Go templates round-trip through `hex(1):` (UTF-16LE bytes); OAuth scopes and list-valued enrolment settings round-trip through `hex(7):` (REG_MULTI_SZ).
- Idempotent export: the `Rules` and `Enrolments` subtrees are deleted before recreation so entries removed from YAML also disappear from the registry on re-import. Optional string fields are emitted as `""` when empty for the same reason — re-import clears stale values rather than leaving them in place.
- Validation: rejects embedded NUL bytes, control characters in key/value names, and unsupported setting types (e.g. ints in enrolment settings); accepts Unicode in rule, enrolment, and value names since UTF-16LE represents them faithfully.
- New `internal/regfile/` package with focused tests covering REG_SZ quoting, REG_DWORD, REG_MULTI_SZ, hex(1) for control chars, rune-aware line wrapping, idempotency stanzas, clearing semantics, and the UTF-16LE+BOM wire format.

## Motivation

Editing the Windows registry by hand is painful. Authors can now keep dotvault Group Policy configuration as YAML (version-controllable, easier to diff and review), then convert to `.reg` for deployment via regedit, GPP > Registry, or central-store roll-out. The export is designed to be idempotent so re-applying after edits won't leave orphaned rules or stale string values behind.

## Test plan

- [x] `go test ./...`
- [x] `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ./cmd/dotvault`
- [x] Hand-inspected output of `dotvault reg-export --ascii config.dev.yaml` (templates emitted as `hex(1)`, scopes as `hex(7)`, dwords for booleans, sorted rule/enrolment names, deletion stanzas before recreation)
- [x] Verified UTF-16LE BOM via `od -tx1` on default output
- [ ] Import the produced `.reg` on a Windows machine and confirm dotvault loads the policy as expected

https://claude.ai/code/session_01RcAZjhcd5BdurEPbkJaH9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcAZjhcd5BdurEPbkJaH9M)_