### PR TITLE
Skip IO prompts in headless mode and idle daemon until shutdown

### DIFF
--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -91,7 +91,7 @@ func setupLogging() {
 	opts := &slog.HandlerOptions{Level: level}
 
 	var handler slog.Handler
-	if isTerminal() {
+	if isStderrTerminal() {
 		handler = slog.NewTextHandler(os.Stderr, opts)
 	} else {
 		handler = slog.NewJSONHandler(os.Stderr, opts)
@@ -484,7 +484,9 @@ func authenticate(ctx context.Context, cfg *config.Config) (string, *vault.Clien
 	return username, vc, nil
 }
 
-func isTerminal() bool {
+// isStderrTerminal reports whether stderr is a character device, used to
+// pick the slog text vs JSON handler at startup.
+func isStderrTerminal() bool {
 	fi, err := os.Stderr.Stat()
 	if err != nil {
 		return false

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -223,6 +223,15 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 			if err := webServer.WaitForAuth(ctx); err != nil {
 				return fmt.Errorf("web-based authentication: %w", err)
 			}
+		} else if !isInteractive() {
+			// Headless: no web UI to drive auth and no terminal to prompt
+			// on. Don't crash and don't spam the logs trying to read from
+			// a closed stdin — stay up so an external interactive facility
+			// (e.g. a login profile that runs `dotvault sync`) can write
+			// the token, and a daemon restart will pick it up.
+			slog.Warn("no vault token available and no interactive facility (web UI disabled, stdin is not a terminal); daemon will idle until shutdown")
+			<-ctx.Done()
+			return nil
 		} else {
 			// Traditional auth flow (OIDC with ephemeral listener, LDAP
 			// prompt, or token file).
@@ -289,12 +298,22 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		case <-ctx.Done():
 			slog.Info("stopping enrolment wait due to shutdown")
 		}
+	} else if !isInteractive() {
+		// Headless CLI mode: no web UI, no terminal. Skip the enrolment
+		// wizard entirely — engines that prompt would either fail or hang
+		// without a TTY. The RefreshManager started above continues to
+		// rotate already-enrolled credentials, and config reloads still
+		// pick up changes once an interactive session completes the
+		// enrolment.
+		if len(cfg.Enrolments) > 0 {
+			slog.Info("skipping enrolment wizard: stdin is not a terminal and web UI is disabled")
+		}
 	} else {
-		// CLI mode: terminal-based wizard (unchanged).
+		// CLI mode: terminal-based wizard.
 		enrolIO := enrol.IO{
-			Out:     os.Stderr,
-			Browser: browser.OpenURL,
-			Log:     slog.Default(),
+			Out:      os.Stderr,
+			Browser:  browser.OpenURL,
+			Log:      slog.Default(),
 			Username: username,
 			PromptSecret: func(label string) (string, error) {
 				fd := int(os.Stdin.Fd())
@@ -471,4 +490,10 @@ func isTerminal() bool {
 		return false
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// isInteractive reports whether stdin is connected to a TTY, i.e. whether
+// the daemon can prompt the user for credentials, MFA passcodes, etc.
+func isInteractive() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -484,14 +484,10 @@ func authenticate(ctx context.Context, cfg *config.Config) (string, *vault.Clien
 	return username, vc, nil
 }
 
-// isStderrTerminal reports whether stderr is a character device, used to
+// isStderrTerminal reports whether stderr is connected to a TTY, used to
 // pick the slog text vs JSON handler at startup.
 func isStderrTerminal() bool {
-	fi, err := os.Stderr.Stat()
-	if err != nil {
-		return false
-	}
-	return fi.Mode()&os.ModeCharDevice != 0
+	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 // isInteractive reports whether stdin is connected to a TTY, i.e. whether

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -229,7 +229,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 			// a closed stdin — stay up so an external interactive facility
 			// (e.g. a login profile that runs `dotvault sync`) can write
 			// the token, and a daemon restart will pick it up.
-			slog.Warn("no vault token available and no interactive facility (web UI disabled, stdin is not a terminal); daemon will idle until shutdown")
+			slog.Warn("no vault token available and no interactive facility (web UI unavailable, stdin is not a terminal); daemon will idle until shutdown")
 			<-ctx.Done()
 			return nil
 		} else {
@@ -302,11 +302,11 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		// Headless CLI mode: no web UI, no terminal. Skip the enrolment
 		// wizard entirely — engines that prompt would either fail or hang
 		// without a TTY. The RefreshManager started above continues to
-		// rotate already-enrolled credentials, and config reloads still
-		// pick up changes once an interactive session completes the
-		// enrolment.
+		// rotate already-enrolled credentials, but enrolment/config
+		// changes are not reloaded in this path and require a daemon
+		// restart to take effect.
 		if len(cfg.Enrolments) > 0 {
-			slog.Info("skipping enrolment wizard: stdin is not a terminal and web UI is disabled")
+			slog.Info("skipping enrolment wizard: stdin is not a terminal and web UI is not running")
 		}
 	} else {
 		// CLI mode: terminal-based wizard.


### PR DESCRIPTION
## Summary

- When `web.enabled=false` and stdin is not a terminal, the daemon now treats itself as headless and skips every interactive IO path instead of erroring or hanging on a blocked read.
- If no vault token is available in headless mode, `runDaemon` logs a warning and idles on `ctx.Done()` so an external interactive facility (e.g. a login profile that runs `dotvault sync` from a TTY) can provision the token, after which a daemon restart picks it up.
- The CLI enrolment wizard is skipped entirely when headless. The `RefreshManager` is still started, so already-enrolled credentials continue to rotate.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — all package tests pass
- [ ] Manual: run `dotvault run` with web disabled, no `~/.vault-token`, and stdin redirected from `/dev/null`; verify the daemon logs the headless warning and stays alive until SIGTERM.
- [ ] Manual: run `dotvault run` from a TTY with web disabled and confirm OIDC/LDAP prompts still work as before.
