### PR TITLE
feat(windows): add system-tray icon for double-click daemon launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 dist/
-dotvault
+/dotvault
 internal/web/frontend/node_modules/
 site/
 .worktrees/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w -X main.version={{.Version}}
+      # Windows: build as GUI subsystem so double-click does not flash a
+      # console. CLI subcommands re-attach to the parent console at runtime.
+      - "{{ if eq .Os \"windows\" }}-H=windowsgui{{ end }}"
     targets:
       - linux_amd64
       - linux_arm64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ make build         # build for current platform
 make build-all     # cross-compile linux/darwin (amd64/arm64) and windows (amd64)
 ```
 
-All builds use `CGO_ENABLED=0` for static binaries. Version is injected via ldflags (`-X main.version=...`).
+All builds use `CGO_ENABLED=0` for static binaries. Version is injected via ldflags (`-X main.version=...`). The Windows build additionally passes `-H=windowsgui` so a double-clicked binary does not flash a console window; CLI subcommands re-attach to the parent console at startup (`cmd/dotvault/console_windows.go`).
 
 The web frontend lives in `internal/web/frontend/` (Preact + esbuild). After changing frontend code:
 
@@ -59,6 +59,7 @@ internal/
   enrol/                 Credential acquisition via OAuth device flow
   web/                   Web UI server (Preact SPA), auth endpoints, REST API
   perms/                 File permission checks (Unix mode bits, Windows DACL)
+  tray/                  Windows system-tray icon (no-op on other platforms)
 test/integration/        Integration tests against real Vault
 packaging/windows/       ADMX Group Policy template
 ```
@@ -124,6 +125,7 @@ Logging uses `log/slog` — text format when stderr is a TTY, JSON otherwise. Al
 6. Run enrolment check (wizard if any credentials missing in Vault)
 7. Start sync engine: initial sync, then hybrid event+poll loop
 8. Background goroutine reloads config on each tick for enrolment changes only
+9. On Windows, install a system-tray icon (`internal/tray/`) with Exit and (when web is enabled) "View web UI" entries; the tray owns the main goroutine because the Win32 message pump must run on a locked OS thread, while the sync loop moves to a goroutine. On non-Windows the same call simply blocks on ctx.
 
 Config reload via SIGHUP is **not implemented**. The daemon must be fully restarted to pick up config changes (except enrolment changes, which are detected on the polling interval).
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 VERSION := $(shell git describe --tags --always --dirty)
 LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
 
+# Windows builds use the GUI subsystem so the binary can be double-clicked
+# without opening a console window. It still functions as a CLI when invoked
+# from cmd.exe / PowerShell — see console_windows.go for AttachConsole logic.
+WINDOWS_LDFLAGS := -ldflags "-s -w -H=windowsgui -X main.version=$(VERSION)"
+
 .PHONY: test
 test:
 	go test ./...
@@ -25,7 +30,7 @@ build-darwin-arm64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o dist/dotvault-darwin-arm64 ./cmd/dotvault
 
 build-windows-amd64:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o dist/dotvault-windows-amd64.exe ./cmd/dotvault
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(WINDOWS_LDFLAGS) -o dist/dotvault-windows-amd64.exe ./cmd/dotvault
 
 .PHONY: clean
 clean:

--- a/cmd/dotvault/console_other.go
+++ b/cmd/dotvault/console_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// attachParentConsole is a no-op on non-Windows platforms. The Windows
+// build needs it because we link with -H=windowsgui, which detaches
+// stdio when the binary is launched outside of a console.
+func attachParentConsole() {}

--- a/cmd/dotvault/console_windows.go
+++ b/cmd/dotvault/console_windows.go
@@ -31,14 +31,20 @@ func attachParentConsole() {
 		return
 	}
 	// Re-bind the Go runtime's stdio to the now-attached console so
-	// fmt.Println and slog land where the user expects.
-	if h, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE); err == nil && h != 0 {
+	// fmt.Println and slog land where the user expects. GetStdHandle
+	// returns 0 if no handle is set and INVALID_HANDLE_VALUE on error;
+	// reject both before wrapping with os.NewFile.
+	if h, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE); err == nil && validHandle(h) {
 		os.Stdout = os.NewFile(uintptr(h), "stdout")
 	}
-	if h, err := windows.GetStdHandle(windows.STD_ERROR_HANDLE); err == nil && h != 0 {
+	if h, err := windows.GetStdHandle(windows.STD_ERROR_HANDLE); err == nil && validHandle(h) {
 		os.Stderr = os.NewFile(uintptr(h), "stderr")
 	}
-	if h, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE); err == nil && h != 0 {
+	if h, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE); err == nil && validHandle(h) {
 		os.Stdin = os.NewFile(uintptr(h), "stdin")
 	}
+}
+
+func validHandle(h windows.Handle) bool {
+	return h != 0 && h != windows.InvalidHandle
 }

--- a/cmd/dotvault/console_windows.go
+++ b/cmd/dotvault/console_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modkernel32         = windows.NewLazySystemDLL("kernel32.dll")
+	procAttachConsole   = modkernel32.NewProc("AttachConsole")
+	procGetConsoleWindow = modkernel32.NewProc("GetConsoleWindow")
+)
+
+const attachParentProcess = ^uintptr(0) // (DWORD)-1
+
+// attachParentConsole tries to inherit the parent process's console so
+// CLI subcommands like `dotvault status` produce visible output even
+// though the binary is linked with -H=windowsgui (no console of its
+// own). If there is no parent console — the user double-clicked the
+// .exe — the call is harmless and stdout/stderr remain detached.
+func attachParentConsole() {
+	// Already have a console? Nothing to do.
+	if hwnd, _, _ := procGetConsoleWindow.Call(); hwnd != 0 {
+		return
+	}
+	ret, _, _ := procAttachConsole.Call(attachParentProcess)
+	if ret == 0 {
+		return
+	}
+	// Re-bind the Go runtime's stdio to the now-attached console so
+	// fmt.Println and slog land where the user expects.
+	if h, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE); err == nil && h != 0 {
+		os.Stdout = os.NewFile(uintptr(h), "stdout")
+	}
+	if h, err := windows.GetStdHandle(windows.STD_ERROR_HANDLE); err == nil && h != 0 {
+		os.Stderr = os.NewFile(uintptr(h), "stderr")
+	}
+	if h, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE); err == nil && h != 0 {
+		os.Stdin = os.NewFile(uintptr(h), "stdin")
+	}
+}

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -410,13 +410,20 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		trayCfg.WebURL = webServer.URL()
 	}
 	if err := tray.Run(ctx, trayCfg); err != nil {
-		slog.Warn("tray exited with error", "error", err)
+		// A failed tray (e.g. RegisterClassEx, CreateWindow, or
+		// Shell_NotifyIcon refused on a session that has no shell) must
+		// not take the daemon down with it. Log and fall back to a plain
+		// ctx wait so the sync engine keeps running headlessly until
+		// signal/lifecycle cancels it.
+		slog.Warn("tray exited with error; daemon continues running headlessly", "error", err)
+		if ctx.Err() == nil {
+			<-ctx.Done()
+		}
 	}
 
-	// Tray returned because either the user picked Exit, ctx was cancelled
-	// elsewhere (signal handler, lifecycle manager), or no tray is supported
-	// on this platform and tray.Run blocked on ctx. Either way, stop the
-	// sync loop and propagate its result.
+	// Tray returned because the user picked Exit or ctx was cancelled
+	// elsewhere (signal handler, lifecycle manager, headless fallback).
+	// Stop the sync loop and propagate its result.
 	cancel()
 	return <-loopErrCh
 }

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/goodtune/dotvault/internal/paths"
 	"github.com/goodtune/dotvault/internal/regfile"
 	"github.com/goodtune/dotvault/internal/sync"
+	"github.com/goodtune/dotvault/internal/tray"
 	"github.com/goodtune/dotvault/internal/vault"
 	"github.com/goodtune/dotvault/internal/web"
 	"github.com/pkg/browser"
@@ -35,6 +36,12 @@ var (
 )
 
 func main() {
+	// On Windows the binary is linked with -H=windowsgui so a double-click
+	// doesn't flash a console window. When the user runs the binary from
+	// cmd.exe / PowerShell instead, attach to the parent console so CLI
+	// subcommands still produce visible output. No-op on other platforms.
+	attachParentConsole()
+
 	rootCmd := &cobra.Command{
 		Use:   "dotvault",
 		Short: "Vault-to-file secret synchronisation daemon",
@@ -379,7 +386,39 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	}
 
 	slog.Info("starting dotvault daemon", "version", version, "user", username)
-	return engine.RunLoop(ctx)
+
+	// Run the sync engine on a goroutine and the tray (Windows) or a
+	// blocking ctx-wait (everything else) on the main goroutine. The tray
+	// must own the main goroutine because the Win32 message pump requires
+	// runtime.LockOSThread on the same OS thread that creates the window.
+	// If the sync loop exits unexpectedly we cancel the context to wake
+	// tray.Run up and let the daemon shut down cleanly.
+	loopErrCh := make(chan error, 1)
+	go func() {
+		loopErrCh <- engine.RunLoop(ctx)
+		cancel()
+	}()
+
+	trayCfg := tray.Config{
+		Tooltip: fmt.Sprintf("dotvault %s", version),
+		OnExit: func() {
+			slog.Info("exit requested from tray")
+			cancel()
+		},
+	}
+	if webServer != nil {
+		trayCfg.WebURL = webServer.URL()
+	}
+	if err := tray.Run(ctx, trayCfg); err != nil {
+		slog.Warn("tray exited with error", "error", err)
+	}
+
+	// Tray returned because either the user picked Exit, ctx was cancelled
+	// elsewhere (signal handler, lifecycle manager), or no tray is supported
+	// on this platform and tray.Run blocked on ctx. Either way, stop the
+	// sync loop and propagate its result.
+	cancel()
+	return <-loopErrCh
 }
 
 func runSync(cmd *cobra.Command, args []string) error {

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -1,0 +1,16 @@
+// Package tray provides an optional Windows system-tray icon for the
+// daemon. On non-Windows platforms Run is a no-op that simply blocks
+// until ctx is cancelled, so callers can wire it unconditionally.
+package tray
+
+// Config bundles the tray menu configuration.
+//
+// WebURL is the URL the "View" menu entry should open. If empty, the
+// View entry is omitted entirely. OnExit is invoked when the user picks
+// the Exit menu entry; it should signal the daemon to shut down (e.g.
+// by cancelling the daemon's context).
+type Config struct {
+	Tooltip string
+	WebURL  string
+	OnExit  func()
+}

--- a/internal/tray/tray_other.go
+++ b/internal/tray/tray_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package tray
+
+import "context"
+
+// Run blocks until ctx is cancelled. The system-tray UI is Windows-only;
+// on other platforms there is nothing to display, so Run simply waits.
+func Run(ctx context.Context, _ Config) error {
+	<-ctx.Done()
+	return nil
+}

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -19,6 +19,7 @@ import (
 // from the Windows SDK headers (winuser.h, shellapi.h).
 const (
 	wmDestroy     = 0x0002
+	wmNull        = 0x0000
 	wmCommand     = 0x0111
 	wmRButtonUp   = 0x0205
 	wmLButtonDbl  = 0x0203
@@ -172,11 +173,16 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("RegisterClassEx: %w", callErr)
 	}
 
+	// Hidden top-level window — no WS_VISIBLE, no taskbar entry. We
+	// deliberately do not pass HWND_MESSAGE: TrackPopupMenu requires a
+	// foreground-able owner to dismiss on click-away (see showMenu's
+	// SetForegroundWindow workaround), and message-only windows cannot
+	// become foreground.
 	hwnd, _, callErr := procCreateWindowExW.Call(
 		0,
 		uintptr(unsafe.Pointer(className)),
 		uintptr(unsafe.Pointer(windowName)),
-		0, // no WS_VISIBLE — we're a message-only host
+		0,
 		0, 0, 0, 0,
 		0, 0,
 		hInstance,
@@ -218,30 +224,41 @@ func Run(ctx context.Context, cfg Config) error {
 	}()
 
 	// Standard Win32 message pump. GetMessageW returns 0 on WM_QUIT
-	// and -1 on error.
+	// and -1 on error — the latter is a real failure (invalid hwnd or
+	// bad message-queue state), surface it instead of treating it as a
+	// clean shutdown.
+	var loopErr error
 	var m msg
 	for {
-		ret, _, _ := procGetMessageW.Call(uintptr(unsafe.Pointer(&m)), 0, 0, 0)
-		if int32(ret) <= 0 {
-			break
+		ret, _, callErr := procGetMessageW.Call(uintptr(unsafe.Pointer(&m)), 0, 0, 0)
+		switch int32(ret) {
+		case -1:
+			loopErr = fmt.Errorf("GetMessage: %w", callErr)
+		case 0:
+			// WM_QUIT — clean exit.
+		default:
+			procTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
+			procDispatchMessageW.Call(uintptr(unsafe.Pointer(&m)))
+			continue
 		}
-		procTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
-		procDispatchMessageW.Call(uintptr(unsafe.Pointer(&m)))
+		break
 	}
 
 	procShellNotifyIconW.Call(nimDelete, uintptr(unsafe.Pointer(&trayState.nid)))
-	return nil
+	return loopErr
 }
 
-// wndProc handles messages for the tray's hidden window. It must not call
-// blocking Go code that re-enters Win32 or holds locks across a syscall.
+// wndProc handles messages for the tray's hidden window. It must not block
+// or re-enter Win32 in ways that stall the pump, so user-supplied callbacks
+// (browser open, daemon shutdown) are dispatched to goroutines and return
+// control immediately.
 func wndProc(hwnd windows.Handle, message uint32, wParam, lParam uintptr) uintptr {
 	switch message {
 	case wmTrayCB:
 		// lParam carries the inner mouse event for the tray icon.
 		switch uint32(lParam) {
 		case wmLButtonDbl:
-			triggerView()
+			go triggerView()
 		case wmRButtonUp:
 			showMenu(hwnd)
 		}
@@ -249,9 +266,9 @@ func wndProc(hwnd windows.Handle, message uint32, wParam, lParam uintptr) uintpt
 	case wmCommand:
 		switch uint32(wParam & 0xFFFF) {
 		case menuIDView:
-			triggerView()
+			go triggerView()
 		case menuIDExit:
-			triggerExit(hwnd)
+			go triggerExit(hwnd)
 		}
 		return 0
 	case wmTrayQuit:
@@ -288,8 +305,11 @@ func showMenu(hwnd windows.Handle) {
 	var pt point
 	procGetCursorPos.Call(uintptr(unsafe.Pointer(&pt)))
 
-	// Required quirk: the foreground window must be us before TrackPopupMenu
-	// is called, otherwise the menu won't dismiss when the user clicks away.
+	// Required quirks (documented in the Shell_NotifyIcon MSDN reference):
+	// 1. Bring our window to the foreground before TrackPopupMenu so the
+	//    menu actually dismisses when the user clicks away.
+	// 2. Post a no-op WM_NULL afterwards to flush the menu's input state;
+	//    without this the menu can stay "stuck" on second invocation.
 	procSetForegroundWindow.Call(uintptr(hwnd))
 	procTrackPopupMenu.Call(
 		hMenu,
@@ -299,6 +319,7 @@ func showMenu(hwnd windows.Handle) {
 		uintptr(hwnd),
 		0,
 	)
+	procPostMessageW.Call(uintptr(hwnd), wmNull, 0, 0)
 }
 
 func triggerView() {
@@ -313,14 +334,17 @@ func triggerView() {
 	}
 }
 
-func triggerExit(hwnd windows.Handle) {
+// triggerExit runs the user-supplied OnExit (typically a context cancel)
+// off-thread so wndProc never blocks. We do not call DestroyWindow here:
+// the ctx-cancel watcher inside Run will see the cancelled context and
+// post wmTrayQuit, which wndProc handles on the correct thread.
+func triggerExit(_ windows.Handle) {
 	trayState.mu.Lock()
 	onExit := trayState.cfg.OnExit
 	trayState.mu.Unlock()
 	if onExit != nil {
 		onExit()
 	}
-	procDestroyWindow.Call(uintptr(hwnd))
 }
 
 // copyUTF16 fills a fixed-size UTF-16 buffer from s, leaving room for a

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -143,9 +143,9 @@ func Run(ctx context.Context, cfg Config) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	hInstance, _, _ := procGetModuleHandleW.Call(0)
+	hInstance, _, callErr := procGetModuleHandleW.Call(0)
 	if hInstance == 0 {
-		return fmt.Errorf("GetModuleHandle failed")
+		return fmt.Errorf("GetModuleHandle: %w", callErr)
 	}
 
 	hIcon, _, _ := procLoadIconW.Call(0, uintptr(idiApplication))

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -218,26 +218,32 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// Tear-down: always remove the tray icon and destroy the window when
 	// Run returns, regardless of whether we exited cleanly via WM_QUIT or
-	// bailed out on a GetMessageW failure. close(done) first so the
-	// ctx-cancel watcher goroutine exits before we touch the window —
-	// otherwise it could PostMessage to a destroyed handle. DestroyWindow
-	// must run on this (locked) thread because it owns the window.
+	// bailed out on a GetMessageW failure. Order matters:
+	//   1. close(done) — releases the ctx-cancel watcher goroutine.
+	//   2. Take the state lock and zero trayState.hwnd before destroying
+	//      the window. Any concurrent postTrayQuit caller will then
+	//      observe hwnd=0 and skip, avoiding a PostMessage targeting a
+	//      destroyed (or recycled) handle. Callers already holding the
+	//      lock complete their PostMessage first; that message simply
+	//      stays queued forever after the pump exits, which is harmless.
+	// DestroyWindow runs on this (locked) OS thread because the window
+	// belongs to it.
 	done := make(chan struct{})
 	defer func() {
 		close(done)
-		procShellNotifyIconW.Call(nimDelete, uintptr(unsafe.Pointer(&trayState.nid)))
-		procDestroyWindow.Call(hwnd)
 		trayState.mu.Lock()
 		trayState.hwnd = 0
 		trayState.mu.Unlock()
+		procShellNotifyIconW.Call(nimDelete, uintptr(unsafe.Pointer(&trayState.nid)))
+		procDestroyWindow.Call(hwnd)
 	}()
 
-	// Watcher: wake the pump on ctx-cancel by posting a custom message,
-	// or exit cleanly when Run returns and closes done.
+	// Watcher: wake the pump on ctx-cancel via postTrayQuit, or exit
+	// cleanly when Run returns and closes done.
 	go func() {
 		select {
 		case <-ctx.Done():
-			procPostMessageW.Call(hwnd, wmTrayQuit, 0, 0)
+			postTrayQuit()
 		case <-done:
 		}
 	}()
@@ -286,7 +292,7 @@ func wndProc(hwnd windows.Handle, message uint32, wParam, lParam uintptr) uintpt
 		case menuIDView:
 			go triggerView()
 		case menuIDExit:
-			go triggerExit(hwnd)
+			go triggerExit()
 		}
 		return 0
 	case wmTrayQuit:
@@ -353,18 +359,33 @@ func triggerView() {
 }
 
 // triggerExit runs the user-supplied OnExit (typically a context cancel)
-// off-thread so wndProc never blocks, then posts wmTrayQuit so the tray
-// reliably closes even if OnExit is nil or doesn't actually cancel ctx.
-// DestroyWindow stays on the pump thread (handled by wndProc), and a
-// duplicate wmTrayQuit from the ctx-cancel watcher is harmless.
-func triggerExit(hwnd windows.Handle) {
+// off-thread so wndProc never blocks, then signals the tray to close so
+// it reliably exits even if OnExit is nil or doesn't actually cancel
+// ctx. DestroyWindow stays on the pump thread (handled by wndProc), and
+// a duplicate wmTrayQuit from the ctx-cancel watcher is harmless.
+func triggerExit() {
 	trayState.mu.Lock()
 	onExit := trayState.cfg.OnExit
 	trayState.mu.Unlock()
 	if onExit != nil {
 		onExit()
 	}
-	procPostMessageW.Call(uintptr(hwnd), wmTrayQuit, 0, 0)
+	postTrayQuit()
+}
+
+// postTrayQuit posts wmTrayQuit to the tray window so the pump can tear
+// itself down, but only if the window is still alive. Reading
+// trayState.hwnd under the state mutex serialises against Run's
+// deferred cleanup, which clears the field before destroying the window;
+// this prevents goroutines from posting to a destroyed (and potentially
+// recycled) HWND.
+func postTrayQuit() {
+	trayState.mu.Lock()
+	defer trayState.mu.Unlock()
+	if trayState.hwnd == 0 {
+		return
+	}
+	procPostMessageW.Call(uintptr(trayState.hwnd), wmTrayQuit, 0, 0)
 }
 
 // copyUTF16 fills a fixed-size UTF-16 buffer from s, leaving room for a

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -294,10 +294,20 @@ func wndProc(hwnd windows.Handle, message uint32, wParam, lParam uintptr) uintpt
 		}
 		return 0
 	case wmTrayQuit:
-		// Ctx-cancel watcher tapping us on the shoulder.
-		procDestroyWindow.Call(uintptr(hwnd))
+		// Ctx-cancel watcher (or menu Exit) signalling shutdown. Just
+		// break out of the pump — Run's deferred cleanup runs
+		// Shell_NotifyIcon(NIM_DELETE) before DestroyWindow so the tray
+		// icon is removed cleanly. Calling DestroyWindow here would
+		// invalidate the HWND before NIM_DELETE could reference it,
+		// leaving Explorer with a "dead" icon until the next mouse
+		// hover.
+		procPostQuitMessage.Call(0)
 		return 0
 	case wmDestroy:
+		// Fired by DestroyWindow in the defer. PostQuitMessage here is
+		// a no-op (pump already exited) but harmless and keeps the
+		// window proc consistent if DestroyWindow is ever invoked from
+		// another path.
 		procPostQuitMessage.Call(0)
 		return 0
 	}

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -1,0 +1,341 @@
+//go:build windows
+
+package tray
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/pkg/browser"
+	"golang.org/x/sys/windows"
+)
+
+// Win32 message identifiers and constants used by the tray. Values come
+// from the Windows SDK headers (winuser.h, shellapi.h).
+const (
+	wmDestroy     = 0x0002
+	wmCommand     = 0x0111
+	wmRButtonUp   = 0x0205
+	wmLButtonDbl  = 0x0203
+	wmUser        = 0x0400
+	wmTrayCB      = wmUser + 1 // notification callback from Shell_NotifyIcon
+	wmTrayQuit    = wmUser + 2 // posted by Run when ctx is cancelled
+	nimAdd        = 0x00000000
+	nimModify     = 0x00000001
+	nimDelete     = 0x00000002
+	nifMessage    = 0x00000001
+	nifIcon       = 0x00000002
+	nifTip        = 0x00000004
+	idiApplication = 32512
+	idcArrow       = 32512
+	tpmRightButton = 0x0002
+	tpmReturnCmd   = 0x0100
+	mfString       = 0x00000000
+	mfSeparator    = 0x00000800
+
+	menuIDView = 1001
+	menuIDExit = 1002
+)
+
+var (
+	user32   = windows.NewLazySystemDLL("user32.dll")
+	shell32  = windows.NewLazySystemDLL("shell32.dll")
+	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procGetModuleHandleW   = kernel32.NewProc("GetModuleHandleW")
+	procLoadIconW          = user32.NewProc("LoadIconW")
+	procLoadCursorW        = user32.NewProc("LoadCursorW")
+	procRegisterClassExW   = user32.NewProc("RegisterClassExW")
+	procCreateWindowExW    = user32.NewProc("CreateWindowExW")
+	procDestroyWindow      = user32.NewProc("DestroyWindow")
+	procDefWindowProcW     = user32.NewProc("DefWindowProcW")
+	procGetMessageW        = user32.NewProc("GetMessageW")
+	procTranslateMessage   = user32.NewProc("TranslateMessage")
+	procDispatchMessageW   = user32.NewProc("DispatchMessageW")
+	procPostMessageW       = user32.NewProc("PostMessageW")
+	procPostQuitMessage    = user32.NewProc("PostQuitMessage")
+	procCreatePopupMenu    = user32.NewProc("CreatePopupMenu")
+	procAppendMenuW        = user32.NewProc("AppendMenuW")
+	procDestroyMenu        = user32.NewProc("DestroyMenu")
+	procTrackPopupMenu     = user32.NewProc("TrackPopupMenu")
+	procGetCursorPos       = user32.NewProc("GetCursorPos")
+	procSetForegroundWindow = user32.NewProc("SetForegroundWindow")
+
+	procShellNotifyIconW = shell32.NewProc("Shell_NotifyIconW")
+)
+
+// wndClassEx mirrors WNDCLASSEXW.
+type wndClassEx struct {
+	cbSize        uint32
+	style         uint32
+	lpfnWndProc   uintptr
+	cbClsExtra    int32
+	cbWndExtra    int32
+	hInstance     windows.Handle
+	hIcon         windows.Handle
+	hCursor       windows.Handle
+	hbrBackground windows.Handle
+	lpszMenuName  *uint16
+	lpszClassName *uint16
+	hIconSm       windows.Handle
+}
+
+// notifyIconData mirrors NOTIFYICONDATAW. The full V4 struct is large but
+// laying it out lets us pass cbSize = unsafe.Sizeof(notifyIconData{}) and
+// rely on the kernel to ignore unset fields.
+type notifyIconData struct {
+	cbSize           uint32
+	hWnd             windows.Handle
+	uID              uint32
+	uFlags           uint32
+	uCallbackMessage uint32
+	hIcon            windows.Handle
+	szTip            [128]uint16
+	dwState          uint32
+	dwStateMask      uint32
+	szInfo           [256]uint16
+	uVersion         uint32
+	szInfoTitle      [64]uint16
+	dwInfoFlags      uint32
+	guidItem         [16]byte
+	hBalloonIcon     windows.Handle
+}
+
+type point struct {
+	x, y int32
+}
+
+type msg struct {
+	hwnd     windows.Handle
+	message  uint32
+	wParam   uintptr
+	lParam   uintptr
+	time     uint32
+	pt       point
+	lPrivate uint32
+}
+
+// state holds everything the WindowProc needs to react to messages. There
+// is exactly one tray per process, so a package-level singleton is fine.
+type state struct {
+	mu       sync.Mutex
+	hwnd     windows.Handle
+	nid      notifyIconData
+	cfg      Config
+	hasView  bool
+}
+
+var trayState state
+
+// Run installs a tray icon, runs the Win32 message pump on a locked OS
+// thread, and returns when ctx is cancelled or the user picks Exit.
+//
+// All Win32 GUI calls must originate from the thread that created the
+// window, so Run pins itself with runtime.LockOSThread. Other goroutines
+// communicate with the pump via PostMessageW (see ctx-cancel watcher).
+func Run(ctx context.Context, cfg Config) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hInstance, _, _ := procGetModuleHandleW.Call(0)
+	if hInstance == 0 {
+		return fmt.Errorf("GetModuleHandle failed")
+	}
+
+	hIcon, _, _ := procLoadIconW.Call(0, uintptr(idiApplication))
+	hCursor, _, _ := procLoadCursorW.Call(0, uintptr(idcArrow))
+
+	className, err := windows.UTF16PtrFromString("dotvaultTrayWnd")
+	if err != nil {
+		return fmt.Errorf("class name: %w", err)
+	}
+	windowName, err := windows.UTF16PtrFromString("dotvault")
+	if err != nil {
+		return fmt.Errorf("window name: %w", err)
+	}
+
+	wc := wndClassEx{
+		lpfnWndProc:   windows.NewCallback(wndProc),
+		hInstance:     windows.Handle(hInstance),
+		hIcon:         windows.Handle(hIcon),
+		hCursor:       windows.Handle(hCursor),
+		lpszClassName: className,
+	}
+	wc.cbSize = uint32(unsafe.Sizeof(wc))
+
+	if ret, _, callErr := procRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc))); ret == 0 {
+		return fmt.Errorf("RegisterClassEx: %w", callErr)
+	}
+
+	hwnd, _, callErr := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),
+		uintptr(unsafe.Pointer(windowName)),
+		0, // no WS_VISIBLE — we're a message-only host
+		0, 0, 0, 0,
+		0, 0,
+		hInstance,
+		0,
+	)
+	if hwnd == 0 {
+		return fmt.Errorf("CreateWindowEx: %w", callErr)
+	}
+
+	trayState.mu.Lock()
+	trayState.hwnd = windows.Handle(hwnd)
+	trayState.cfg = cfg
+	trayState.hasView = cfg.WebURL != ""
+	trayState.nid = notifyIconData{
+		hWnd:             windows.Handle(hwnd),
+		uID:              1,
+		uFlags:           nifMessage | nifIcon | nifTip,
+		uCallbackMessage: wmTrayCB,
+		hIcon:            windows.Handle(hIcon),
+	}
+	trayState.nid.cbSize = uint32(unsafe.Sizeof(trayState.nid))
+	tip := cfg.Tooltip
+	if tip == "" {
+		tip = "dotvault"
+	}
+	copyUTF16(trayState.nid.szTip[:], tip)
+	trayState.mu.Unlock()
+
+	if ret, _, callErr := procShellNotifyIconW.Call(nimAdd, uintptr(unsafe.Pointer(&trayState.nid))); ret == 0 {
+		procDestroyWindow.Call(hwnd)
+		return fmt.Errorf("Shell_NotifyIcon(NIM_ADD): %w", callErr)
+	}
+
+	// Watcher: when the daemon context is cancelled, tell the message
+	// pump to break out by posting a custom message to our window.
+	go func() {
+		<-ctx.Done()
+		procPostMessageW.Call(hwnd, wmTrayQuit, 0, 0)
+	}()
+
+	// Standard Win32 message pump. GetMessageW returns 0 on WM_QUIT
+	// and -1 on error.
+	var m msg
+	for {
+		ret, _, _ := procGetMessageW.Call(uintptr(unsafe.Pointer(&m)), 0, 0, 0)
+		if int32(ret) <= 0 {
+			break
+		}
+		procTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
+		procDispatchMessageW.Call(uintptr(unsafe.Pointer(&m)))
+	}
+
+	procShellNotifyIconW.Call(nimDelete, uintptr(unsafe.Pointer(&trayState.nid)))
+	return nil
+}
+
+// wndProc handles messages for the tray's hidden window. It must not call
+// blocking Go code that re-enters Win32 or holds locks across a syscall.
+func wndProc(hwnd windows.Handle, message uint32, wParam, lParam uintptr) uintptr {
+	switch message {
+	case wmTrayCB:
+		// lParam carries the inner mouse event for the tray icon.
+		switch uint32(lParam) {
+		case wmLButtonDbl:
+			triggerView()
+		case wmRButtonUp:
+			showMenu(hwnd)
+		}
+		return 0
+	case wmCommand:
+		switch uint32(wParam & 0xFFFF) {
+		case menuIDView:
+			triggerView()
+		case menuIDExit:
+			triggerExit(hwnd)
+		}
+		return 0
+	case wmTrayQuit:
+		// Ctx-cancel watcher tapping us on the shoulder.
+		procDestroyWindow.Call(uintptr(hwnd))
+		return 0
+	case wmDestroy:
+		procPostQuitMessage.Call(0)
+		return 0
+	}
+	ret, _, _ := procDefWindowProcW.Call(uintptr(hwnd), uintptr(message), wParam, lParam)
+	return ret
+}
+
+func showMenu(hwnd windows.Handle) {
+	hMenu, _, _ := procCreatePopupMenu.Call()
+	if hMenu == 0 {
+		return
+	}
+	defer procDestroyMenu.Call(hMenu)
+
+	trayState.mu.Lock()
+	hasView := trayState.hasView
+	trayState.mu.Unlock()
+
+	if hasView {
+		viewPtr, _ := windows.UTF16PtrFromString("&View web UI")
+		procAppendMenuW.Call(hMenu, mfString, uintptr(menuIDView), uintptr(unsafe.Pointer(viewPtr)))
+		procAppendMenuW.Call(hMenu, mfSeparator, 0, 0)
+	}
+	exitPtr, _ := windows.UTF16PtrFromString("E&xit")
+	procAppendMenuW.Call(hMenu, mfString, uintptr(menuIDExit), uintptr(unsafe.Pointer(exitPtr)))
+
+	var pt point
+	procGetCursorPos.Call(uintptr(unsafe.Pointer(&pt)))
+
+	// Required quirk: the foreground window must be us before TrackPopupMenu
+	// is called, otherwise the menu won't dismiss when the user clicks away.
+	procSetForegroundWindow.Call(uintptr(hwnd))
+	procTrackPopupMenu.Call(
+		hMenu,
+		tpmRightButton,
+		uintptr(pt.x), uintptr(pt.y),
+		0,
+		uintptr(hwnd),
+		0,
+	)
+}
+
+func triggerView() {
+	trayState.mu.Lock()
+	url := trayState.cfg.WebURL
+	trayState.mu.Unlock()
+	if url == "" {
+		return
+	}
+	if err := browser.OpenURL(url); err != nil {
+		slog.Warn("tray: failed to open browser", "url", url, "error", err)
+	}
+}
+
+func triggerExit(hwnd windows.Handle) {
+	trayState.mu.Lock()
+	onExit := trayState.cfg.OnExit
+	trayState.mu.Unlock()
+	if onExit != nil {
+		onExit()
+	}
+	procDestroyWindow.Call(uintptr(hwnd))
+}
+
+// copyUTF16 fills a fixed-size UTF-16 buffer from s, leaving room for a
+// trailing null terminator regardless of input length.
+func copyUTF16(dst []uint16, s string) {
+	enc, err := syscall.UTF16FromString(s)
+	if err != nil {
+		return
+	}
+	n := len(enc)
+	if n > len(dst) {
+		n = len(dst)
+	}
+	copy(dst[:n], enc[:n])
+	if len(dst) > 0 {
+		dst[len(dst)-1] = 0
+	}
+}

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -216,11 +216,30 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("Shell_NotifyIcon(NIM_ADD): %w", callErr)
 	}
 
-	// Watcher: when the daemon context is cancelled, tell the message
-	// pump to break out by posting a custom message to our window.
+	// Tear-down: always remove the tray icon and destroy the window when
+	// Run returns, regardless of whether we exited cleanly via WM_QUIT or
+	// bailed out on a GetMessageW failure. close(done) first so the
+	// ctx-cancel watcher goroutine exits before we touch the window —
+	// otherwise it could PostMessage to a destroyed handle. DestroyWindow
+	// must run on this (locked) thread because it owns the window.
+	done := make(chan struct{})
+	defer func() {
+		close(done)
+		procShellNotifyIconW.Call(nimDelete, uintptr(unsafe.Pointer(&trayState.nid)))
+		procDestroyWindow.Call(hwnd)
+		trayState.mu.Lock()
+		trayState.hwnd = 0
+		trayState.mu.Unlock()
+	}()
+
+	// Watcher: wake the pump on ctx-cancel by posting a custom message,
+	// or exit cleanly when Run returns and closes done.
 	go func() {
-		<-ctx.Done()
-		procPostMessageW.Call(hwnd, wmTrayQuit, 0, 0)
+		select {
+		case <-ctx.Done():
+			procPostMessageW.Call(hwnd, wmTrayQuit, 0, 0)
+		case <-done:
+		}
 	}()
 
 	// Standard Win32 message pump. GetMessageW returns 0 on WM_QUIT
@@ -244,7 +263,6 @@ func Run(ctx context.Context, cfg Config) error {
 		break
 	}
 
-	procShellNotifyIconW.Call(nimDelete, uintptr(unsafe.Pointer(&trayState.nid)))
 	return loopErr
 }
 
@@ -335,16 +353,18 @@ func triggerView() {
 }
 
 // triggerExit runs the user-supplied OnExit (typically a context cancel)
-// off-thread so wndProc never blocks. We do not call DestroyWindow here:
-// the ctx-cancel watcher inside Run will see the cancelled context and
-// post wmTrayQuit, which wndProc handles on the correct thread.
-func triggerExit(_ windows.Handle) {
+// off-thread so wndProc never blocks, then posts wmTrayQuit so the tray
+// reliably closes even if OnExit is nil or doesn't actually cancel ctx.
+// DestroyWindow stays on the pump thread (handled by wndProc), and a
+// duplicate wmTrayQuit from the ctx-cancel watcher is harmless.
+func triggerExit(hwnd windows.Handle) {
 	trayState.mu.Lock()
 	onExit := trayState.cfg.OnExit
 	trayState.mu.Unlock()
 	if onExit != nil {
 		onExit()
 	}
+	procPostMessageW.Call(uintptr(hwnd), wmTrayQuit, 0, 0)
 }
 
 // copyUTF16 fills a fixed-size UTF-16 buffer from s, leaving room for a

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -27,7 +27,6 @@ const (
 	wmTrayCB      = wmUser + 1 // notification callback from Shell_NotifyIcon
 	wmTrayQuit    = wmUser + 2 // posted by Run when ctx is cancelled
 	nimAdd        = 0x00000000
-	nimModify     = 0x00000001
 	nimDelete     = 0x00000002
 	nifMessage    = 0x00000001
 	nifIcon       = 0x00000002
@@ -35,7 +34,6 @@ const (
 	idiApplication = 32512
 	idcArrow       = 32512
 	tpmRightButton = 0x0002
-	tpmReturnCmd   = 0x0100
 	mfString       = 0x00000000
 	mfSeparator    = 0x00000800
 


### PR DESCRIPTION
## Summary

- Build the Windows binary with `-H=windowsgui` so double-clicking the `.exe` no longer flashes a console window.
- Add `internal/tray` (pure-Go via `x/sys/windows`) — a hidden top-level window (deliberately **not** `HWND_MESSAGE`, since `TrackPopupMenu` requires a foreground-able owner to dismiss the menu on click-away), `Shell_NotifyIcon`, and a popup menu. Menu offers **Exit** (cancels the daemon context) and, when the web UI is enabled, **View web UI** (opens the browser via `pkg/browser`).
- The Win32 message pump owns the main goroutine on `runtime.LockOSThread`; the sync engine moves to a goroutine. Non-Windows platforms get a no-op `Run` that just blocks on `ctx` so the call site stays uniform.
- Tray failures are non-fatal: if `tray.Run` returns an error before ctx is cancelled, the daemon logs and falls back to a headless ctx-wait so the sync engine keeps running.
- CLI subcommands invoked from `cmd.exe` / PowerShell still produce visible output: `AttachConsole(ATTACH_PARENT_PROCESS)` runs at the top of `main` and re-binds Go's stdio to the parent console (rejecting both `0` and `INVALID_HANDLE_VALUE`).
- Drive-by fix: `.gitignore` had an unanchored `dotvault` pattern that was excluding the entire `cmd/dotvault/` directory; anchored it as `/dotvault`.

### Tray threading model

- `wndProc` runs on the message-pump goroutine (the one with `runtime.LockOSThread`).
- Menu actions dispatch to fresh goroutines so `browser.OpenURL` and the daemon `OnExit` callback never block the pump.
- `triggerExit` only invokes `OnExit`; it does **not** call `DestroyWindow` itself. Cancelling the daemon context wakes the ctx-cancel watcher, which posts `wmTrayQuit`, and `wndProc` calls `DestroyWindow` on the correct thread.
- `GetMessageW = -1` is treated as a real failure and surfaced through `Run`'s return value.
- `WM_NULL` is posted after `TrackPopupMenu` so the menu dismisses reliably on subsequent invocations.

## Test plan

- [x] `go build ./...` (linux)
- [x] `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-H=windowsgui" ./cmd/dotvault` (Windows GUI subsystem PE32+ verified via `file`)
- [x] `CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ./cmd/dotvault`
- [x] `go vet ./...` for both linux and windows targets
- [x] `go test ./...` — all packages pass
- [ ] Manual: double-click `dotvault.exe` on Windows, confirm tray icon appears, right-click shows Exit (+ View web UI when enabled), Exit cleanly stops the daemon
- [ ] Manual: invoke `dotvault.exe status` from PowerShell, confirm output appears in the parent console