### PR TITLE
fix(release): rename archives.builds to archives.ids for goreleaser v2.8

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ archives:
       - goos: windows
         formats:
           - zip
-    builds:
+    ids:
       - dotvault
       - dotvaultw
     files:


### PR DESCRIPTION
## Summary

The 0.11.1 release workflow failed at the GoReleaser step and uploaded no binary artifacts. PR #55 introduced an `archives.builds` filter to limit the archive to the new `dotvault` / `dotvaultw` build IDs. GoReleaser v2.8 renamed that field to `archives.ids` (the same nomenclature used everywhere else in the config), and `release.yml` pins the action to `version: latest`, so this run picked up the new release and rejected the deprecated key.

Reference: https://goreleaser.com/deprecations#archivesbuilds

## Changes

- `.goreleaser.yml`: rename `archives.builds` → `archives.ids`.

## Verification

```
$ goreleaser check
  • checking                                  path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!

$ goreleaser build --snapshot --clean --single-target
  • build succeeded after 21s
```

Both succeed against goreleaser 2.15.4 (the same `latest` that the failing release pulled).

## Test plan

- [ ] Re-cut release tag (or re-run the failed workflow) once merged and confirm artifacts upload to the GitHub release.

https://claude.ai/code/session_01QTYmKg9uQZEKgHh3bjJnEW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTYmKg9uQZEKgHh3bjJnEW)_