### PR TITLE
fix(release): allow different binary count for Windows archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,8 @@ builds:
       - windows_amd64
 
 archives:
-  - formats:
+  - allow_different_binary_count: true
+    formats:
       - tar.gz
     format_overrides:
       - goos: windows


### PR DESCRIPTION
## Summary

- Adds `allow_different_binary_count: true` to the `archives` config in `.goreleaser.yml`
- Prevents GoReleaser from erroring when the Windows zip contains both `dotvault.exe` and `dotvaultw.exe` while Linux/macOS archives contain only `dotvault`

## Test plan

- [ ] Run `goreleaser release --snapshot --clean` locally and verify the Windows zip contains both `dotvault.exe` and `dotvaultw.exe`
- [ ] Verify Linux/macOS `.tar.gz` archives contain only `dotvault`