### PR TITLE
fix(windows): namespace GPO registry path under `Policies\goodtune\dotvault`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ YAML config file at platform-specific system paths:
 - Linux: `/etc/xdg/dotvault/config.yaml` (also checks `$XDG_CONFIG_DIRS`)
 - Windows: `%ProgramData%\dotvault\config.yaml`
 
-On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\dotvault`, configuration is loaded entirely from the registry and the file-based config is ignored. Only machine-level (HKLM) policy is read; HKCU is intentionally skipped because it is user-writable.
+On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\goodtune\dotvault`, configuration is loaded entirely from the registry and the file-based config is ignored. Only machine-level (HKLM) policy is read; HKCU is intentionally skipped because it is user-writable.
 
 ### Config Sections
 
@@ -118,7 +118,7 @@ user-facing form, `reg-import` casts a YAML config into the .reg form a
 Windows admin would push back into the registry.
 
 `reg-export` parses a `.reg` file (positional path or stdin when
-omitted/`-`) under `HKLM\SOFTWARE\Policies\dotvault` and emits the
+omitted/`-`) under `HKLM\SOFTWARE\Policies\goodtune\dotvault` and emits the
 equivalent dotvault YAML configuration to stdout (or `--output <path>`,
 0600). Both UTF-16LE-with-BOM and plain ASCII inputs are accepted — the
 encoding is detected from the leading BOM. The reconstructed YAML is
@@ -129,7 +129,7 @@ combine with `--ascii` for the plain-text variant of the v5 format.
 
 `reg-import` is the inverse: it reads and validates a YAML config, then
 emits a `Windows Registry Editor Version 5.00` file targeting
-`HKLM\SOFTWARE\Policies\dotvault` to stdout (or `--output <path>`,
+`HKLM\SOFTWARE\Policies\goodtune\dotvault` to stdout (or `--output <path>`,
 written with 0600 permissions). Default encoding is UTF-16LE with BOM,
 matching the canonical format produced by regedit.exe; `--ascii`
 produces an unencoded plain-text variant of the same v5 format.
@@ -359,7 +359,7 @@ Configurable markdown content via `web.login_text` and `web.secret_view_text` fi
 
 ## Windows Registry / Group Policy
 
-When HKLM registry keys exist at `SOFTWARE\Policies\dotvault`, the daemon loads all config from registry and ignores the YAML file. The `registryLayer` struct reads Vault, Sync, and Web settings from typed subkeys (REG_SZ, REG_DWORD). Rules are subkeys under `Rules\{RuleName}` with an optional `OAuth` subkey.
+When HKLM registry keys exist at `SOFTWARE\Policies\goodtune\dotvault`, the daemon loads all config from registry and ignores the YAML file. The `registryLayer` struct reads Vault, Sync, and Web settings from typed subkeys (REG_SZ, REG_DWORD). Rules are subkeys under `Rules\{RuleName}` with an optional `OAuth` subkey.
 
 ADMX template at `packaging/windows/dotvault.admx` defines Group Policy UI for Vault, Sync, and Web settings.
 

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -558,7 +558,7 @@ func newRegExportCmd() *cobra.Command {
 		Use:   "reg-export [config.reg]",
 		Short: "Export a Windows .reg file as YAML (default) or canonical .reg",
 		Long: `Read a Windows Registry .reg file representing dotvault policy under
-HKLM\SOFTWARE\Policies\dotvault and emit its contents in the requested
+HKLM\SOFTWARE\Policies\goodtune\dotvault and emit its contents in the requested
 form. The default output is the equivalent dotvault YAML configuration;
 pass --regedit to re-emit the .reg in its canonical Windows Registry
 Editor v5 form (--ascii alongside --regedit selects the plain-text
@@ -690,7 +690,7 @@ func newRegImportCmd() *cobra.Command {
 		Use:   "reg-import [config.yaml]",
 		Short: "Convert a YAML config into a Windows .reg file",
 		Long: `Convert a dotvault YAML configuration file into a Windows Registry
-.reg file targeting HKLM\SOFTWARE\Policies\dotvault.
+.reg file targeting HKLM\SOFTWARE\Policies\goodtune\dotvault.
 
 The input config path may be supplied as a positional argument or via the
 inherited --config flag; the positional argument takes precedence when

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -95,7 +95,7 @@ Place the config file at:
 Or use [Group Policy](windows-gpo.md) to manage configuration centrally via the registry.
 
 !!! warning "Registry takes precedence"
-    On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\dotvault`, dotvault loads all configuration from the registry and **ignores the YAML file entirely**. The only way to bypass this is the `--config` CLI flag, which always takes precedence.
+    On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\goodtune\dotvault`, dotvault loads all configuration from the registry and **ignores the YAML file entirely**. The only way to bypass this is the `--config` CLI flag, which always takes precedence.
 
 ## Running as a user service
 

--- a/docs/admin/windows-gpo.md
+++ b/docs/admin/windows-gpo.md
@@ -4,7 +4,7 @@ On Windows, dotvault can be fully configured via Group Policy using the Windows 
 
 ## How it works
 
-When HKLM registry keys exist at `SOFTWARE\Policies\dotvault`, dotvault loads **all** configuration from the registry and ignores the YAML config file entirely. Only machine-level policy (HKLM) is read — HKCU is intentionally skipped because it is user-writable and therefore cannot be trusted for enforced configuration.
+When HKLM registry keys exist at `SOFTWARE\Policies\goodtune\dotvault`, dotvault loads **all** configuration from the registry and ignores the YAML config file entirely. Only machine-level policy (HKLM) is read — HKCU is intentionally skipped because it is user-writable and therefore cannot be trusted for enforced configuration.
 
 !!! important "The `--config` flag always wins"
     If a user invokes dotvault with `--config path/to/config.yaml`, the specified file is used regardless of whether registry keys exist. This is useful for development and troubleshooting but means the user can bypass the managed configuration. In environments where strict enforcement is required, restrict access to the dotvault binary's command-line options.
@@ -65,26 +65,26 @@ The ADMX template provides UI for these settings in the Group Policy editor:
 
 ## Registry-only settings (Group Policy Preferences)
 
-Sync rules and enrolments are complex multi-field objects that cannot be fully expressed as ADMX policies. Configure these using **Group Policy Preferences > Registry**, targeting keys under `SOFTWARE\Policies\dotvault`.
+Sync rules and enrolments are complex multi-field objects that cannot be fully expressed as ADMX policies. Configure these using **Group Policy Preferences > Registry**, targeting keys under `SOFTWARE\Policies\goodtune\dotvault`.
 
 ### Rules
 
 Each rule is a subkey under `Rules\{RuleName}`:
 
 ```
-SOFTWARE\Policies\dotvault\Rules\gh\VaultKey        (REG_SZ)    "gh"
-SOFTWARE\Policies\dotvault\Rules\gh\TargetPath       (REG_SZ)    "~/.config/gh/hosts.yml"
-SOFTWARE\Policies\dotvault\Rules\gh\TargetFormat     (REG_SZ)    "yaml"
-SOFTWARE\Policies\dotvault\Rules\gh\TargetTemplate   (REG_SZ)    "github.com:\n  oauth_token: \"{{.oauth_token}}\""
-SOFTWARE\Policies\dotvault\Rules\gh\Description      (REG_SZ)    "GitHub CLI credentials"
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\VaultKey        (REG_SZ)    "gh"
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\TargetPath       (REG_SZ)    "~/.config/gh/hosts.yml"
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\TargetFormat     (REG_SZ)    "yaml"
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\TargetTemplate   (REG_SZ)    "github.com:\n  oauth_token: \"{{.oauth_token}}\""
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\Description      (REG_SZ)    "GitHub CLI credentials"
 ```
 
 Optional OAuth subkey for rules with service onboarding:
 
 ```
-SOFTWARE\Policies\dotvault\Rules\gh\OAuth\EnginePath (REG_SZ)
-SOFTWARE\Policies\dotvault\Rules\gh\OAuth\Provider   (REG_SZ)
-SOFTWARE\Policies\dotvault\Rules\gh\OAuth\Scopes     (REG_MULTI_SZ)
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\OAuth\EnginePath (REG_SZ)
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\OAuth\Provider   (REG_SZ)
+SOFTWARE\Policies\goodtune\dotvault\Rules\gh\OAuth\Scopes     (REG_MULTI_SZ)
 ```
 
 ### Enrolments
@@ -92,9 +92,9 @@ SOFTWARE\Policies\dotvault\Rules\gh\OAuth\Scopes     (REG_MULTI_SZ)
 Each enrolment is a subkey under `Enrolments\{Name}`:
 
 ```
-SOFTWARE\Policies\dotvault\Enrolments\gh\Engine                  (REG_SZ)    "github"
-SOFTWARE\Policies\dotvault\Enrolments\gh\Settings\client_id      (REG_SZ)    "178c6fc778ccc68e1d6a"
-SOFTWARE\Policies\dotvault\Enrolments\gh\Settings\scopes         (REG_MULTI_SZ) "repo\0read:org\0gist"
+SOFTWARE\Policies\goodtune\dotvault\Enrolments\gh\Engine                  (REG_SZ)    "github"
+SOFTWARE\Policies\goodtune\dotvault\Enrolments\gh\Settings\client_id      (REG_SZ)    "178c6fc778ccc68e1d6a"
+SOFTWARE\Policies\goodtune\dotvault\Enrolments\gh\Settings\scopes         (REG_MULTI_SZ) "repo\0read:org\0gist"
 ```
 
 ## Example: deploying via GPO

--- a/docs/configuration/config-reference.md
+++ b/docs/configuration/config-reference.md
@@ -15,7 +15,7 @@ dotvault run --config /path/to/config.yaml
 ```
 
 !!! warning "Windows Group Policy override"
-    On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\dotvault`, dotvault loads all configuration from the registry and **ignores the YAML file entirely**. The `--config` CLI flag is the only way to bypass this behaviour. See [Windows Group Policy](../admin/windows-gpo.md) for details.
+    On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\goodtune\dotvault`, dotvault loads all configuration from the registry and **ignores the YAML file entirely**. The `--config` CLI flag is the only way to bypass this behaviour. See [Windows Group Policy](../admin/windows-gpo.md) for details.
 
 ## Full example
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,8 +153,8 @@ var validFormats = map[string]bool{
 
 // LoadSystem loads configuration using the platform-appropriate source.
 // On Windows, if Group Policy registry keys exist under
-// HKLM\SOFTWARE\Policies\dotvault, configuration is loaded from the
-// registry and the file-based config at path is ignored. Only
+// HKLM\SOFTWARE\Policies\goodtune\dotvault, configuration is loaded from
+// the registry and the file-based config at path is ignored. Only
 // machine-level (HKLM) policy is read; HKCU is intentionally skipped
 // because it is user-writable and cannot be treated as a trusted policy
 // boundary on unmanaged machines.

--- a/internal/config/registry_windows.go
+++ b/internal/config/registry_windows.go
@@ -13,15 +13,15 @@ import (
 
 const (
 	// registryPolicyPath is the GPO-managed registry path. Policies are read
-	// from HKLM\SOFTWARE\Policies\dotvault only. HKCU is intentionally not
-	// used as a trusted policy source because it is normally user-writable.
-	registryPolicyPath = `SOFTWARE\Policies\dotvault`
+	// from HKLM\SOFTWARE\Policies\goodtune\dotvault only. HKCU is intentionally
+	// not used as a trusted policy source because it is normally user-writable.
+	registryPolicyPath = `SOFTWARE\Policies\goodtune\dotvault`
 )
 
 // loadFromRegistry attempts to load configuration from Windows Registry
 // Group Policy keys. It reads machine-level values from
-// HKLM\SOFTWARE\Policies\dotvault. HKCU is not consulted because it is
-// user-writable and cannot be treated as a trusted policy boundary.
+// HKLM\SOFTWARE\Policies\goodtune\dotvault. HKCU is not consulted because it
+// is user-writable and cannot be treated as a trusted policy boundary.
 //
 // Returns (nil, false, nil) if no GPO registry keys are found.
 func loadFromRegistry() (*Config, bool, error) {

--- a/internal/regfile/parse.go
+++ b/internal/regfile/parse.go
@@ -12,7 +12,7 @@ import (
 
 // Parse reads a Windows Registry Editor Version 5.00 .reg file and
 // reconstructs a *config.Config from values under
-// HKLM\SOFTWARE\Policies\dotvault.
+// HKLM\SOFTWARE\Policies\goodtune\dotvault.
 //
 // The input may be UTF-16LE with BOM (the canonical regedit.exe format
 // produced by Generate) or plain text/UTF-8 (the variant produced by
@@ -493,7 +493,7 @@ func canonicalizeKeyPath(path string) string {
 	return strings.Join(parts, `\`)
 }
 
-// pathInScope reports whether path lives under HKLM\SOFTWARE\Policies\dotvault.
+// pathInScope reports whether path lives under HKLM\SOFTWARE\Policies\goodtune\dotvault.
 func pathInScope(path string) bool {
 	if path == rootKey {
 		return true

--- a/internal/regfile/parse_test.go
+++ b/internal/regfile/parse_test.go
@@ -196,7 +196,7 @@ func TestParseDeletionStanzaIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateText: %v", err)
 	}
-	if !strings.Contains(text, `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`) {
+	if !strings.Contains(text, `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Rules]`) {
 		t.Fatalf("generator should emit deletion stanza")
 	}
 	got, err := Parse([]byte(text))
@@ -343,9 +343,9 @@ func TestMarshalYAMLLoadsBack(t *testing.T) {
 // lowercase keys engines consume (e.g. `host`, `client_id`).
 func TestParseLowercasesEnrolmentSettingNames(t *testing.T) {
 	reg := "Windows Registry Editor Version 5.00\r\n\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\gh]\r\n" +
 		"\"Engine\"=\"github\"\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh\\Settings]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\gh\\Settings]\r\n" +
 		"\"Host\"=\"github.com\"\r\n" +
 		"\"Client_ID\"=\"abc123\"\r\n"
 
@@ -430,7 +430,7 @@ func TestMarshalYAMLMapKeysSorted(t *testing.T) {
 // fail loudly instead.
 func TestParseRejectsUnterminatedContinuation(t *testing.T) {
 	bad := "Windows Registry Editor Version 5.00\r\n\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r]\r\n" +
 		"\"TargetTemplate\"=hex(1):67,00,69,00,\\\r\n" // dangling continuation
 	_, err := Parse([]byte(bad))
 	if err == nil {
@@ -447,10 +447,10 @@ func TestParseRejectsUnterminatedContinuation(t *testing.T) {
 // stop reg-export from converting otherwise valid input.
 func TestParseSkipsValueDeletions(t *testing.T) {
 	src := "Windows Registry Editor Version 5.00\r\n\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Vault]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Vault]\r\n" +
 		"\"Address\"=\"https://vault.example.com:8200\"\r\n" +
 		"\"DeprecatedSetting\"=-\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r]\r\n" +
 		"\"VaultKey\"=\"r\"\r\n" +
 		"\"TargetPath\"=\"/tmp/r\"\r\n" +
 		"\"TargetFormat\"=\"text\"\r\n" +
@@ -480,24 +480,24 @@ func TestParseKindMismatchErrors(t *testing.T) {
 	}{
 		{
 			name: "string where dword expected",
-			body: "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Vault]\r\n" +
+			body: "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Vault]\r\n" +
 				"\"Address\"=\"https://vault.example.com:8200\"\r\n" +
 				"\"TLSSkipVerify\"=\"yes\"\r\n",
 			wantSubstr: "TLSSkipVerify",
 		},
 		{
 			name: "dword where string expected",
-			body: "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Vault]\r\n" +
+			body: "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Vault]\r\n" +
 				"\"Address\"=dword:00000001\r\n",
 			wantSubstr: "Address",
 		},
 		{
 			name: "string where multi-string expected",
-			body: "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r]\r\n" +
+			body: "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r]\r\n" +
 				"\"VaultKey\"=\"r\"\r\n" +
 				"\"TargetPath\"=\"/tmp/r\"\r\n" +
 				"\"TargetFormat\"=\"text\"\r\n" +
-				"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r\\OAuth]\r\n" +
+				"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r\\OAuth]\r\n" +
 				"\"Provider\"=\"github\"\r\n" +
 				"\"Scopes\"=\"repo\"\r\n",
 			wantSubstr: "Scopes",
@@ -529,14 +529,14 @@ func TestParseKindMismatchErrors(t *testing.T) {
 func TestParseCaseInsensitivePaths(t *testing.T) {
 	src := "Windows Registry Editor Version 5.00\r\n\r\n" +
 		// Lower-case Software, mixed-case dotvault, lowercase vault
-		"[HKEY_LOCAL_MACHINE\\Software\\Policies\\DotVault\\vault]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\Software\\Policies\\goodtune\\DotVault\\vault]\r\n" +
 		"\"Address\"=\"https://vault.example.com:8200\"\r\n" +
 		// Lowercase rules + oauth under it.
-		"[hkey_local_machine\\SOFTWARE\\Policies\\dotvault\\RULES\\gh]\r\n" +
+		"[hkey_local_machine\\SOFTWARE\\Policies\\goodtune\\dotvault\\RULES\\gh]\r\n" +
 		"\"VaultKey\"=\"gh\"\r\n" +
 		"\"TargetPath\"=\"/tmp/gh\"\r\n" +
 		"\"TargetFormat\"=\"text\"\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\gh\\oauth]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\gh\\oauth]\r\n" +
 		"\"Provider\"=\"github\"\r\n"
 
 	got, err := Parse([]byte(src))
@@ -562,9 +562,9 @@ func TestParseCaseInsensitivePaths(t *testing.T) {
 // value would silently degrade the config without warning.
 func TestParseRejectsUnsupportedSettingType(t *testing.T) {
 	src := "Windows Registry Editor Version 5.00\r\n\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\gh]\r\n" +
 		"\"Engine\"=\"github\"\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh\\Settings]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\gh\\Settings]\r\n" +
 		"\"port\"=dword:00000016\r\n"
 	_, err := Parse([]byte(src))
 	if err == nil {
@@ -622,11 +622,11 @@ func TestParseMultiSZPreservesMiddleEmptyElements(t *testing.T) {
 func TestParseRejectsUnterminatedMultiSZ(t *testing.T) {
 	// hex(7) for "ab" without the trailing NUL terminator pair.
 	bad := "Windows Registry Editor Version 5.00\r\n\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r]\r\n" +
 		"\"VaultKey\"=\"r\"\r\n" +
 		"\"TargetPath\"=\"/tmp/r\"\r\n" +
 		"\"TargetFormat\"=\"text\"\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r\\OAuth]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r\\OAuth]\r\n" +
 		"\"Provider\"=\"github\"\r\n" +
 		// 61,00,62,00 = "ab" UTF-16LE, missing the trailing 00,00 pair.
 		"\"Scopes\"=hex(7):61,00,62,00\r\n"
@@ -644,7 +644,7 @@ func TestParseRejectsUnterminatedMultiSZ(t *testing.T) {
 // silently producing partial config.
 func TestParseRejectsMalformedHex(t *testing.T) {
 	bad := "Windows Registry Editor Version 5.00\r\n\r\n" +
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\r]\r\n" +
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\r]\r\n" +
 		"\"TargetTemplate\"=hex(1):zz,zz\r\n"
 	if _, err := Parse([]byte(bad)); err == nil {
 		t.Errorf("expected error for malformed hex bytes")

--- a/internal/regfile/regfile.go
+++ b/internal/regfile/regfile.go
@@ -1,5 +1,5 @@
 // Package regfile renders a dotvault configuration as a Windows
-// Registry (.reg) file targeting HKLM\SOFTWARE\Policies\dotvault.
+// Registry (.reg) file targeting HKLM\SOFTWARE\Policies\goodtune\dotvault.
 //
 // The output is the canonical "Windows Registry Editor Version 5.00"
 // format encoded as UTF-16LE with a BOM, matching what regedit.exe
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	rootKey    = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault`
+	rootKey    = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault`
 	header     = "Windows Registry Editor Version 5.00\r\n\r\n"
 	maxLineLen = 76
 )

--- a/internal/regfile/regfile_test.go
+++ b/internal/regfile/regfile_test.go
@@ -53,14 +53,14 @@ func TestGenerateMinimal(t *testing.T) {
 
 	wantContains := []string{
 		"Windows Registry Editor Version 5.00\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault]\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Vault]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Vault]\r\n",
 		"\"Address\"=\"https://vault.example.com:8200\"\r\n",
 		"\"DisableTokenRenewal\"=dword:00000000\r\n",
 		"\"TLSSkipVerify\"=dword:00000000\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Sync]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Sync]\r\n",
 		"\"Interval\"=\"15m\"\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Web]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Web]\r\n",
 		"\"Enabled\"=dword:00000000\r\n",
 	}
 	for _, want := range wantContains {
@@ -93,13 +93,13 @@ func TestGenerateRulesAndOAuth(t *testing.T) {
 	got := mustGenerate(t, cfg)
 
 	wantContains := []string{
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules]\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\gh]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\gh]\r\n",
 		"\"Description\"=\"GitHub host config\"\r\n",
 		"\"TargetFormat\"=\"yaml\"\r\n",
 		"\"TargetPath\"=\"~/.config/gh/hosts.yml\"\r\n",
 		"\"VaultKey\"=\"gh\"\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Rules\\gh\\OAuth]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Rules\\gh\\OAuth]\r\n",
 		"\"Provider\"=\"github\"\r\n",
 		// REG_MULTI_SZ for ["repo", "read:org"]: "repo"\0"read:org"\0\0
 		// As UTF-16LE bytes the value starts with the prefix below; the
@@ -168,13 +168,13 @@ func TestGenerateEnrolments(t *testing.T) {
 	got := mustGenerate(t, cfg)
 
 	wantContains := []string{
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments]\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\gh]\r\n",
 		"\"Engine\"=\"github\"\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\gh\\Settings]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\gh\\Settings]\r\n",
 		"\"host\"=\"github.com\"\r\n",
 		"\"scopes\"=hex(7):",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\ssh]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\ssh]\r\n",
 		"\"Engine\"=\"ssh\"\r\n",
 		"\"passphrase\"=\"recommended\"\r\n",
 	}
@@ -212,11 +212,11 @@ func TestGenerateNestedMapSetting(t *testing.T) {
 	got := mustGenerate(t, cfg)
 
 	wantContains := []string{
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\sample]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\sample]\r\n",
 		"\"Engine\"=\"copy\"\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\sample\\Settings]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\sample\\Settings]\r\n",
 		"\"format\"=\"json\"\r\n",
-		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\dotvault\\Enrolments\\sample\\Settings\\from]\r\n",
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\goodtune\\dotvault\\Enrolments\\sample\\Settings\\from]\r\n",
 		"\"mount\"=\"kv\"\r\n",
 		"\"path\"=\"apps/sample/keys/{{.user}}\"\r\n",
 	}
@@ -352,10 +352,10 @@ func TestRulesAndEnrolmentsAreDeletedBeforeRecreate(t *testing.T) {
 	}
 	got := mustGenerate(t, cfg)
 
-	rulesDel := `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`
-	rulesKey := `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`
-	enrolDel := `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Enrolments]`
-	enrolKey := `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Enrolments]`
+	rulesDel := `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Rules]`
+	rulesKey := `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Rules]`
+	enrolDel := `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Enrolments]`
+	enrolKey := `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Enrolments]`
 
 	for _, want := range []string{rulesDel, rulesKey, enrolDel, enrolKey} {
 		if !strings.Contains(got, want) {
@@ -382,11 +382,11 @@ func TestEmptyRulesEmitsOnlyDeletion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateText: %v", err)
 	}
-	if !strings.Contains(got, `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`) {
+	if !strings.Contains(got, `[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Rules]`) {
 		t.Errorf("expected Rules deletion stanza even with no rules:\n%s", got)
 	}
 	// And no recreation key for Rules (no rules to put under it).
-	if strings.Contains(got, `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\dotvault\Rules]`+"\r\n") {
+	if strings.Contains(got, `[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\goodtune\dotvault\Rules]`+"\r\n") {
 		t.Errorf("did not expect Rules recreation when no rules present:\n%s", got)
 	}
 }

--- a/packaging/windows/dotvault.admx
+++ b/packaging/windows/dotvault.admx
@@ -17,7 +17,7 @@
 
   Rules (sync rules) are complex multi-field objects that cannot be
   fully expressed as ADMX policies. Author them as a YAML config and
-  convert with `dotvault reg-export config.yaml -o dotvault.reg`, or
+  convert with `dotvault reg-import config.yaml -o dotvault.reg`, or
   configure them by hand via Group Policy Preferences > Registry, targeting:
     SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\VaultKey      (REG_SZ)
     SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\TargetPath    (REG_SZ)

--- a/packaging/windows/dotvault.admx
+++ b/packaging/windows/dotvault.admx
@@ -9,7 +9,7 @@
   Deploy the matching ADML file to the en-US subdirectory.
 
   Registry paths used:
-    Machine: HKLM\SOFTWARE\Policies\dotvault
+    Machine: HKLM\SOFTWARE\Policies\goodtune\dotvault
 
   Only machine-level (HKLM) policy is read by dotvault. HKCU is not
   consulted because it is user-writable. When any HKLM policy key is
@@ -19,23 +19,23 @@
   fully expressed as ADMX policies. Author them as a YAML config and
   convert with `dotvault reg-export config.yaml -o dotvault.reg`, or
   configure them by hand via Group Policy Preferences > Registry, targeting:
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\VaultKey      (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\TargetPath    (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\TargetFormat  (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\TargetTemplate (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\TargetMerge   (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\Description   (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\VaultKey      (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\TargetPath    (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\TargetFormat  (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\TargetTemplate (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\TargetMerge   (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\Description   (REG_SZ)
   Optional OAuth subkey:
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\OAuth\EnginePath (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\OAuth\Provider   (REG_SZ)
-    SOFTWARE\Policies\dotvault\Rules\<rule-name>\OAuth\Scopes     (REG_MULTI_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\OAuth\EnginePath (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\OAuth\Provider   (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Rules\<rule-name>\OAuth\Scopes     (REG_MULTI_SZ)
 
   Enrolments (credential acquisition flows) are also configured via
   Group Policy Preferences > Registry, targeting:
-    SOFTWARE\Policies\dotvault\Enrolments\<name>\Engine            (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Enrolments\<name>\Engine            (REG_SZ)
   Optional Settings subkey:
-    SOFTWARE\Policies\dotvault\Enrolments\<name>\Settings\<key>    (REG_SZ)
-    SOFTWARE\Policies\dotvault\Enrolments\<name>\Settings\<key>    (REG_MULTI_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Enrolments\<name>\Settings\<key>    (REG_SZ)
+    SOFTWARE\Policies\goodtune\dotvault\Enrolments\<name>\Settings\<key>    (REG_MULTI_SZ)
 -->
 <policyDefinitions
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -77,7 +77,7 @@
             class="Machine"
             displayName="$(string.VaultAddress)"
             explainText="$(string.VaultAddress_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultAddress)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -90,7 +90,7 @@
             class="Machine"
             displayName="$(string.VaultCACert)"
             explainText="$(string.VaultCACert_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultCACert)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -103,7 +103,7 @@
             class="Machine"
             displayName="$(string.VaultTLSSkipVerify)"
             explainText="$(string.VaultTLSSkipVerify_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             valueName="TLSSkipVerify">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -115,7 +115,7 @@
             class="Machine"
             displayName="$(string.VaultKVMount)"
             explainText="$(string.VaultKVMount_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultKVMount)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -128,7 +128,7 @@
             class="Machine"
             displayName="$(string.VaultUserPrefix)"
             explainText="$(string.VaultUserPrefix_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultUserPrefix)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -141,7 +141,7 @@
             class="Machine"
             displayName="$(string.VaultAuthMethod)"
             explainText="$(string.VaultAuthMethod_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultAuthMethod)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -158,7 +158,7 @@
             class="Machine"
             displayName="$(string.VaultAuthRole)"
             explainText="$(string.VaultAuthRole_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultAuthRole)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -171,7 +171,7 @@
             class="Machine"
             displayName="$(string.VaultAuthMount)"
             explainText="$(string.VaultAuthMount_Help)"
-            key="SOFTWARE\Policies\dotvault\Vault"
+            key="SOFTWARE\Policies\goodtune\dotvault\Vault"
             presentation="$(presentation.VaultAuthMount)">
       <parentCategory ref="Vault" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -188,7 +188,7 @@
             class="Machine"
             displayName="$(string.SyncInterval)"
             explainText="$(string.SyncInterval_Help)"
-            key="SOFTWARE\Policies\dotvault\Sync"
+            key="SOFTWARE\Policies\goodtune\dotvault\Sync"
             presentation="$(presentation.SyncInterval)">
       <parentCategory ref="Sync" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -205,7 +205,7 @@
             class="Machine"
             displayName="$(string.WebEnabled)"
             explainText="$(string.WebEnabled_Help)"
-            key="SOFTWARE\Policies\dotvault\Web"
+            key="SOFTWARE\Policies\goodtune\dotvault\Web"
             valueName="Enabled">
       <parentCategory ref="WebUI" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
@@ -217,7 +217,7 @@
             class="Machine"
             displayName="$(string.WebListen)"
             explainText="$(string.WebListen_Help)"
-            key="SOFTWARE\Policies\dotvault\Web"
+            key="SOFTWARE\Policies\goodtune\dotvault\Web"
             presentation="$(presentation.WebListen)">
       <parentCategory ref="WebUI" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0" />


### PR DESCRIPTION
## Summary

- Move the Group Policy registry root from `HKLM\SOFTWARE\Policies\dotvault` to `HKLM\SOFTWARE\Policies\goodtune\dotvault` so corporate-managed Windows machines can keep all goodtune-published tools under a vendor namespace and avoid colliding with any other product that might claim a top-level `Policies\dotvault` key.
- Updated registry loader, `.reg` renderer/parser, ADMX template, CLI help text (`reg-export` / `reg-import`), and the admin/configuration docs to point at the new path.
- Tests in `internal/regfile/{regfile,parse}_test.go` updated to assert against the new key prefix; full `go test ./...` passes.

## Migration note

Existing machines that have policy at the old path will need a one-time GPO redeploy under the new key — this is a breaking change for any environment that previously rolled out `dotvault.admx` / `.reg` exports.

## Test plan

- [x] `go test ./...`
- [ ] Manual: import a generated `.reg` on a Windows machine and confirm the daemon picks up policy from the new path
- [ ] Manual: load `dotvault.admx` in `gpedit.msc` and confirm settings write to `HKLM\SOFTWARE\Policies\goodtune\dotvault`

https://claude.ai/code/session_01EHu3dowuNWzPZn3HCvfAtF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHu3dowuNWzPZn3HCvfAtF)_