### PR TITLE
docs(services): document the copy enrolment engine

### DIFF
--- a/docs/services/copy.md
+++ b/docs/services/copy.md
@@ -57,7 +57,7 @@ enrolments:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `from.mount` | _(required)_ | KV mount of the source secret (e.g. `kv`) |
-| `from.path` | _(required)_ | Path of the source secret. Supports a `{{.user}}` substitution that resolves to the authenticated Vault username (`token_meta_username`) |
+| `from.path` | _(required)_ | Path of the source secret. Supports a `{{.user}}` substitution that resolves to the local OS username (`paths.Username()`, with any `DOMAIN\` prefix stripped) |
 | `format` | `json` | Output format. Only `json` is currently supported — anything else is rejected at run time |
 | `template` | _(required)_ | Go template that renders a JSON object. Top-level keys of the rendered object become the fields written to Vault |
 
@@ -66,13 +66,13 @@ The template receives two top-level values as dot context:
 | Reference | Description |
 |-----------|-------------|
 | `.data` | The source secret's data map. Access individual fields as `{{ .data.fieldname }}` |
-| `.user` | The authenticated Vault username (same value used to substitute `{{.user}}` in `from.path`) |
+| `.user` | The local OS username (same value used to substitute `{{.user}}` in `from.path`). In deployments where the Vault identity differs from the OS login, this is the OS-side login, not `token_meta_username` |
 
 The engine wraps `text/template`, so the same helpers documented in [Templates](../configuration/templates.md) (`env`, `base64encode`, `base64decode`, `default`, `quote`) are available inside the copy template as well.
 
 ## How it works
 
-1. The manager resolves the source path by substituting `{{.user}}` for the authenticated username (so a single config line covers every user)
+1. The manager resolves the source path by substituting `{{.user}}` for the local OS username (so a single config line covers every user)
 2. dotvault reads the source secret from Vault using the daemon's own token — the user must therefore have read permission on the source path
 3. The template is executed with `{"data": <source data>, "user": <username>}` as dot context
 4. The rendered output is parsed as a JSON object. Each top-level key becomes a field to write; non-string values are coerced to their JSON textual form
@@ -86,7 +86,10 @@ The target secret is **merged**, not overwritten:
 - Keys produced by the template are written (overwriting any existing value with the same name)
 - Pre-existing keys at the target path that the template does **not** name are preserved
 
-This makes it safe to co-tenant a copy enrolment with other writers — for example, an unrelated operator process that maintains a separate field at the same Vault path. The completeness check for the enrolment looks only at the fields the template emits, so the engine never reports "incomplete" because of fields it does not own.
+The completeness check for the enrolment looks only at the fields the template emits, so the engine never reports "incomplete" because of fields it does not own — letting an unrelated operator process maintain a separate field at the same Vault path without confusing the wizard.
+
+!!! warning "No CAS — concurrent writers can clobber each other"
+    The merge is not a compare-and-swap. The engine reads the current target, computes the merged result, and writes back via `KVv2.Put` without checking that the version has not changed in between. Any field a third party writes to the target path between the read and the write will be lost on the next copy refresh. The "merge, don't replace" guarantee therefore covers same-version snapshots and non-concurrent writers only; if you need stronger co-tenancy, drive the other writer through a workflow that runs while the daemon is paused, or partition fields so only one process ever writes a given path.
 
 !!! warning "Stringified preservation"
     Preserved values are stringified, not type-preserved. The engine returns `map[string]string`, so any pre-existing object, number, or boolean field at the target is JSON-marshalled to its textual form before being written back. This is intentional (dropping non-strings would lose data) but means the copy engine should not share a target path with workflows that depend on KVv2 fields keeping their original JSON type.

--- a/docs/services/copy.md
+++ b/docs/services/copy.md
@@ -2,7 +2,7 @@
 
 The `copy` enrolment engine mirrors an existing Vault KVv2 secret into the user's enrolment path, optionally reshaping it through a Go template. It is the right choice when another tool (or an operator workflow) already populates a per-user secret under a shared prefix and dotvault needs to expose that value to the user under their own path — usually with different field names — without re-running an interactive flow.
 
-Unlike the OAuth and key-generation engines, the copy engine is fully automated: there is no browser flow, no terminal prompt, and no clipboard handoff. The first invocation runs synchronously like any other enrolment, and after that the daemon's `WatchManager` keeps the target in sync whenever the source changes.
+Unlike the OAuth and key-generation engines, the copy engine is fully automated: there is no browser flow, no terminal prompt, and no clipboard handoff. The daemon's `WatchManager` runs the engine on its own — not the wizard — so a copy enrolment converges from the background even in headless mode (no TTY, no web UI), where the interactive wizard is skipped entirely. `WatchManager.Start` is invoked before any enrolment UI, and its first action is an immediate `tickAll` that performs the initial mirror, after which polling and (on Vault Enterprise) `kv-v2/data-write` events keep the target in sync whenever the source changes.
 
 ## Configuration
 
@@ -97,6 +97,9 @@ The completeness check for the enrolment looks only at the fields the template e
 ### Dynamic field set
 
 Most engines declare a static list of fields they write via `Fields()`. The copy engine cannot — the field set is whatever the template produces. The engine implements the optional `SettingsFielder` interface instead, parsing the template source (with `{{ ... }}` actions replaced by `null`) to infer the top-level JSON keys without executing it. The manager treats the enrolment as complete only when every inferred key is present in the target secret.
+
+!!! warning "Top-level keys must be literal"
+    Field inference is performed on the raw template, with every `{{ ... }}` action substituted by `null`. This means top-level JSON keys are read straight from the template source: a key written as `"{{ .data.name }}"` is inferred as the literal string `"null"` (or, for multiple templated keys, deduplicated to a single `"null"` entry), the completeness check will look for a field called `null` in the target, and the enrolment will appear incomplete on every cycle. Always spell the top-level keys you intend to write as literal strings — `{{ ... }}` actions belong inside the values, not the keys.
 
 If the template is missing, syntactically invalid JSON, or has actions inside quoted-string arguments containing literal `}}`, field inference falls back to `nil` and the manager treats the enrolment as incomplete on every cycle — surfacing the misconfiguration rather than silently skipping it.
 

--- a/docs/services/copy.md
+++ b/docs/services/copy.md
@@ -1,0 +1,139 @@
+# Copy Onboarding
+
+The `copy` enrolment engine mirrors an existing Vault KVv2 secret into the user's enrolment path, optionally reshaping it through a Go template. It is the right choice when another tool (or an operator workflow) already populates a per-user secret under a shared prefix and dotvault needs to expose that value to the user under their own path — usually with different field names — without re-running an interactive flow.
+
+Unlike the OAuth and key-generation engines, the copy engine is fully automated: there is no browser flow, no terminal prompt, and no clipboard handoff. The first invocation runs synchronously like any other enrolment, and after that the daemon's `WatchManager` keeps the target in sync whenever the source changes.
+
+## Configuration
+
+### Minimal
+
+```yaml
+enrolments:
+  sample:
+    engine: copy
+    settings:
+      from:
+        mount: kv
+        path: "apps/sample/keys/{{.user}}"
+      format: json
+      template: |
+        {
+          "token": "{{ .data.key }}"
+        }
+
+rules:
+  - name: sample
+    vault_key: "sample"
+    target:
+      path: "~/.config/sample/credentials"
+      format: text
+      template: "{{ .token }}"
+```
+
+With the example above, an operator who populates `kv/apps/sample/keys/alice` (with a field `key`) makes the value available to user `alice` at `kv/users/alice/sample` under the field `token`, which the sync rule then writes to disk.
+
+### Renaming several fields at once
+
+```yaml
+enrolments:
+  artifactory-readonly:
+    engine: copy
+    settings:
+      from:
+        mount: kv
+        path: "shared/artifactory/{{.user}}"
+      format: json
+      template: |
+        {
+          "username": "{{ .data.user }}",
+          "password": "{{ .data.api_key }}",
+          "url": "{{ .data.url }}"
+        }
+```
+
+## Settings reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `from.mount` | _(required)_ | KV mount of the source secret (e.g. `kv`) |
+| `from.path` | _(required)_ | Path of the source secret. Supports a `{{.user}}` substitution that resolves to the authenticated Vault username (`token_meta_username`) |
+| `format` | `json` | Output format. Only `json` is currently supported — anything else is rejected at run time |
+| `template` | _(required)_ | Go template that renders a JSON object. Top-level keys of the rendered object become the fields written to Vault |
+
+The template receives two top-level values as dot context:
+
+| Reference | Description |
+|-----------|-------------|
+| `.data` | The source secret's data map. Access individual fields as `{{ .data.fieldname }}` |
+| `.user` | The authenticated Vault username (same value used to substitute `{{.user}}` in `from.path`) |
+
+The engine wraps `text/template`, so the same helpers documented in [Templates](../configuration/templates.md) (`env`, `base64encode`, `base64decode`, `default`, `quote`) are available inside the copy template as well.
+
+## How it works
+
+1. The manager resolves the source path by substituting `{{.user}}` for the authenticated username (so a single config line covers every user)
+2. dotvault reads the source secret from Vault using the daemon's own token — the user must therefore have read permission on the source path
+3. The template is executed with `{"data": <source data>, "user": <username>}` as dot context
+4. The rendered output is parsed as a JSON object. Each top-level key becomes a field to write; non-string values are coerced to their JSON textual form
+5. The target enrolment path is read. Any existing keys are preserved unless the template explicitly overwrites them
+6. The merged map is written back to Vault, creating a new KVv2 version
+
+### Merge, don't replace
+
+The target secret is **merged**, not overwritten:
+
+- Keys produced by the template are written (overwriting any existing value with the same name)
+- Pre-existing keys at the target path that the template does **not** name are preserved
+
+This makes it safe to co-tenant a copy enrolment with other writers — for example, an unrelated operator process that maintains a separate field at the same Vault path. The completeness check for the enrolment looks only at the fields the template emits, so the engine never reports "incomplete" because of fields it does not own.
+
+!!! warning "Stringified preservation"
+    Preserved values are stringified, not type-preserved. The engine returns `map[string]string`, so any pre-existing object, number, or boolean field at the target is JSON-marshalled to its textual form before being written back. This is intentional (dropping non-strings would lose data) but means the copy engine should not share a target path with workflows that depend on KVv2 fields keeping their original JSON type.
+
+### Dynamic field set
+
+Most engines declare a static list of fields they write via `Fields()`. The copy engine cannot — the field set is whatever the template produces. The engine implements the optional `SettingsFielder` interface instead, parsing the template source (with `{{ ... }}` actions replaced by `null`) to infer the top-level JSON keys without executing it. The manager treats the enrolment as complete only when every inferred key is present in the target secret.
+
+If the template is missing, syntactically invalid JSON, or has actions inside quoted-string arguments containing literal `}}`, field inference falls back to `nil` and the manager treats the enrolment as incomplete on every cycle — surfacing the misconfiguration rather than silently skipping it.
+
+### Periodic re-evaluation
+
+The engine implements the `Watcher` interface, so the daemon's `WatchManager` keeps the target in sync after the initial enrolment:
+
+- **Poll cycle** — on every tick of the configured sync interval, the manager re-runs the engine and writes back only when the merged result differs from the current target. Identical evaluations are skipped, so KVv2 versions are not bumped spuriously.
+- **Event-driven refresh (Vault Enterprise)** — the manager subscribes to the `kv-v2/data-write` event type, filters events client-side against the resolved `from.mount`/`from.path` for each copy enrolment, and triggers an immediate refresh on a match. Subscription failures degrade gracefully to poll-only, mirroring the sync engine's reconnection behaviour.
+
+Per-enrolment exponential backoff isolates a single flaky upstream from blocking the others.
+
+## Credentials stored in Vault
+
+There is no fixed list — the engine writes exactly the top-level keys produced by your template, plus any pre-existing keys at the target path. For example, with:
+
+```yaml
+template: |
+  {
+    "username": "{{ .data.user }}",
+    "password": "{{ .data.api_key }}"
+  }
+```
+
+dotvault writes the fields `username` and `password` at the target enrolment path. The completeness check expects exactly those two fields, regardless of what the source secret contains.
+
+## Requirements
+
+- The dotvault daemon's Vault token must have read permission on the source mount and path
+- The source secret must already exist when the enrolment runs — the engine does not create source secrets, only consumes them. Missing source secrets fail the enrolment with a clear error
+- Only `json` is supported for `format`. YAML / INI / TOML / text / netrc targets are out of scope: copy is for reshaping structured KV data, and JSON is the only round-trippable representation that aligns with KVv2's data model
+
+## Combining enrolment with sync
+
+A typical setup pairs the enrolment with a sync rule so the workflow is:
+
+1. An operator (or another automation) writes a per-user secret to `kv/apps/sample/keys/alice`
+2. dotvault, running as `alice`, checks Vault for `users/alice/sample` — the template's fields are absent
+3. The copy engine reads `apps/sample/keys/alice`, renders the template, and writes the result to `users/alice/sample`
+4. The sync rule picks up the new secret and writes the local file
+5. On every subsequent poll (and on `data-write` events on Vault Enterprise), the WatchManager re-evaluates the copy and writes back only if the result has changed
+
+On subsequent daemon starts the enrolment check finds the template's fields already present and skips the interactive part of the wizard, but the WatchManager continues to mirror upstream changes for as long as the daemon is running.

--- a/docs/services/copy.md
+++ b/docs/services/copy.md
@@ -102,7 +102,7 @@ The completeness check for the enrolment looks only at the fields the template e
 
 ### Dynamic field set
 
-Most engines declare a static list of fields they write via `Fields()`. The copy engine cannot — the field set is whatever the template produces. The engine implements the optional `SettingsFielder` interface instead, parsing the template source (with `{{ ... }}` actions replaced by `null`) to infer the top-level JSON keys without executing it. The manager treats the enrolment as complete only when every inferred key is present in the target secret.
+Most engines declare a static list of fields they write via `Fields()`. The copy engine cannot — the field set is whatever the template produces. The engine implements the optional `SettingsFielder` interface instead, parsing the template source (with `{{ ... }}` actions replaced by `null`) to infer the top-level JSON keys without executing it. The manager (via `enrol.HasAllFields`) treats the enrolment as complete only when every inferred key is present in the target secret **and** holds a non-empty string value (the check trims whitespace, so whitespace-only values count as empty). A template that renders `""` — or just whitespace — for an inferred field will keep the enrolment pending forever, so make sure each inferred key receives a real value (use `default` from the template helpers when the source field may be absent).
 
 !!! warning "Top-level keys must be literal"
     Field inference is performed on the raw template, with every `{{ ... }}` action substituted by `null`. This means top-level JSON keys are read straight from the template source: a key written as `"{{ .data.name }}"` is inferred as the literal string `"null"` (or, for multiple templated keys, deduplicated to a single `"null"` entry), the completeness check will look for a field called `null` in the target, and the enrolment will appear incomplete on every cycle. Always spell the top-level keys you intend to write as literal strings — `{{ ... }}` actions belong inside the values, not the keys.
@@ -130,7 +130,7 @@ template: |
   }
 ```
 
-dotvault writes the fields `username` and `password` at the target enrolment path. The completeness check expects exactly those two fields, regardless of what the source secret contains.
+dotvault writes the fields `username` and `password` at the target enrolment path. The completeness check expects exactly those two fields to be present as non-empty strings, regardless of what the source secret contains; if `.data.user` or `.data.api_key` is missing or empty, the rendered value will be empty and the enrolment will be retried on every cycle until the source secret is fixed.
 
 ## Requirements
 

--- a/docs/services/copy.md
+++ b/docs/services/copy.md
@@ -2,7 +2,13 @@
 
 The `copy` enrolment engine mirrors an existing Vault KVv2 secret into the user's enrolment path, optionally reshaping it through a Go template. It is the right choice when another tool (or an operator workflow) already populates a per-user secret under a shared prefix and dotvault needs to expose that value to the user under their own path — usually with different field names — without re-running an interactive flow.
 
-Unlike the OAuth and key-generation engines, the copy engine is fully automated: there is no browser flow, no terminal prompt, and no clipboard handoff. The daemon's `WatchManager` runs the engine on its own — not the wizard — so a copy enrolment converges from the background even in headless mode (no TTY, no web UI), where the interactive wizard is skipped entirely. `WatchManager.Start` is invoked before any enrolment UI, and its first action is an immediate `tickAll` that performs the initial mirror, after which polling and (on Vault Enterprise) `kv-v2/data-write` events keep the target in sync whenever the source changes.
+Unlike the OAuth and key-generation engines, the copy engine is fully automated: there is no browser flow, no terminal prompt, and no clipboard handoff. Either of three paths can perform the initial mirror — whichever reaches the engine first wins, and the others see the target already populated and become no-ops:
+
+- The CLI wizard's `enrolMgr.CheckAll(ctx)` invocation, which calls `engine.Run` for any pending engine
+- The web enrolment runner, which does the same for the browser-driven flow
+- The daemon's `WatchManager`, whose `Start` is invoked before any enrolment UI and whose first action is an immediate `tickAll` that performs the mirror
+
+The practical consequence is that copy enrolments converge even in headless mode (no TTY, no web UI), where the interactive wizard is skipped entirely — `WatchManager` keeps running and will produce the same result on its first tick. After the initial population, polling and (on Vault Enterprise) `kv-v2/data-write` events keep the target in sync whenever the source changes.
 
 ## Configuration
 

--- a/docs/services/copy.md
+++ b/docs/services/copy.md
@@ -127,7 +127,7 @@ dotvault writes the fields `username` and `password` at the target enrolment pat
 
 - The dotvault daemon's Vault token must have read permission on the source mount and path
 - The source secret must already exist when the enrolment runs — the engine does not create source secrets, only consumes them. Missing source secrets fail the enrolment with a clear error
-- Only `json` is supported for `format`. YAML / INI / TOML / text / netrc targets are out of scope: copy is for reshaping structured KV data, and JSON is the only round-trippable representation that aligns with KVv2's data model
+- The engine's `settings.format` must be `json`. This governs only how the rendered template is parsed before being written to Vault — sync rules consuming the resulting KVv2 secret can still target any of the supported file formats (`yaml`, `json`, `ini`, `toml`, `text`, `netrc`), as the minimal example above demonstrates with a `text` target
 
 ## Combining enrolment with sync
 

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -36,12 +36,14 @@ Enrolment configuration changes are detected on each polling tick without requir
 | `github` | GitHub / GitHub Enterprise | OAuth device flow |
 | `jfrog` | JFrog Platform / Artifactory | Browser-based web login + token rotation |
 | `ssh` | SSH key generation | Ed25519 key pair |
+| `copy` | Mirror an existing Vault KVv2 secret | Non-interactive; template-driven copy with periodic re-evaluation |
 
 See the individual engine pages for details:
 
 - [GitHub CLI](github.md)
 - [JFrog Platform](jfrog.md)
 - [SSH Keys](ssh.md)
+- [Copy](copy.md)
 
 ## Engine interface
 
@@ -50,5 +52,11 @@ Engines implement a simple interface:
 - **`Name()`** — human-readable provider name for display
 - **`Run(ctx, settings, io)`** — execute the credential acquisition flow
 - **`Fields()`** — Vault KV field names this engine writes (used to check completeness)
+
+Engines that need extra behaviour layer it on through optional interfaces the manager probes for at run time:
+
+- **`SettingsFielder`** — for engines whose written-field set is determined by per-enrolment settings rather than being static (used by `copy`, where the JSON template decides the keys)
+- **`Refresher`** — for engines whose credentials expire and can be rotated without user interaction (used by `jfrog`); driven by the daemon's `RefreshManager`
+- **`Watcher`** — for engines whose output is derived from upstream Vault data and must track source changes (used by `copy`); driven by the daemon's `WatchManager`, which polls on every sync interval and reacts to `kv-v2/data-write` events on Vault Enterprise
 
 This means new engines can be added to support additional services without changes to the core enrolment system.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - GitHub CLI: services/github.md
       - JFrog Platform: services/jfrog.md
       - SSH Keys: services/ssh.md
+      - Copy: services/copy.md
   - Web UI: web-ui.md
   - Admin Guide:
       - Deployment: admin/deployment.md


### PR DESCRIPTION
## Summary

- Add `docs/services/copy.md` with a full page covering configuration, template context (`.data` / `.user`), merge-preserve semantics, dynamic field inference via `SettingsFielder`, and watch-driven refresh (poll + Enterprise events)
- Add a `copy` row to the engine matrix in `docs/services/overview.md` and expand the engine-interface section with the optional `SettingsFielder` / `Refresher` / `Watcher` interfaces so the role of copy in the system is explicit
- Add the new page to the `mkdocs.yml` Service Onboarding navigation

## Test plan

- [ ] `mkdocs build` (or `mkdocs serve`) renders without warnings and the new `Copy` entry appears under Service Onboarding
- [ ] Internal links from `services/overview.md` to `copy.md` resolve in the rendered site
- [ ] Doc examples match `config.dev.yaml`'s `sample` enrolment (source mount/path, template shape)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QaBoi5DWtFY3gFbCWoZrgx)_