### PR TITLE
feat(cli): split daemon/login commands, recover from expired tokens without restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,14 +103,38 @@ On Windows, if Group Policy registry keys exist at `HKLM\SOFTWARE\Policies\goodt
 ## CLI
 
 ```
-dotvault            Run daemon (default command)
-dotvault run        Explicit daemon mode (same as bare invocation)
-dotvault sync       One-shot sync cycle, then exit
-dotvault status     Display auth state, token TTL, per-rule sync state
-dotvault version    Print build version
-dotvault reg-export Convert a Windows .reg file to YAML (or canonical .reg)
-dotvault reg-import Convert a YAML config to a Windows .reg file
+dotvault             Print help (no implicit daemon start)
+dotvault run         Run the long-lived daemon
+dotvault sync        One-shot sync cycle, then exit
+dotvault login       Force a fresh login via the configured auth method
+dotvault login-check Validate/renew cached token on interactive login (tty-aware)
+dotvault status      Display auth state, token TTL, per-rule sync state
+dotvault version     Print build version
+dotvault reg-export  Convert a Windows .reg file to YAML (or canonical .reg)
+dotvault reg-import  Convert a YAML config to a Windows .reg file
 ```
+
+Running `dotvault` with no subcommand prints help — the daemon is no
+longer the default. Use `dotvault run` to start it explicitly.
+
+`dotvault login` always runs the configured fresh-auth flow (OIDC, LDAP),
+ignoring any cached token. It is the dotvault-config-driven analogue of
+`vault login -address … -method …` and is the natural entry point when a
+running daemon needs a new token after expiry.
+
+`dotvault login-check` is intended for interactive-shell login profiles:
+
+- If stdout is not a TTY the command exits silently (status 0) so
+  non-interactive callers (cron, sshd ForceCommand, scp) never see a
+  prompt.
+- If a cached token is valid and still within the first half of its
+  creation TTL, exit clean.
+- If the cached token is valid but past the halfway mark, attempt renewal.
+  On renewal failure where the token is still valid, warn with the
+  absolute expiry time and exit 0.
+- If the cached token is missing or invalid, run the configured login
+  flow. Ctrl-C exits without fanfare (so a user can dismiss the prompt
+  on a fresh terminal without leaving an error in their scrollback).
 
 The naming follows regedit's `/e` (export) and `/s` (import) directional
 convention: `reg-export` pulls policy out of the registry world into a
@@ -146,7 +170,7 @@ in-memory `*config.Config` and routes through the same regfile renderers,
 so a daemon that loaded its config from a Windows GPO can be exported
 back as YAML (or vice versa) without restart.
 
-Flags: `--config <path>`, `--log-level debug|info|warn|error`, `--dry-run`, `--once` (redirects to sync from within runDaemon).
+Flags: `--config <path>`, `--log-level debug|info|warn|error`, `--dry-run`. Subcommand-scoped: `--once` on `dotvault run` redirects to the sync path.
 
 Logging uses `log/slog` — text format when stderr is a TTY, JSON otherwise. Always writes to stderr; no file-based logging.
 
@@ -179,7 +203,24 @@ Async login state machine (`internal/auth/login.go`) shared by CLI and web paths
 
 ### Token Lifecycle
 
-`LifecycleManager` checks token TTL every 5 minutes. Renews at 75% remaining TTL. Signals re-auth needed on 403 Forbidden or token expiration. In web mode, re-auth opens the browser to the web UI root.
+`LifecycleManager` checks token TTL every 5 minutes. Renews at 75% remaining TTL.
+On detecting an invalid/expired token (403 Forbidden or TTL=0 + concrete
+`expire_time`) the manager runs a recovery sequence:
+
+1. Re-read the token file (and `VAULT_TOKEN` env). If a different value
+   is present and `LookupSelf` succeeds with it, swap the in-memory token
+   on the Vault client, clear the needs-reauth flag, and return to the
+   normal 5-minute check cadence. This lets a parallel `dotvault login`
+   recover a running daemon without a restart.
+2. If no fresh token is on disk, signal re-auth: fire the registered
+   `OnReauth` callback (web mode clears the in-memory token, invalidating
+   any browser session sitting on a stale "logged-in" view), push an
+   error on the error channel, and switch to a 10-second recovery poll
+   so a subsequent token write is picked up quickly.
+
+In web mode the daemon also re-opens the browser to the web UI root when
+the lifecycle manager signals re-auth, subject to a 10-minute cooldown
+to avoid flapping during transient errors.
 
 ## Sync Engine
 

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -672,6 +672,12 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 			// Clear it and fall through to the interactive login flow.
 			vc.SetToken("")
 		} else {
+			// Ctrl-C during LookupSelf surfaces as a wrapped
+			// context.Canceled here — exit silently to honour the
+			// command's documented "Ctrl-C without fanfare" contract.
+			if loginCheckCancelled(ctx, lookupErr) {
+				return nil
+			}
 			// Transient Vault/TLS/network error. A shell startup hook
 			// should not invent an interactive login prompt every time
 			// the user opens a terminal while their VPN is reconnecting
@@ -695,6 +701,12 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 	_, healthErr := vc.ServerHealth(healthCtx)
 	healthCancel()
 	if healthErr != nil {
+		// Ctrl-C during the health probe inherits cancellation from the
+		// outer signal context. Suppress the warning in that case so the
+		// shell scrollback stays clean.
+		if loginCheckCancelled(ctx, healthErr) {
+			return nil
+		}
 		fmt.Fprintf(os.Stderr, "vault unreachable (will retry on next login): %v\n", healthErr)
 		return nil
 	}
@@ -713,7 +725,7 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 	}
 	if err := mgr.Login(ctx); err != nil {
 		// Ctrl-C: silent exit. The user dismissed the prompt knowingly.
-		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+		if loginCheckCancelled(ctx, err) {
 			return nil
 		}
 		return fmt.Errorf("login: %w", err)
@@ -781,6 +793,12 @@ func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Se
 	}
 
 	if _, err := vc.RenewSelf(ctx, 0); err != nil {
+		// Ctrl-C during renewal: exit silently (the command's documented
+		// contract), leaving the cached token in place — it's still
+		// valid, just not yet renewed this session.
+		if loginCheckCancelled(ctx, err) {
+			return true, err
+		}
 		fmt.Fprintf(os.Stderr, "vault token renewal failed: %v\n", err)
 		fmt.Fprintf(os.Stderr, "token is still valid but nearing expiry: %s remaining, expires %s\n",
 			ttl.Truncate(time.Second), absoluteExpiry(ttl))
@@ -788,6 +806,21 @@ func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Se
 	}
 	fmt.Fprintln(os.Stderr, "vault token renewed")
 	return true, nil
+}
+
+// loginCheckCancelled reports whether err is a context-cancellation
+// (i.e. the user pressed Ctrl-C). Used at every login-check error site
+// to honour the command's "Ctrl-C exits without fanfare" contract — a
+// cancelled lookup, health probe, or renewal must not leave warnings
+// in the shell's startup scrollback.
+func loginCheckCancelled(ctx context.Context, err error) bool {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return false
 }
 
 func readSecondsField(data map[string]any, key string) (int64, bool) {

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -21,6 +23,7 @@ import (
 	"github.com/goodtune/dotvault/internal/tray"
 	"github.com/goodtune/dotvault/internal/vault"
 	"github.com/goodtune/dotvault/internal/web"
+	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -42,23 +45,65 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "dotvault",
 		Short: "Vault-to-file secret synchronisation daemon",
-		RunE:  runDaemon,
+		Long: `dotvault synchronises Vault KVv2 secrets into local config files.
+
+Run with no subcommand prints this help. Use "dotvault run" to start the
+long-lived daemon, "dotvault login-check" to validate (and optionally
+renew) the cached token on an interactive login, or "dotvault login" to
+force a fresh login flow.`,
+		// Cobra's default RunE for a command with no Run/RunE prints help
+		// when called bare, which is what we want — explicitly running the
+		// daemon now requires `dotvault run`.
+		SilenceUsage: true,
 	}
 
 	rootCmd.PersistentFlags().StringVar(&flagConfig, "config", "", "override system config path")
 	rootCmd.PersistentFlags().StringVar(&flagLogLevel, "log-level", "info", "log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().BoolVar(&flagDryRun, "dry-run", false, "show what would change without writing")
 
+	runCmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run daemon in foreground",
+		RunE:  runDaemon,
+	}
+	// --once on the daemon means "do one sync and exit" — keep it as a
+	// subcommand-scoped flag so it doesn't pollute the global flag list.
+	runCmd.Flags().Bool("once", false, "run one sync cycle and exit")
+
 	rootCmd.AddCommand(
-		&cobra.Command{
-			Use:   "run",
-			Short: "Run daemon in foreground",
-			RunE:  runDaemon,
-		},
+		runCmd,
 		&cobra.Command{
 			Use:   "sync",
 			Short: "Run one sync cycle and exit",
 			RunE:  runSync,
+		},
+		&cobra.Command{
+			Use:   "login",
+			Short: "Run the configured Vault login flow (always fresh)",
+			Long: `Run the configured Vault login flow, ignoring any cached token.
+Equivalent to "vault login -address <vault.address> -method <vault.auth_method>"
+but driven by dotvault's loaded configuration (YAML or Group Policy).`,
+			RunE: runLogin,
+		},
+		&cobra.Command{
+			Use:   "login-check",
+			Short: "Validate cached token on interactive login, renew or re-login as needed",
+			Long: `Intended to be wired into shell rc / login-profile scripts.
+
+If stdout is not a terminal the command exits silently with status 0 so
+non-interactive environments (cron, system services, scp) never see a
+prompt.
+
+When run on an interactive terminal:
+  - If the cached token is valid and still within the first half of its
+    creation TTL, exit clean.
+  - If the cached token is valid but past the halfway point, attempt
+    renewal. If renewal succeeds, exit clean. If renewal fails but the
+    token is still valid, warn with the absolute expiry time and exit 0.
+  - If the cached token is missing or invalid, run the configured login
+    flow. Ctrl-C exits without fanfare so the user can dismiss the prompt
+    on a fresh terminal session.`,
+			RunE: runLoginCheck,
 		},
 		&cobra.Command{
 			Use:   "status",
@@ -75,9 +120,6 @@ func main() {
 		newRegExportCmd(),
 		newRegImportCmd(),
 	)
-
-	// --once as alias for sync
-	rootCmd.PersistentFlags().Bool("once", false, "run one sync cycle and exit")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -259,8 +301,17 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Start token lifecycle manager.
+	// Start token lifecycle manager. Wire the token-file path so that on
+	// detecting an invalid token the manager can pick up a fresh value
+	// written by an external facility (`dotvault login`) before forcing a
+	// full re-auth. In web mode register a callback that clears the
+	// in-memory token, invalidating any browser session sitting on a
+	// stale "logged-in" view.
 	lm := auth.NewLifecycleManager(vc, 5*time.Minute, cfg.Vault.DisableTokenRenewal)
+	lm.SetTokenFilePath(tokenPath)
+	if webServer != nil {
+		lm.SetOnReauth(webServer.ForceReauth)
+	}
 	lifecycleErrCh := lm.Start(ctx)
 
 	// Start refresh manager for any enrolment whose engine rotates its own
@@ -516,6 +567,209 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// runLogin implements `dotvault login` — always forces a fresh login via
+// the configured method, ignoring any cached token. This mirrors
+// `vault login -address <vault.address> -method <vault.auth_method>` but
+// is driven from dotvault's loaded configuration (YAML or GPO) so the
+// user doesn't have to re-specify the same parameters on the CLI.
+func runLogin(cmd *cobra.Command, args []string) error {
+	setupLogging()
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	username, err := paths.Username()
+	if err != nil {
+		return fmt.Errorf("resolve username: %w", err)
+	}
+
+	vc, err := vault.NewClient(vault.Config{
+		Address:       cfg.Vault.Address,
+		CACert:        cfg.Vault.CACert,
+		TLSSkipVerify: cfg.Vault.TLSSkipVerify,
+	})
+	if err != nil {
+		return fmt.Errorf("create vault client: %w", err)
+	}
+
+	mgr := &auth.Manager{
+		VaultClient:   vc,
+		TokenFilePath: paths.VaultTokenPath(),
+		AuthMethod:    cfg.Vault.AuthMethod,
+		AuthMount:     cfg.Vault.AuthMount,
+		AuthRole:      cfg.Vault.AuthRole,
+		Username:      username,
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := mgr.Login(ctx); err != nil {
+		// Ctrl-C should exit quietly — the user knows they cancelled.
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return fmt.Errorf("login: %w", err)
+	}
+	return nil
+}
+
+// runLoginCheck implements `dotvault login-check`, intended to be called
+// from a user's interactive-shell login profile. The semantics are
+// described in the command's Long help text.
+func runLoginCheck(cmd *cobra.Command, args []string) error {
+	// Only attach the slog default in interactive mode — non-interactive
+	// callers should be completely silent. We still log to stderr (text
+	// handler) in the interactive path so renewal/failure messages reach
+	// the operator.
+	if !isStdoutTerminal() {
+		// No tty: nothing for us to do. Exit clean rather than blocking
+		// or emitting JSON-shaped logs into the shell startup output.
+		return nil
+	}
+	setupLogging()
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	vc, err := vault.NewClient(vault.Config{
+		Address:       cfg.Vault.Address,
+		CACert:        cfg.Vault.CACert,
+		TLSSkipVerify: cfg.Vault.TLSSkipVerify,
+	})
+	if err != nil {
+		return fmt.Errorf("create vault client: %w", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	tokenPath := paths.VaultTokenPath()
+	token := auth.ResolveToken(tokenPath)
+	if token != "" {
+		vc.SetToken(token)
+		secret, lookupErr := vc.LookupSelf(ctx)
+		if lookupErr == nil {
+			// Token valid. Decide whether to renew based on how much of
+			// the original TTL has been consumed.
+			handled, err := handleValidToken(ctx, vc, secret)
+			if err != nil {
+				// Renewal failed but token still valid — already warned
+				// inside handleValidToken; exit 0 anyway.
+				return nil
+			}
+			if handled {
+				return nil
+			}
+		} else {
+			// Token invalid — proceed to login.
+			vc.SetToken("")
+		}
+	}
+
+	// No valid token: run the configured login flow.
+	username, err := paths.Username()
+	if err != nil {
+		return fmt.Errorf("resolve username: %w", err)
+	}
+	mgr := &auth.Manager{
+		VaultClient:   vc,
+		TokenFilePath: tokenPath,
+		AuthMethod:    cfg.Vault.AuthMethod,
+		AuthMount:     cfg.Vault.AuthMount,
+		AuthRole:      cfg.Vault.AuthRole,
+		Username:      username,
+	}
+	if err := mgr.Login(ctx); err != nil {
+		// Ctrl-C: silent exit. The user dismissed the prompt knowingly.
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return fmt.Errorf("login: %w", err)
+	}
+	return nil
+}
+
+// handleValidToken inspects a successful LookupSelf response and decides
+// whether to renew the token. Returns (handled=true, err=nil) when the
+// token is fresh enough to leave alone or was renewed successfully.
+// Returns (false, nil) for tokens with no TTL data (caller falls through
+// to login). On renewal failure where the token is still valid, the
+// function warns and returns (true, non-nil err) — the caller treats
+// this as "leave the token, exit clean".
+func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Secret) (bool, error) {
+	ttlSec, ok := readSecondsField(secret.Data, "ttl")
+	if !ok {
+		// Non-expiring token (e.g. root) — nothing to do.
+		return true, nil
+	}
+	ttl := time.Duration(ttlSec) * time.Second
+	creationTTLSec, _ := readSecondsField(secret.Data, "creation_ttl")
+	creationTTL := time.Duration(creationTTLSec) * time.Second
+
+	renewableRaw, _ := secret.Data["renewable"]
+	renewable, _ := renewableRaw.(bool)
+
+	// If we have a creation TTL, compare remaining TTL against half of
+	// it. Otherwise fall back to "remaining ttl > 15m means fresh", which
+	// matches the daemon's renewal heuristic for tokens with unknown
+	// creation TTL.
+	threshold := creationTTL / 2
+	if creationTTL == 0 {
+		threshold = 15 * time.Minute
+	}
+
+	if ttl > threshold {
+		// Still in the fresh half — nothing to do.
+		return true, nil
+	}
+
+	if !renewable {
+		fmt.Fprintf(os.Stderr, "vault token is past halfway (%s remaining) and not renewable; expires %s\n",
+			ttl.Truncate(time.Second), absoluteExpiry(ttl))
+		return true, nil
+	}
+
+	if _, err := vc.RenewSelf(ctx, 0); err != nil {
+		fmt.Fprintf(os.Stderr, "vault token renewal failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "token is still valid but nearing expiry: %s remaining, expires %s\n",
+			ttl.Truncate(time.Second), absoluteExpiry(ttl))
+		return true, err
+	}
+	fmt.Fprintln(os.Stderr, "vault token renewed")
+	return true, nil
+}
+
+func readSecondsField(data map[string]any, key string) (int64, bool) {
+	v, ok := data[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case json.Number:
+		s, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return s, true
+	case float64:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	}
+	return 0, false
+}
+
+func absoluteExpiry(ttl time.Duration) string {
+	return time.Now().Add(ttl).Format(time.RFC3339)
 }
 
 func authenticate(ctx context.Context, cfg *config.Config) (string, *vault.Client, error) {
@@ -787,6 +1041,13 @@ func validateYAML(data []byte) error {
 // pick the slog text vs JSON handler at startup.
 func isStderrTerminal() bool {
 	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// isStdoutTerminal reports whether stdout is connected to a TTY. Used by
+// `dotvault login-check` to silently no-op when invoked from a
+// non-interactive shell (cron, sshd ForceCommand, scp, etc.).
+func isStdoutTerminal() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // isInteractive reports whether stdin is connected to a TTY, i.e. whether

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -682,7 +682,23 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// No valid token: run the configured login flow.
+	// No valid token: preflight Vault connectivity before falling through
+	// to the configured login flow. Without this, an LDAP login would
+	// prompt for the user's password and only then discover that the
+	// network/TLS/Vault layer is broken — login-check is supposed to be
+	// quiet on a flaky boot, not interrogate the user mid-coffee.
+	// `Sys().Health` is unauthenticated and exposed on every Vault
+	// install, so it's the cheapest discriminator between "Vault is
+	// reachable, our token is just gone" and "Vault itself is
+	// unreachable".
+	healthCtx, healthCancel := context.WithTimeout(ctx, 5*time.Second)
+	_, healthErr := vc.ServerHealth(healthCtx)
+	healthCancel()
+	if healthErr != nil {
+		fmt.Fprintf(os.Stderr, "vault unreachable (will retry on next login): %v\n", healthErr)
+		return nil
+	}
+
 	username, err := paths.Username()
 	if err != nil {
 		return fmt.Errorf("resolve username: %w", err)

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -667,9 +667,18 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 			if handled {
 				return nil
 			}
-		} else {
-			// Token invalid — proceed to login.
+		} else if vault.IsForbidden(lookupErr) {
+			// 403: the cached token is revoked or otherwise invalid.
+			// Clear it and fall through to the interactive login flow.
 			vc.SetToken("")
+		} else {
+			// Transient Vault/TLS/network error. A shell startup hook
+			// should not invent an interactive login prompt every time
+			// the user opens a terminal while their VPN is reconnecting
+			// — warn and exit clean, leaving the cached token in place
+			// for the next shell invocation to retry.
+			fmt.Fprintf(os.Stderr, "vault token check failed (will retry on next login): %v\n", lookupErr)
+			return nil
 		}
 	}
 
@@ -706,10 +715,22 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Secret) (bool, error) {
 	ttlSec, ok := readSecondsField(secret.Data, "ttl")
 	if !ok {
-		// Non-expiring token (e.g. root) — nothing to do.
+		// No TTL field at all — non-expiring (e.g. root). Nothing to do.
 		return true, nil
 	}
 	ttl := time.Duration(ttlSec) * time.Second
+	if ttl <= 0 {
+		// Vault commonly returns ttl=0 for non-expiring tokens (root,
+		// service tokens minted without a TTL). A concrete expire_time
+		// alongside ttl=0 means the token has actually expired —
+		// surface that to the caller so login-check drops to the
+		// configured login flow. Mirrors the lifecycle manager's
+		// handling of the same shape.
+		if secret.Data["expire_time"] == nil {
+			return true, nil
+		}
+		return false, nil
+	}
 	creationTTLSec, _ := readSecondsField(secret.Data, "creation_ttl")
 	creationTTL := time.Duration(creationTTLSec) * time.Second
 

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -706,12 +706,19 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 }
 
 // handleValidToken inspects a successful LookupSelf response and decides
-// whether to renew the token. Returns (handled=true, err=nil) when the
-// token is fresh enough to leave alone or was renewed successfully.
-// Returns (false, nil) for tokens with no TTL data (caller falls through
-// to login). On renewal failure where the token is still valid, the
-// function warns and returns (true, non-nil err) — the caller treats
-// this as "leave the token, exit clean".
+// whether to renew the token.
+//
+// Returns (handled=true, err=nil) when the token is fresh enough to leave
+// alone, is non-expiring (no TTL field, or ttl<=0 without an
+// expire_time), or was renewed successfully.
+//
+// Returns (handled=false, err=nil) when the token has actually expired
+// (ttl<=0 with a concrete expire_time) — the caller falls through to the
+// configured login flow.
+//
+// Returns (handled=true, err=non-nil) when renewal was attempted and
+// failed but the cached token is still valid; the function has already
+// warned with the absolute expiry time and the caller should exit clean.
 func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Secret) (bool, error) {
 	ttlSec, ok := readSecondsField(secret.Data, "ttl")
 	if !ok {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,9 +2,14 @@
 
 ## Commands
 
-### `dotvault` / `dotvault run`
+### `dotvault`
 
-Run the daemon in the foreground. This is the default command.
+Running `dotvault` with no subcommand prints help. The daemon is no
+longer the default; use `dotvault run` to start it explicitly.
+
+### `dotvault run`
+
+Run the daemon in the foreground.
 
 ```sh
 dotvault run [flags]
@@ -18,6 +23,10 @@ The daemon:
 4. Runs the enrolment wizard for any missing credentials
 5. Starts the sync engine (initial sync, then hybrid event + poll loop)
 
+`dotvault run --once` redirects to the sync path — a one-shot cycle
+followed by exit. This is the only place `--once` is accepted (it is
+no longer a global flag).
+
 ### `dotvault sync`
 
 Run a single sync cycle and exit.
@@ -27,6 +36,39 @@ dotvault sync [flags]
 ```
 
 Useful for cron jobs, testing, or one-off synchronisation.
+
+### `dotvault login`
+
+Force a fresh Vault login via the configured auth method (OIDC, LDAP),
+ignoring any cached token. The dotvault-config-driven analogue of
+`vault login -address <vault.address> -method <vault.auth_method>` —
+use it when a running daemon needs a new token after expiry without
+re-typing the address and method.
+
+```sh
+dotvault login [flags]
+```
+
+### `dotvault login-check`
+
+Intended to be wired into shell rc / login-profile scripts.
+
+```sh
+dotvault login-check [flags]
+```
+
+- If stdout is not a TTY, the command exits silently with status 0 so
+  non-interactive callers (cron, sshd ForceCommand, scp) never see a
+  prompt.
+- If the cached token is valid and still within the first half of its
+  creation TTL, exit clean.
+- If the cached token is valid but past the halfway mark, attempt
+  renewal. On success, exit clean. If renewal fails but the token is
+  still valid, warn with the absolute expiry time and exit 0.
+- If the cached token is missing or invalid, run the configured login
+  flow. Transient Vault/TLS/network errors warn and exit clean rather
+  than prompting. Ctrl-C exits without fanfare so the user can dismiss
+  the prompt on a fresh terminal session.
 
 ### `dotvault status`
 
@@ -44,6 +86,12 @@ Print the build version and exit.
 dotvault version
 ```
 
+### `dotvault reg-export` / `dotvault reg-import`
+
+Convert between dotvault YAML configuration and the Windows .reg file
+format used to deploy configuration via Group Policy. See the
+project README and the Windows admin docs for details.
+
 ## Global flags
 
 | Flag | Default | Description |
@@ -51,7 +99,8 @@ dotvault version
 | `--config <path>` | *(system default)* | Override the config file path |
 | `--log-level <level>` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `--dry-run` | `false` | Show what would change without writing files |
-| `--once` | `false` | Run one sync cycle and exit (alias for `sync`) |
+
+`--once` is scoped to `dotvault run` only.
 
 ## Environment variables
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -34,7 +34,13 @@ func (m *Manager) Authenticate(ctx context.Context) error {
 		m.VaultClient.SetToken("")
 	}
 
-	// Step 2: Authenticate with configured method
+	return m.Login(ctx)
+}
+
+// Login runs the configured fresh-auth flow unconditionally, without
+// attempting to reuse an existing token. Used by `dotvault login` and as
+// the fallback path inside Authenticate.
+func (m *Manager) Login(ctx context.Context) error {
 	switch m.AuthMethod {
 	case "oidc":
 		return m.authenticateOIDC(ctx)

--- a/internal/auth/lifecycle.go
+++ b/internal/auth/lifecycle.go
@@ -161,28 +161,51 @@ func (lm *LifecycleManager) clearReauth() {
 	lm.needsReauth.Store(false)
 }
 
-// tryReload re-reads the token file/env and, if a different value is
-// present, swaps it onto the Vault client and validates with LookupSelf.
-// Returns true iff the swap produced a working token. On failure the
-// previous (broken) token is restored so the caller's error-handling
-// path sees the same state it would have without a reload.
+// tryReload re-reads the token file (and VAULT_TOKEN env) and, if a
+// different value is present, swaps it onto the Vault client and
+// validates with LookupSelf. Returns true iff one of the candidates
+// produced a working token. On failure the previous (broken) token is
+// restored so the caller's error-handling path sees the same state it
+// would have without a reload.
+//
+// Candidate ordering: the token file is consulted before VAULT_TOKEN
+// because the env variable cannot be mutated by an external
+// `dotvault login` running in another shell — if VAULT_TOKEN itself is
+// the expired token the daemon was started with, ResolveToken's
+// env-first policy would keep selecting it and never see a fresh
+// value on disk. Reading the file first sidesteps that loop.
 func (lm *LifecycleManager) tryReload(ctx context.Context) bool {
 	if lm.tokenFilePath == "" {
 		return false
 	}
 	current := lm.client.Token()
-	candidate := ResolveToken(lm.tokenFilePath)
-	if candidate == "" || candidate == current {
+
+	candidates := make([]string, 0, 2)
+	if fileToken, _ := ReadTokenFile(lm.tokenFilePath); fileToken != "" && fileToken != current {
+		candidates = append(candidates, fileToken)
+	}
+	if envToken := ReadTokenEnv(); envToken != "" && envToken != current {
+		// Skip if we already queued an identical file token, but still
+		// try env when it differs from both the current and file values.
+		if len(candidates) == 0 || candidates[0] != envToken {
+			candidates = append(candidates, envToken)
+		}
+	}
+	if len(candidates) == 0 {
 		return false
 	}
-	lm.client.SetToken(candidate)
-	if _, err := lm.client.LookupSelf(ctx); err != nil {
-		slog.Warn("attempted token reload, candidate is also invalid", "error", err)
-		lm.client.SetToken(current)
-		return false
+
+	for _, candidate := range candidates {
+		lm.client.SetToken(candidate)
+		if _, err := lm.client.LookupSelf(ctx); err == nil {
+			slog.Info("picked up fresh vault token")
+			return true
+		} else {
+			slog.Warn("attempted token reload, candidate is also invalid", "error", err)
+		}
 	}
-	slog.Info("picked up fresh vault token from file")
-	return true
+	lm.client.SetToken(current)
+	return false
 }
 
 func (lm *LifecycleManager) checkAndRenew(ctx context.Context) error {

--- a/internal/auth/lifecycle.go
+++ b/internal/auth/lifecycle.go
@@ -18,9 +18,12 @@ type LifecycleManager struct {
 	needsReauth    atomic.Bool
 
 	// Token file path. When the current in-memory token becomes invalid,
-	// the manager will first attempt to reload from this path (or the
-	// VAULT_TOKEN env var via ResolveToken) before signalling re-auth.
-	// Empty means no reload attempt is made.
+	// the manager will first read this file directly (and only then fall
+	// back to VAULT_TOKEN) before signalling re-auth. The file-first
+	// precedence is deliberate: VAULT_TOKEN cannot be updated from
+	// another shell, so if the env value is itself the broken token the
+	// daemon was started with, env-first ordering would loop on the
+	// same stale value. Empty means no reload attempt is made.
 	tokenFilePath string
 
 	// OnReauth, when non-nil, is invoked exactly once each time the

--- a/internal/auth/lifecycle.go
+++ b/internal/auth/lifecycle.go
@@ -101,7 +101,19 @@ func (lm *LifecycleManager) Start(ctx context.Context) <-chan error {
 				return
 			case <-timer.C:
 				if err := lm.checkAndRenew(ctx); err != nil {
-					if vault.IsForbidden(err) || IsExpired(err) {
+					// Recoverable failure modes:
+					//   - 403 (token revoked/invalid)
+					//   - sentinel for an expired token reported via
+					//     lookup-self with a concrete expire_time
+					//   - we are already in the needs-reauth state, OR the
+					//     current client token is empty (because OnReauth
+					//     just cleared it). In the empty-token case Vault
+					//     returns "missing client token" (400), which is
+					//     neither 403 nor the expired sentinel — without
+					//     this branch the manager would slip into the
+					//     transient-error path, back off to 5m, and never
+					//     observe a fresh token written to disk.
+					if vault.IsForbidden(err) || IsExpired(err) || lm.needsReauth.Load() || lm.client.Token() == "" {
 						// Try reloading the token from disk/env before
 						// declaring re-auth — a parallel `dotvault login`
 						// may have already written a fresh token. If the

--- a/internal/auth/lifecycle.go
+++ b/internal/auth/lifecycle.go
@@ -17,6 +17,25 @@ type LifecycleManager struct {
 	disableRenewal bool
 	needsReauth    atomic.Bool
 
+	// Token file path. When the current in-memory token becomes invalid,
+	// the manager will first attempt to reload from this path (or the
+	// VAULT_TOKEN env var via ResolveToken) before signalling re-auth.
+	// Empty means no reload attempt is made.
+	tokenFilePath string
+
+	// OnReauth, when non-nil, is invoked exactly once each time the
+	// manager transitions to the needs-reauth state. Used by web mode to
+	// clear in-memory auth state and force the SPA back to its login
+	// screen. Reset when a subsequent check succeeds, so the callback
+	// fires again on the next failure.
+	onReauth func()
+
+	// Recovery poll interval used while in the needs-reauth state. When
+	// the token is broken we want to pick up a freshly-minted token from
+	// the file faster than the normal 5-minute lookup cycle. Defaults to
+	// 10s, capped at checkInterval.
+	recoveryInterval time.Duration
+
 	// Exponential backoff state for check failures.
 	currentDelay time.Duration
 	maxDelay     time.Duration
@@ -26,13 +45,35 @@ type LifecycleManager struct {
 // disableRenewal is true the manager still monitors TTL and signals re-auth
 // when the token expires, but never calls RenewSelf.
 func NewLifecycleManager(client *vault.Client, checkInterval time.Duration, disableRenewal bool) *LifecycleManager {
-	return &LifecycleManager{
-		client:         client,
-		checkInterval:  checkInterval,
-		disableRenewal: disableRenewal,
-		currentDelay:   checkInterval,
-		maxDelay:       5 * time.Minute,
+	recovery := 10 * time.Second
+	if recovery > checkInterval {
+		recovery = checkInterval
 	}
+	return &LifecycleManager{
+		client:           client,
+		checkInterval:    checkInterval,
+		disableRenewal:   disableRenewal,
+		recoveryInterval: recovery,
+		currentDelay:     checkInterval,
+		maxDelay:         5 * time.Minute,
+	}
+}
+
+// SetTokenFilePath wires a token file path so that on detection of an
+// invalid/expired token the manager will attempt to reload (and re-validate)
+// the token from disk or VAULT_TOKEN before declaring re-auth necessary.
+// This lets an external facility (e.g. a tty session running `dotvault login`)
+// recover a running daemon without a restart.
+func (lm *LifecycleManager) SetTokenFilePath(p string) {
+	lm.tokenFilePath = p
+}
+
+// SetOnReauth registers a callback fired when the manager transitions into
+// the needs-reauth state. The callback runs synchronously on the lifecycle
+// goroutine — keep it short. In web mode this is used to clear the
+// in-memory Vault token so the SPA's status check reflects "logged out".
+func (lm *LifecycleManager) SetOnReauth(fn func()) {
+	lm.onReauth = fn
 }
 
 // NeedsReauth returns true if the token is expired or needs re-authentication.
@@ -57,26 +98,36 @@ func (lm *LifecycleManager) Start(ctx context.Context) <-chan error {
 				return
 			case <-timer.C:
 				if err := lm.checkAndRenew(ctx); err != nil {
-					// Compute next capped delay before logging so the logged value is accurate
-					nextDelay := lm.currentDelay * 2
-					if nextDelay > lm.maxDelay {
-						nextDelay = lm.maxDelay
-					}
-					if vault.IsForbidden(err) {
-						slog.Warn("vault token forbidden (403), re-authentication required", "error", err, "next_retry", nextDelay)
-						if !lm.needsReauth.Load() {
-							lm.needsReauth.Store(true)
-							select {
-							case errCh <- err:
-							default:
-							}
+					if vault.IsForbidden(err) || IsExpired(err) {
+						// Try reloading the token from disk/env before
+						// declaring re-auth — a parallel `dotvault login`
+						// may have already written a fresh token. If the
+						// reload yields a working token we treat the
+						// failure as transient.
+						if lm.tryReload(ctx) {
+							lm.clearReauth()
+							lm.currentDelay = lm.checkInterval
+							timer.Reset(lm.currentDelay)
+							continue
 						}
+						nextDelay := lm.recoveryInterval
+						slog.Warn("vault token invalid, re-authentication required", "error", err, "next_retry", nextDelay)
+						lm.signalReauth(errCh, err)
+						lm.currentDelay = nextDelay
 					} else {
+						// Transient error: backoff up to maxDelay.
+						nextDelay := lm.currentDelay * 2
+						if nextDelay > lm.maxDelay {
+							nextDelay = lm.maxDelay
+						}
 						slog.Warn("token lifecycle check failed, will retry", "error", err, "next_retry", nextDelay)
+						lm.currentDelay = nextDelay
 					}
-					lm.currentDelay = nextDelay
 				} else {
-					// Reset to base interval on success
+					// Reset to base interval on success and clear any
+					// previously-set re-auth state (a freshly-loaded token
+					// can succeed even after the previous one was revoked).
+					lm.clearReauth()
 					lm.currentDelay = lm.checkInterval
 				}
 				timer.Reset(lm.currentDelay)
@@ -85,6 +136,53 @@ func (lm *LifecycleManager) Start(ctx context.Context) <-chan error {
 	}()
 
 	return errCh
+}
+
+// signalReauth flips the manager into the needs-reauth state and invokes
+// the OnReauth callback once per transition. The error is pushed onto errCh
+// non-blockingly so a consumer that has stopped reading doesn't deadlock.
+func (lm *LifecycleManager) signalReauth(errCh chan<- error, err error) {
+	if lm.needsReauth.Load() {
+		return
+	}
+	lm.needsReauth.Store(true)
+	if lm.onReauth != nil {
+		lm.onReauth()
+	}
+	select {
+	case errCh <- err:
+	default:
+	}
+}
+
+// clearReauth resets the needs-reauth flag — used when a check succeeds
+// (either after a clean cycle or after picking up a fresh token from disk).
+func (lm *LifecycleManager) clearReauth() {
+	lm.needsReauth.Store(false)
+}
+
+// tryReload re-reads the token file/env and, if a different value is
+// present, swaps it onto the Vault client and validates with LookupSelf.
+// Returns true iff the swap produced a working token. On failure the
+// previous (broken) token is restored so the caller's error-handling
+// path sees the same state it would have without a reload.
+func (lm *LifecycleManager) tryReload(ctx context.Context) bool {
+	if lm.tokenFilePath == "" {
+		return false
+	}
+	current := lm.client.Token()
+	candidate := ResolveToken(lm.tokenFilePath)
+	if candidate == "" || candidate == current {
+		return false
+	}
+	lm.client.SetToken(candidate)
+	if _, err := lm.client.LookupSelf(ctx); err != nil {
+		slog.Warn("attempted token reload, candidate is also invalid", "error", err)
+		lm.client.SetToken(current)
+		return false
+	}
+	slog.Info("picked up fresh vault token from file")
+	return true
 }
 
 func (lm *LifecycleManager) checkAndRenew(ctx context.Context) error {
@@ -116,9 +214,10 @@ func (lm *LifecycleManager) checkAndRenew(ctx context.Context) error {
 		if expireTime == nil {
 			return nil // Non-expiring token (e.g., root)
 		}
-		slog.Warn("token expired")
-		lm.needsReauth.Store(true)
-		return nil
+		// Token has expired — surface this as a tokenExpiredError so the
+		// goroutine runs the same recovery path (token-file reload, then
+		// signal re-auth) it uses for 403 responses.
+		return errTokenExpired
 	}
 
 	// Check if renewable
@@ -134,8 +233,25 @@ func (lm *LifecycleManager) checkAndRenew(ctx context.Context) error {
 			return err
 		}
 		slog.Info("token renewed successfully")
-		lm.needsReauth.Store(false)
 	}
 
 	return nil
+}
+
+// errTokenExpired is the sentinel returned by checkAndRenew when
+// LookupSelf succeeds but reports the token has expired (TTL=0 with a
+// concrete expire_time). The Start loop treats it identically to a 403:
+// attempt a file-based reload, then signal re-auth if that fails.
+var errTokenExpired = &expiredError{}
+
+type expiredError struct{}
+
+func (*expiredError) Error() string { return "vault token has expired" }
+
+// IsExpired reports whether err is the token-expired sentinel. The Start
+// loop uses this to route expired tokens through the same recovery path
+// as a 403 response.
+func IsExpired(err error) bool {
+	_, ok := err.(*expiredError)
+	return ok
 }

--- a/internal/auth/lifecycle_test.go
+++ b/internal/auth/lifecycle_test.go
@@ -217,6 +217,74 @@ func TestLifecycleManager_ReloadFromTokenFile(t *testing.T) {
 	}
 }
 
+// TestLifecycleManager_ReloadPrefersFileOverStaleEnv guards against a
+// regression where ResolveToken's env-first policy would re-select the
+// stale VAULT_TOKEN value the daemon was originally started with and
+// never observe a fresh token written to disk by an external
+// `dotvault login`. The recovery path must read the file first.
+func TestLifecycleManager_ReloadPrefersFileOverStaleEnv(t *testing.T) {
+	var currentValid atomic.Value
+	currentValid.Store("file-token")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		expected := currentValid.Load().(string)
+		if r.Header.Get("X-Vault-Token") == expected {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"ttl":          json.Number("3600"),
+					"creation_ttl": json.Number("3600"),
+					"renewable":    true,
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string][]string{"errors": {"permission denied"}})
+	}))
+	defer ts.Close()
+
+	// VAULT_TOKEN is the same stale value the daemon is currently
+	// holding — the process environment can't be updated from another
+	// shell, so the file must take precedence during recovery.
+	t.Setenv("VAULT_TOKEN", "stale-token")
+
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+	if err := os.WriteFile(tokenPath, []byte("file-token"), 0600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	vc, err := vault.NewClient(vault.Config{Address: ts.URL, Token: "stale-token"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, false)
+	lm.SetTokenFilePath(tokenPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	errCh := lm.Start(ctx)
+	go func() {
+		for range errCh {
+		}
+	}()
+
+	deadline := time.Now().Add(900 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if vc.Token() == "file-token" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := vc.Token(); got != "file-token" {
+		t.Fatalf("client token = %q after reload, want %q (file content); env-first ResolveToken regressed", got, "file-token")
+	}
+}
+
 // TestLifecycleManager_OnReauthFires verifies that when the token is
 // invalid AND no fresh value is available on disk, the OnReauth callback
 // fires exactly once (so web mode can clear the in-memory token and

--- a/internal/auth/lifecycle_test.go
+++ b/internal/auth/lifecycle_test.go
@@ -285,6 +285,91 @@ func TestLifecycleManager_ReloadPrefersFileOverStaleEnv(t *testing.T) {
 	}
 }
 
+// TestLifecycleManager_RecoversAfterTokenCleared simulates the
+// post-OnReauth state: the daemon's web-mode OnReauth callback has
+// cleared the in-memory Vault token, so the next lookup-self call
+// goes out with no `X-Vault-Token` header and Vault returns a
+// "missing client token" 400. Without the empty-token branch on the
+// recoverable-failure check this would slip into the transient-error
+// path, back off, and never observe a fresh token written to disk.
+// The test pins the recovery path: a new token is written to the
+// file after the clear, and the manager picks it up on its 10s
+// recovery poll.
+func TestLifecycleManager_RecoversAfterTokenCleared(t *testing.T) {
+	var validToken atomic.Value
+	validToken.Store("new-token")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		tok := r.Header.Get("X-Vault-Token")
+		switch {
+		case tok == "":
+			// Vault returns 400 for a request with no token header.
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string][]string{"errors": {"missing client token"}})
+		case tok == validToken.Load().(string):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"ttl":          json.Number("3600"),
+					"creation_ttl": json.Number("3600"),
+					"renewable":    true,
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string][]string{"errors": {"permission denied"}})
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+
+	vc, err := vault.NewClient(vault.Config{Address: ts.URL, Token: ""}) // already cleared
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, false)
+	lm.SetTokenFilePath(tokenPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	errCh := lm.Start(ctx)
+	go func() {
+		for range errCh {
+		}
+	}()
+
+	// Let the manager run a tick or two with the empty token — it should
+	// surface "missing client token" responses but stay on the recovery
+	// path (10s recovery interval, not the transient backoff).
+	time.Sleep(150 * time.Millisecond)
+	if !lm.NeedsReauth() {
+		t.Error("NeedsReauth() = false after empty-token checks; recovery path was not taken")
+	}
+
+	// Drop the new token on disk — the manager should pick it up.
+	if err := os.WriteFile(tokenPath, []byte("new-token"), 0600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	deadline := time.Now().Add(800 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if vc.Token() == "new-token" && !lm.NeedsReauth() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := vc.Token(); got != "new-token" {
+		t.Fatalf("client token = %q after token-file write, want %q (recovery never fired)", got, "new-token")
+	}
+	if lm.NeedsReauth() {
+		t.Error("NeedsReauth() = true after recovery picked up a working token")
+	}
+}
+
 // TestLifecycleManager_OnReauthFires verifies that when the token is
 // invalid AND no fresh value is available on disk, the OnReauth callback
 // fires exactly once (so web mode can clear the in-memory token and

--- a/internal/auth/lifecycle_test.go
+++ b/internal/auth/lifecycle_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -124,6 +127,148 @@ func TestLifecycleManager_DisableRenewalSkipsRenewCall(t *testing.T) {
 
 	if renewCalled {
 		t.Error("RenewSelf was called despite disable_token_renewal=true")
+	}
+}
+
+// TestLifecycleManager_ReloadFromTokenFile exercises the recovery path
+// where a token has expired/been revoked but a fresh value has been
+// written to the token file by an external process (e.g. an interactive
+// `dotvault login` running in another session). The manager must pick
+// up the new token on its next check and continue running instead of
+// permanently latching the needs-reauth state.
+func TestLifecycleManager_ReloadFromTokenFile(t *testing.T) {
+	var currentValid atomic.Value // string — the token Vault will currently accept
+	currentValid.Store("good-token")
+
+	var lookups atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/token/lookup-self" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		lookups.Add(1)
+		expected := currentValid.Load().(string)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("X-Vault-Token") == expected {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"ttl":          json.Number("3600"),
+					"creation_ttl": json.Number("3600"),
+					"renewable":    true,
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string][]string{"errors": {"permission denied"}})
+	}))
+	defer ts.Close()
+
+	// Start with the old (now-revoked) token loaded on the client and
+	// the new valid token already written to disk — emulating the
+	// "user already ran `dotvault login` in another session" timing.
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+	if err := os.WriteFile(tokenPath, []byte("new-token"), 0600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	currentValid.Store("new-token") // server will only accept the new token now
+
+	vc, err := vault.NewClient(vault.Config{Address: ts.URL, Token: "stale-token"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, false)
+	lm.SetTokenFilePath(tokenPath)
+
+	var onReauthFired atomic.Bool
+	lm.SetOnReauth(func() { onReauthFired.Store(true) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	errCh := lm.Start(ctx)
+
+	// Drain errCh in the background — we don't assert on it here because
+	// the reload path may suppress the re-auth signal entirely.
+	go func() {
+		for range errCh {
+		}
+	}()
+
+	// Wait until the manager has had a chance to run a check and reload.
+	deadline := time.Now().Add(900 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if vc.Token() == "new-token" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := vc.Token(); got != "new-token" {
+		t.Fatalf("client token = %q after reload, want %q", got, "new-token")
+	}
+	if lm.NeedsReauth() {
+		t.Error("NeedsReauth() = true after successful reload")
+	}
+	if onReauthFired.Load() {
+		t.Error("OnReauth callback fired despite successful token-file reload")
+	}
+}
+
+// TestLifecycleManager_OnReauthFires verifies that when the token is
+// invalid AND no fresh value is available on disk, the OnReauth callback
+// fires exactly once (so web mode can clear the in-memory token and
+// force the SPA back to its login screen).
+func TestLifecycleManager_OnReauthFires(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string][]string{"errors": {"permission denied"}})
+	}))
+	defer ts.Close()
+
+	vc, err := vault.NewClient(vault.Config{Address: ts.URL, Token: "bad-token"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// Empty token file: tryReload should return false and the manager
+	// should signal re-auth.
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+
+	lm := NewLifecycleManager(vc, 50*time.Millisecond, false)
+	lm.SetTokenFilePath(tokenPath)
+
+	var fired atomic.Int64
+	lm.SetOnReauth(func() { fired.Add(1) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	errCh := lm.Start(ctx)
+
+	select {
+	case <-errCh:
+		// good — re-auth signalled
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected re-auth signal on errCh within 500ms")
+	}
+
+	if got := fired.Load(); got != 1 {
+		t.Errorf("OnReauth fired %d times, want exactly 1", got)
+	}
+	if !lm.NeedsReauth() {
+		t.Error("NeedsReauth() = false, want true after re-auth signal")
+	}
+
+	// Give it another tick or two to confirm the callback isn't re-fired
+	// on subsequent failures.
+	time.Sleep(300 * time.Millisecond)
+	if got := fired.Load(); got != 1 {
+		t.Errorf("OnReauth fired %d times after additional ticks, want exactly 1", got)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -320,6 +320,29 @@ func (s *Server) URL() string {
 	return fmt.Sprintf("http://%s/", s.listenAddr)
 }
 
+// ForceReauth clears the in-memory Vault token so /api/v1/status reports
+// authenticated=false on the next poll. The SPA is configured to redirect
+// to the login screen whenever that flag flips, which effectively
+// invalidates any browser session that was sitting on a stale "logged-in"
+// view while the underlying token rotted. The token file on disk is
+// intentionally left in place — operators may have written a fresh token
+// out-of-band that the daemon can pick up without involving the user.
+//
+// Also resets the authDone channel so a fresh call to WaitForAuth (e.g.
+// from a re-entry into the startup auth flow) will block until the user
+// completes the new login.
+func (s *Server) ForceReauth() {
+	if s.vault != nil {
+		s.vault.SetToken("")
+	}
+	// Drain any pending authDone signal — the previous auth is no
+	// longer current and shouldn't satisfy a fresh WaitForAuth.
+	select {
+	case <-s.authDone:
+	default:
+	}
+}
+
 func (s *Server) userKVPrefix() string {
 	return s.userPrefix + s.username + "/"
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -194,9 +194,6 @@ func TestMiddlewareRejectsBadHost(t *testing.T) {
 	}
 }
 
-// TestMiddlewareForbiddenHostNonAPIPlainText pins that requests outside
-// /api/ and /auth/ still get the human-readable text/plain 403 — useful
-// when a misconfigured browser hits `/` directly.
 // TestForceReauth verifies the two behaviours that keep the SPA and
 // WaitForAuth state consistent when the lifecycle manager declares the
 // cached Vault token unusable:
@@ -242,6 +239,9 @@ func TestForceReauth(t *testing.T) {
 	}
 }
 
+// TestMiddlewareForbiddenHostNonAPIPlainText pins that requests outside
+// /api/ and /auth/ still get the human-readable text/plain 403 — useful
+// when a misconfigured browser hits `/` directly.
 func TestMiddlewareForbiddenHostNonAPIPlainText(t *testing.T) {
 	s := testServer(t)
 	s.cfg.Listen = "127.0.0.1:0"

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -197,6 +197,51 @@ func TestMiddlewareRejectsBadHost(t *testing.T) {
 // TestMiddlewareForbiddenHostNonAPIPlainText pins that requests outside
 // /api/ and /auth/ still get the human-readable text/plain 403 — useful
 // when a misconfigured browser hits `/` directly.
+// TestForceReauth verifies the two behaviours that keep the SPA and
+// WaitForAuth state consistent when the lifecycle manager declares the
+// cached Vault token unusable:
+//
+//  1. The in-memory Vault token is cleared, so a follow-up GET
+//     /api/v1/status reports authenticated=false and the SPA bounces
+//     to its login screen.
+//  2. Any signal previously queued on authDone is drained so a fresh
+//     WaitForAuth (e.g. from a re-entry into the startup auth flow)
+//     blocks until the user completes the *new* login rather than
+//     immediately satisfying on the stale signal.
+func TestForceReauth(t *testing.T) {
+	s := testServer(t)
+	vc, err := vault.NewClient(vault.Config{Address: "http://127.0.0.1:8200", Token: "stale-token"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	s.vault = vc
+	s.authDone = make(chan struct{}, 1)
+
+	// Simulate the previous successful auth that left a signal queued.
+	s.authDone <- struct{}{}
+
+	s.ForceReauth()
+
+	if got := s.vault.Token(); got != "" {
+		t.Errorf("vault token after ForceReauth = %q, want \"\"", got)
+	}
+
+	// authDone must have been drained — a non-blocking read should
+	// observe an empty channel.
+	select {
+	case <-s.authDone:
+		t.Error("authDone still has a queued signal after ForceReauth; WaitForAuth would fire immediately")
+	default:
+	}
+
+	// A second invocation must be a no-op (idempotent) even with no
+	// token and no pending signal — exercises the empty-state branches.
+	s.ForceReauth()
+	if got := s.vault.Token(); got != "" {
+		t.Errorf("vault token after idempotent ForceReauth = %q, want \"\"", got)
+	}
+}
+
 func TestMiddlewareForbiddenHostNonAPIPlainText(t *testing.T) {
 	s := testServer(t)
 	s.cfg.Listen = "127.0.0.1:0"

--- a/test/integration/lifecycle_test.go
+++ b/test/integration/lifecycle_test.go
@@ -1,0 +1,144 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+
+	"github.com/goodtune/dotvault/internal/auth"
+	"github.com/goodtune/dotvault/internal/vault"
+)
+
+// TestLifecycleRecoversFromExpiredToken exercises the full
+// expire-and-recover cycle described in the design notes:
+//
+//  1. Mint a short-lived token via the dev Vault and load it onto the
+//     client. Start the lifecycle manager pointing at a writable token
+//     file.
+//  2. Let the token expire — the next lookup-self returns 403 and the
+//     manager should signal re-auth (the OnReauth callback fires and the
+//     in-memory client token is cleared by the daemon path).
+//  3. Mint a fresh token via the same parent and write it to the token
+//     file out-of-band — as if an interactive `dotvault login` had run.
+//  4. The manager's next check should observe the broken state, reload
+//     the new token from disk, swap it in, and clear needs-reauth.
+//
+// This guards against the regression the spec calls out: that a daemon
+// would previously latch its broken token and require a restart to pick
+// up a freshly-minted credential even when one was available on disk.
+func TestLifecycleRecoversFromExpiredToken(t *testing.T) {
+	skipIfNoVault(t)
+
+	rootClient, err := vault.NewClient(vault.Config{
+		Address: "http://127.0.0.1:8200",
+		Token:   "dev-root-token",
+	})
+	if err != nil {
+		t.Fatalf("NewClient (root): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mintShortToken := func(t *testing.T, ttl string) string {
+		t.Helper()
+		secret, err := rootClient.Raw().Auth().Token().CreateWithContext(ctx, &vaultapi.TokenCreateRequest{
+			TTL:       ttl,
+			Renewable: boolPtr(false),
+			NoParent:  true,
+		})
+		if err != nil {
+			t.Fatalf("token create: %v", err)
+		}
+		if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
+			t.Fatal("token create: empty auth response")
+		}
+		return secret.Auth.ClientToken
+	}
+
+	initialToken := mintShortToken(t, "2s")
+
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+	if err := os.WriteFile(tokenPath, []byte(initialToken), 0600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	vc, err := vault.NewClient(vault.Config{
+		Address: "http://127.0.0.1:8200",
+		Token:   initialToken,
+	})
+	if err != nil {
+		t.Fatalf("NewClient (daemon): %v", err)
+	}
+
+	lm := auth.NewLifecycleManager(vc, 250*time.Millisecond, false)
+	lm.SetTokenFilePath(tokenPath)
+
+	var reauthFired atomic.Int64
+	lm.SetOnReauth(func() {
+		reauthFired.Add(1)
+		// The web server clears the in-memory token here in production;
+		// mirror that behaviour so the test verifies the same observable
+		// state the SPA would see (vc.Token() returns "" → status reports
+		// authenticated=false).
+		vc.SetToken("")
+	})
+
+	loopCtx, loopCancel := context.WithCancel(ctx)
+	defer loopCancel()
+	errCh := lm.Start(loopCtx)
+	go func() {
+		for range errCh {
+		}
+	}()
+
+	// 1. Wait for the token to expire and the manager to detect it.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if reauthFired.Load() > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if reauthFired.Load() == 0 {
+		t.Fatal("lifecycle manager never signalled re-auth after token expiry")
+	}
+	if got := vc.Token(); got != "" {
+		t.Fatalf("client token = %q after expiry, want cleared (\"\") via OnReauth", got)
+	}
+
+	// 2. Mint a fresh token (longer TTL so it survives the rest of the test)
+	//    and write it to the token file out-of-band.
+	newToken := mintShortToken(t, "1h")
+	if newToken == initialToken {
+		t.Fatal("freshly-minted token equals expired token — should be different")
+	}
+	if err := os.WriteFile(tokenPath, []byte(newToken), 0600); err != nil {
+		t.Fatalf("write new token file: %v", err)
+	}
+
+	// 3. The manager polls at 250ms while in the broken state — it
+	//    should reload the token and recover within a couple of cycles.
+	deadline = time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if vc.Token() == newToken && !lm.NeedsReauth() {
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	if got := vc.Token(); got != newToken {
+		t.Fatalf("client token = %q after recovery window, want %q", got, newToken)
+	}
+	if lm.NeedsReauth() {
+		t.Error("NeedsReauth() = true after successful recovery from token file")
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
## Summary

**Breaking change:** running `dotvault` with no subcommand now prints help instead of starting the daemon. Use `dotvault run` to start the long-lived service explicitly.

### New commands

- **`dotvault login`** — always forces a fresh login via the configured method (OIDC/LDAP), ignoring any cached token. The dotvault-config-driven analogue of `vault login -address … -method …`. Natural entry point when a running daemon needs a new token after expiry.
- **`dotvault login-check`** — intended to be wired into interactive-shell login profiles:
  - Exits silently (status 0) when stdout is not a TTY so non-interactive callers (cron, sshd ForceCommand, scp) never see a prompt.
  - On a TTY: keeps the cached token if it's within the first half of its creation TTL; attempts renewal past the halfway mark (warns with the absolute expiry time on failure but still valid); runs the configured login flow if the cached token is missing/invalid.
  - Ctrl-C exits without fanfare so a user can dismiss the prompt on a fresh terminal session without leaving an error in their scrollback.

### Daemon picks up new tokens without restart

This addresses the regression where the daemon would latch a broken/expired token and continue making 403 requests until manually restarted, even when a fresh token had been written to `~/.vault-token`.

`LifecycleManager` now:

1. On 403 / expired-TTL response, re-reads the token file (and `VAULT_TOKEN` env) and validates the candidate before declaring re-auth needed. A successful reload swaps the in-memory token on the Vault client and clears the needs-reauth flag.
2. On a failed reload, signals re-auth once, drops to a 10-second recovery poll (so a freshly-minted token written shortly after is picked up quickly), and fires the `OnReauth` callback so callers can clear ancillary state.

### Web sessions invalidated on token expiry

In web mode the daemon now registers `Server.ForceReauth` as the lifecycle `OnReauth` callback, which clears the in-memory Vault token. The SPA's `/api/v1/status` endpoint reports `authenticated: false` on the next poll, forcing the browser back to the login screen — closing the previous gap where the UI stayed "logged in" while the underlying Vault interaction was broken.

### Tests

- Unit tests in `internal/auth/lifecycle_test.go` cover the reload-from-file recovery path and the one-shot OnReauth callback semantics (no Vault dependency, uses `httptest`).
- New integration test `TestLifecycleRecoversFromExpiredToken` mints a 2-second token via the dev Vault, watches the manager detect the expiry, writes a fresh token to disk out-of-band, and asserts the daemon picks it up without a restart.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] `go test ./...` passes (auth, web, sync, integration suites)
- [x] Stress: `go test ./internal/auth/... -run TestLifecycleManager -count=10` passes
- [x] `dotvault` bare prints help with all expected subcommands (`login`, `login-check`, `run`, `sync`, `status`, `version`, `reg-*`)
- [x] `dotvault login-check` exits silently with status 0 when stdout is not a TTY
- [ ] CI: `TestLifecycleRecoversFromExpiredToken` runs against the dev Vault (skipped locally; verified with the unit-test equivalent)
- [ ] Manual: with web UI enabled, let the token age out — verify the browser is forced back to the login screen and the daemon recovers when a fresh token is written


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rwZF3MBfeoXfLXcYwNyX)_