### PR TITLE
fix(windows): default `dotvaultw` to running the daemon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ All builds use `CGO_ENABLED=0` for static binaries. Version is injected via ldfl
 
 Windows ships two binaries from the same source — the PE subsystem flag is immutable post-link, so the only correct fix is to build twice:
 
-- `dotvault.exe` — Console subsystem. The CLI for `sync`, `status`, `run` (foreground daemon), `reg-export`/`reg-import`, etc. cmd.exe / PowerShell wait for it, stdio is inherited, Ctrl+C works.
-- `dotvaultw.exe` — GUI subsystem (`-H=windowsgui`). For double-click. Runs the daemon with the system-tray icon and no console flash. CLI subcommands invoked through it will appear to do nothing because cmd.exe does not wait for GUI-subsystem binaries — use `dotvault.exe` for CLI work.
+- `dotvault.exe` — Console subsystem. The CLI for `sync`, `status`, `run` (foreground daemon), `reg-export`/`reg-import`, etc. cmd.exe / PowerShell wait for it, stdio is inherited, Ctrl+C works. Bare invocation prints help.
+- `dotvaultw.exe` — GUI subsystem (`-H=windowsgui`). For double-click. Runs the daemon with the system-tray icon and no console flash. Bare invocation defaults to the daemon (equivalent to `dotvault run`) because there's no console to show help on; this is detected at runtime via `os.Args[0]`. CLI subcommands invoked through it will appear to do nothing because cmd.exe does not wait for GUI-subsystem binaries — use `dotvault.exe` for CLI work.
 
 Installer / Start Menu shortcuts should point at `dotvaultw.exe`; the PATH entry should be `dotvault.exe`.
 

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"syscall"
 	"time"
 
@@ -42,6 +43,8 @@ var (
 )
 
 func main() {
+	gui := isGUIBinary(os.Args[0])
+
 	rootCmd := &cobra.Command{
 		Use:   "dotvault",
 		Short: "Vault-to-file secret synchronisation daemon",
@@ -53,8 +56,14 @@ renew) the cached token on an interactive login, or "dotvault login" to
 force a fresh login flow.`,
 		// Cobra's default RunE for a command with no Run/RunE prints help
 		// when called bare, which is what we want — explicitly running the
-		// daemon now requires `dotvault run`.
+		// daemon now requires `dotvault run`. The GUI-subsystem variant
+		// (dotvaultw.exe) is wired below to default to the daemon instead,
+		// because it's launched by double-click and has no console to show
+		// help on.
 		SilenceUsage: true,
+	}
+	if gui {
+		rootCmd.RunE = runDaemon
 	}
 
 	rootCmd.PersistentFlags().StringVar(&flagConfig, "config", "", "override system config path")
@@ -1131,4 +1140,21 @@ func isStdoutTerminal() bool {
 // the daemon can prompt the user for credentials, MFA passcodes, etc.
 func isInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// isGUIBinary reports whether the running executable is the GUI-subsystem
+// Windows variant (dotvaultw.exe). The two Windows binaries are built from
+// the same source with a different PE subsystem flag; the GUI build is
+// launched by double-click / Start Menu shortcut and must default to the
+// daemon because there's no console to show help on. Both `/` and `\` are
+// treated as path separators so the check behaves identically when run
+// from a Linux-hosted test suite and on Windows itself.
+func isGUIBinary(arg0 string) bool {
+	name := arg0
+	if i := strings.LastIndexAny(name, `/\`); i >= 0 {
+		name = name[i+1:]
+	}
+	name = strings.ToLower(name)
+	name = strings.TrimSuffix(name, ".exe")
+	return name == "dotvaultw"
 }

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestIsGUIBinary(t *testing.T) {
+	tests := []struct {
+		arg0 string
+		want bool
+	}{
+		{"dotvault", false},
+		{"./dotvault", false},
+		{"/usr/local/bin/dotvault", false},
+		{"dotvault.exe", false},
+		{`C:\Program Files\dotvault\dotvault.exe`, false},
+		{"dotvaultw", true},
+		{"dotvaultw.exe", true},
+		{"DotVaultW.exe", true},
+		{`C:\Program Files\dotvault\dotvaultw.exe`, true},
+		{"./dotvaultw", true},
+		{"dotvault-windows-amd64.exe", false},
+		{"dotvaultw-windows-amd64.exe", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.arg0, func(t *testing.T) {
+			if got := isGUIBinary(tc.arg0); got != tc.want {
+				t.Errorf("isGUIBinary(%q) = %v, want %v", tc.arg0, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- PR #62 made bare `dotvault` print help instead of starting the daemon. The same source also produces `dotvaultw.exe` (GUI subsystem) for double-click / Start Menu launch, where there's no console to show that help on — so 0.13.0 effectively broke the double-click launch path.
- Detect the GUI variant at runtime via `os.Args[0]` and wire the root command's `RunE` to the daemon when invoked under that name. `dotvaultw` (no args) is now equivalent to `dotvault run`; `dotvault` (no args) still prints help.
- Bare invocation is the only behavior that changes — explicit subcommands (`dotvaultw status`, `dotvaultw version`, etc.) still resolve to their respective handlers, matching the existing caveat in `CLAUDE.md` that those won't produce visible output because cmd.exe doesn't wait for GUI-subsystem binaries.

## Test plan

- [x] `go test ./...` — full suite, including a new table-driven test for `isGUIBinary` that covers both `/` and `\` separators, `.exe` suffix, and case-insensitive match
- [x] Cross-compile both Windows binaries (`dotvault.exe` and `dotvaultw.exe`) with their respective ldflags
- [ ] On Windows, double-click `dotvaultw.exe` and confirm the tray icon appears (no console flash, daemon running)
- [ ] On Windows, run `dotvault.exe` from PowerShell and confirm it still prints help (regression check for #62)

https://claude.ai/code/session_01RadDXE9mjhxyfzgusWwmDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RadDXE9mjhxyfzgusWwmDK)_