### PR TITLE
feat(login-check): centralise suppression marker and signal handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ internal/
   paths/                 OS-specific path resolution
   vault/                 Vault client wrapper, KVv2 operations, Events API (WebSocket)
   auth/                  Auth orchestration (OIDC, LDAP with MFA, token)
+  loginsuppress/         login-check suppression marker (path/window/freshness/refresh)
   sync/                  Hybrid event+poll sync engine, state store
   handlers/              File format handlers (yaml, json, ini, toml, text, netrc)
   tmpl/                  Go template rendering (named tmpl to avoid shadowing text/template)
@@ -122,19 +123,45 @@ ignoring any cached token. It is the dotvault-config-driven analogue of
 `vault login -address … -method …` and is the natural entry point when a
 running daemon needs a new token after expiry.
 
-`dotvault login-check` is intended for interactive-shell login profiles:
+`dotvault login-check` is intended for interactive-shell login profiles
+wired in via a thin wrapper that gates on interactivity, TTY, and the
+daemon being active (`systemctl --user is-active dotvault.service`).
+The binary trusts those preconditions and never re-checks them, so the
+wrapper stays trivial and signal handling works correctly during shell
+startup.
 
-- If stdout is not a TTY the command exits silently (status 0) so
-  non-interactive callers (cron, sshd ForceCommand, scp) never see a
-  prompt.
+- A suppression marker at
+  `${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress`
+  is checked first. While its mtime is within `DOTVAULT_SUPPRESS_HOURS`
+  (positive integer, default `6`) the command exits silently with no
+  vault calls. A future mtime is treated as stale so clock skew, VM
+  snapshot rollback, or restored backups cannot lock suppression on.
+  The path can be overridden via `DOTVAULT_SUPPRESS_MARKER` (used by
+  tests). The path matches the previous shell-managed location, so
+  existing suppression state survives the rollout without migration.
+  Logic lives in `internal/loginsuppress/`.
 - If a cached token is valid and still within the first half of its
   creation TTL, exit clean.
 - If the cached token is valid but past the halfway mark, attempt renewal.
   On renewal failure where the token is still valid, warn with the
   absolute expiry time and exit 0.
 - If the cached token is missing or invalid, run the configured login
-  flow. Ctrl-C exits without fanfare (so a user can dismiss the prompt
-  on a fresh terminal without leaving an error in their scrollback).
+  flow. Ctrl-C exits immediately without requiring an extra Enter: a
+  dedicated signal handler restores the terminal state captured before
+  the password prompt, refreshes the marker, and `os.Exit(0)`s
+  (`term.ReadPassword` does not observe context cancellation, so going
+  through a goroutine + `os.Exit` is the only reliable way to honour
+  the contract).
+- The marker is refreshed on every exit past the freshness check
+  (success, decline, failure, Ctrl+C, internal errors) so concurrent
+  shells across tmux/IDE/SSH-multiplex fanout only ever prompt once
+  per window. Concurrent marker updates are intentionally
+  unsynchronised — duplicate prompts in a tight race are acceptable;
+  blocking shell startup on a `flock` is not.
+- Exits `0` for suppressed, success, decline, cancellation, or
+  expected authentication failure. Exits `1` only on invalid
+  `DOTVAULT_SUPPRESS_HOURS` or genuine internal errors. The shell
+  wrapper does not branch on exit code.
 
 The naming follows regedit's `/e` (export) and `/s` (import) directional
 convention: `reg-export` pulls policy out of the registry world into a

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -644,6 +644,21 @@ func runLogin(cmd *cobra.Command, args []string) error {
 // loginsuppress package and the login-check Long help for the full
 // contract.
 func runLoginCheck(cmd *cobra.Command, args []string) error {
+	// Catch SIGINT before any other work so a Ctrl+C arriving during
+	// setup (env parse, marker stat, term.GetState) cannot fall through
+	// to Go's default handler and bypass the terminal-restore +
+	// marker-refresh contract. The handler goroutine is started later,
+	// once it has marker path / saved terminal state to act on; signals
+	// arriving before then sit in the buffered channel and are picked
+	// up the moment the goroutine starts. We register only SIGINT
+	// because the contract is exclusively about user-initiated
+	// cancellation — SIGTERM from a session/process manager should
+	// follow Go's default (terminate with non-zero status) rather than
+	// silently extending suppression as if the check succeeded.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
 	window, err := loginsuppress.Window()
 	if err != nil {
 		// Invalid DOTVAULT_SUPPRESS_HOURS: surface the problem loudly so
@@ -693,19 +708,15 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Dedicated signal handler rather than signal.NotifyContext: the
-	// password prompt inside the LDAP flow blocks in a read syscall that
-	// does not observe context cancellation, so the only reliable way
-	// to honour the "Ctrl+C exits immediately, no extra Enter" contract
-	// is to short-circuit to os.Exit from a goroutine. We restore the
-	// terminal and refresh the marker first since defers won't run.
-	// We also call cancel() — os.Exit usually wins the race, but if
-	// an in-flight Vault call happens to unwind first it will see
-	// context.Canceled and the loginCheckCancelled() backstops below
-	// can suppress its error message before exit.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
+	// Now start the handler goroutine. It also calls cancel() — os.Exit
+	// usually wins the race, but if an in-flight Vault call happens to
+	// unwind first it will see context.Canceled and the
+	// loginCheckCancelled() backstops below can suppress its error
+	// message before exit. The password prompt inside the LDAP flow
+	// blocks in a read syscall that does not observe context
+	// cancellation, so the only reliable way to honour the
+	// "Ctrl+C exits immediately, no extra Enter" contract is to
+	// short-circuit to os.Exit from this goroutine.
 	go func() {
 		select {
 		case <-sigCh:

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goodtune/dotvault/internal/auth"
 	"github.com/goodtune/dotvault/internal/config"
 	"github.com/goodtune/dotvault/internal/enrol"
+	"github.com/goodtune/dotvault/internal/loginsuppress"
 	"github.com/goodtune/dotvault/internal/paths"
 	"github.com/goodtune/dotvault/internal/regfile"
 	"github.com/goodtune/dotvault/internal/sync"
@@ -97,21 +98,30 @@ but driven by dotvault's loaded configuration (YAML or Group Policy).`,
 		&cobra.Command{
 			Use:   "login-check",
 			Short: "Validate cached token on interactive login, renew or re-login as needed",
-			Long: `Intended to be wired into shell rc / login-profile scripts.
+			Long: `Intended to be wired into shell rc / login-profile scripts via a thin
+wrapper that gates on interactivity, TTY, and daemon state. This binary
+trusts those preconditions and does not re-check them.
 
-If stdout is not a terminal the command exits silently with status 0 so
-non-interactive environments (cron, system services, scp) never see a
-prompt.
+Behaviour:
+  - A suppression marker at
+    ${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress
+    (overridable with DOTVAULT_SUPPRESS_MARKER) is checked first. If
+    the marker's mtime is within DOTVAULT_SUPPRESS_HOURS (default 6),
+    the command exits silently. A future mtime is treated as stale so
+    clock skew or backup restores cannot lock suppression on.
+  - Otherwise: if the cached token is valid and still within the first
+    half of its creation TTL, exit clean. Past halfway, attempt
+    renewal; if renewal fails but the token is still valid, warn with
+    the absolute expiry time. If no valid token, run the configured
+    fresh-auth flow.
+  - On every exit past the suppression check the marker is refreshed,
+    so a declined login, a failed login, an internal error, or Ctrl+C
+    all silence the next shell in the window. Ctrl+C exits immediately
+    without requiring an additional Enter.
 
-When run on an interactive terminal:
-  - If the cached token is valid and still within the first half of its
-    creation TTL, exit clean.
-  - If the cached token is valid but past the halfway point, attempt
-    renewal. If renewal succeeds, exit clean. If renewal fails but the
-    token is still valid, warn with the absolute expiry time and exit 0.
-  - If the cached token is missing or invalid, run the configured login
-    flow. Ctrl-C exits without fanfare so the user can dismiss the prompt
-    on a fresh terminal session.`,
+Exits 0 on suppressed, success, decline, cancellation, or expected
+authentication failure. Exits 1 on invalid DOTVAULT_SUPPRESS_HOURS or
+genuine internal errors.`,
 			RunE: runLoginCheck,
 		},
 		&cobra.Command{
@@ -627,20 +637,79 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runLoginCheck implements `dotvault login-check`, intended to be called
-// from a user's interactive-shell login profile. The semantics are
-// described in the command's Long help text.
+// runLoginCheck implements `dotvault login-check`, intended to be wired
+// into shell rc / login-profile scripts via a thin wrapper that handles
+// environment gating (interactive shell, TTYs, daemon active). The
+// binary trusts those preconditions and never re-checks them — see the
+// loginsuppress package and the login-check Long help for the full
+// contract.
 func runLoginCheck(cmd *cobra.Command, args []string) error {
-	// Only attach the slog default in interactive mode — non-interactive
-	// callers should be completely silent. We still log to stderr (text
-	// handler) in the interactive path so renewal/failure messages reach
-	// the operator.
-	if !isStdoutTerminal() {
-		// No tty: nothing for us to do. Exit clean rather than blocking
-		// or emitting JSON-shaped logs into the shell startup output.
+	setupLogging()
+
+	window, err := loginsuppress.Window()
+	if err != nil {
+		// Invalid DOTVAULT_SUPPRESS_HOURS: surface the problem loudly so
+		// the user fixes it. Bypass cobra's error printing so the message
+		// reads exactly as specified, and skip marker refresh — leaving
+		// the marker untouched means the next shell will also raise the
+		// error rather than masking it.
+		fmt.Fprintln(os.Stderr, "dotvault: "+err.Error())
+		os.Exit(1)
+	}
+
+	markerPath := loginsuppress.Path()
+	if loginsuppress.IsFresh(markerPath, window, time.Now()) {
+		// Suppressed: another invocation within the window already
+		// handled (or attempted) the check. Exit silently without
+		// touching the marker — refreshing here would extend
+		// suppression indefinitely under tight shell-fanout loops.
 		return nil
 	}
-	setupLogging()
+
+	// From here on every exit path refreshes the marker so the next
+	// shell startup is silent. The signal handler below explicitly
+	// refreshes too (defers do not run after os.Exit).
+	defer func() {
+		if rerr := loginsuppress.Refresh(markerPath); rerr != nil {
+			slog.Warn("failed to refresh login-check suppression marker", "error", rerr, "path", markerPath)
+		}
+	}()
+
+	// Capture the terminal state now so the SIGINT handler can restore
+	// it even if mgr.Login is mid-prompt (term.ReadPassword puts the
+	// terminal into a no-echo mode that bash cannot read out of cleanly
+	// on its own). If stdin isn't a TTY, GetState returns an error and
+	// we simply leave savedTermState nil.
+	fd := int(os.Stdin.Fd())
+	var savedTermState *term.State
+	if st, gerr := term.GetState(fd); gerr == nil {
+		savedTermState = st
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Dedicated signal handler rather than signal.NotifyContext: the
+	// password prompt inside the LDAP flow blocks in a read syscall that
+	// does not observe context cancellation, so the only reliable way
+	// to honour the "Ctrl+C exits immediately, no extra Enter" contract
+	// is to short-circuit to os.Exit from a goroutine. We restore the
+	// terminal and refresh the marker first since defers won't run.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			if savedTermState != nil {
+				_ = term.Restore(fd, savedTermState)
+				fmt.Fprintln(os.Stderr)
+			}
+			_ = loginsuppress.Refresh(markerPath)
+			os.Exit(0)
+		case <-ctx.Done():
+		}
+	}()
 
 	cfg, err := loadConfig()
 	if err != nil {
@@ -655,9 +724,6 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("create vault client: %w", err)
 	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
 
 	tokenPath := paths.VaultTokenPath()
 	token := auth.ResolveToken(tokenPath)
@@ -737,7 +803,15 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 		if loginCheckCancelled(ctx, err) {
 			return nil
 		}
-		return fmt.Errorf("login: %w", err)
+		// Login was attempted and failed for an expected reason (user
+		// declined, wrong password, auth method refused). Exit 0 so
+		// shell startup proceeds normally; the marker (refreshed via
+		// defer above) silences subsequent shells in the window.
+		hours := int(window / time.Hour)
+		fmt.Fprintf(os.Stderr,
+			"dotvault: login-check declined or failed (%v); suppressed for %dh (rm %s to retry)\n",
+			err, hours, markerPath)
+		return nil
 	}
 	return nil
 }
@@ -1127,13 +1201,6 @@ func validateYAML(data []byte) error {
 // pick the slog text vs JSON handler at startup.
 func isStderrTerminal() bool {
 	return term.IsTerminal(int(os.Stderr.Fd()))
-}
-
-// isStdoutTerminal reports whether stdout is connected to a TTY. Used by
-// `dotvault login-check` to silently no-op when invoked from a
-// non-interactive shell (cron, sshd ForceCommand, scp, etc.).
-func isStdoutTerminal() bool {
-	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // isInteractive reports whether stdin is connected to a TTY, i.e. whether

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -644,8 +644,6 @@ func runLogin(cmd *cobra.Command, args []string) error {
 // loginsuppress package and the login-check Long help for the full
 // contract.
 func runLoginCheck(cmd *cobra.Command, args []string) error {
-	setupLogging()
-
 	window, err := loginsuppress.Window()
 	if err != nil {
 		// Invalid DOTVAULT_SUPPRESS_HOURS: surface the problem loudly so
@@ -663,8 +661,14 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 		// handled (or attempted) the check. Exit silently without
 		// touching the marker — refreshing here would extend
 		// suppression indefinitely under tight shell-fanout loops.
+		// setupLogging() is deliberately deferred until past this point
+		// so the suppressed fast path performs zero side effects (no
+		// slog handler swap, no future startup-line leakage into shell
+		// scrollback).
 		return nil
 	}
+
+	setupLogging()
 
 	// From here on every exit path refreshes the marker so the next
 	// shell startup is silent. The signal handler below explicitly
@@ -695,12 +699,17 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 	// to honour the "Ctrl+C exits immediately, no extra Enter" contract
 	// is to short-circuit to os.Exit from a goroutine. We restore the
 	// terminal and refresh the marker first since defers won't run.
+	// We also call cancel() — os.Exit usually wins the race, but if
+	// an in-flight Vault call happens to unwind first it will see
+	// context.Canceled and the loginCheckCancelled() backstops below
+	// can suppress its error message before exit.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 	go func() {
 		select {
 		case <-sigCh:
+			cancel()
 			if savedTermState != nil {
 				_ = term.Restore(fd, savedTermState)
 				fmt.Fprintln(os.Stderr)
@@ -747,9 +756,10 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 			// Clear it and fall through to the interactive login flow.
 			vc.SetToken("")
 		} else {
-			// Ctrl-C during LookupSelf surfaces as a wrapped
-			// context.Canceled here — exit silently to honour the
-			// command's documented "Ctrl-C without fanfare" contract.
+			// Backstop for context.Canceled: the SIGINT handler usually
+			// wins the race and os.Exits before this point, but if
+			// LookupSelf happens to unwind first we don't want a
+			// cancellation message in the shell scrollback.
 			if loginCheckCancelled(ctx, lookupErr) {
 				return nil
 			}
@@ -776,9 +786,10 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 	_, healthErr := vc.ServerHealth(healthCtx)
 	healthCancel()
 	if healthErr != nil {
-		// Ctrl-C during the health probe inherits cancellation from the
-		// outer signal context. Suppress the warning in that case so the
-		// shell scrollback stays clean.
+		// Backstop for context.Canceled propagating from the outer
+		// context (cancelled by the SIGINT handler). os.Exit usually
+		// wins the race, but if the health probe unwinds first we
+		// suppress the warning to keep shell scrollback clean.
 		if loginCheckCancelled(ctx, healthErr) {
 			return nil
 		}
@@ -799,7 +810,10 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 		Username:      username,
 	}
 	if err := mgr.Login(ctx); err != nil {
-		// Ctrl-C: silent exit. The user dismissed the prompt knowingly.
+		// Backstop for context.Canceled. The SIGINT handler normally
+		// reaches os.Exit before mgr.Login returns, so this branch
+		// only fires if a Vault-side cancellation unwinds first;
+		// either way we exit silently.
 		if loginCheckCancelled(ctx, err) {
 			return nil
 		}
@@ -876,9 +890,11 @@ func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Se
 	}
 
 	if _, err := vc.RenewSelf(ctx, 0); err != nil {
-		// Ctrl-C during renewal: exit silently (the command's documented
-		// contract), leaving the cached token in place — it's still
-		// valid, just not yet renewed this session.
+		// Backstop for context.Canceled (the SIGINT handler cancels
+		// the outer context before os.Exit, but the race usually goes
+		// to os.Exit). If RenewSelf does happen to unwind first, exit
+		// silently and leave the cached token alone — it's still valid,
+		// just not yet renewed this session.
 		if loginCheckCancelled(ctx, err) {
 			return true, err
 		}
@@ -891,11 +907,12 @@ func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Se
 	return true, nil
 }
 
-// loginCheckCancelled reports whether err is a context-cancellation
-// (i.e. the user pressed Ctrl-C). Used at every login-check error site
-// to honour the command's "Ctrl-C exits without fanfare" contract — a
-// cancelled lookup, health probe, or renewal must not leave warnings
-// in the shell's startup scrollback.
+// loginCheckCancelled reports whether err is a context-cancellation.
+// The login-check SIGINT handler primarily exits via os.Exit(0), but it
+// also cancel()s the outer context — this helper is a backstop at every
+// in-flight Vault call site for the rare race where the call unwinds
+// before os.Exit lands, suppressing the would-be warning so shell
+// startup scrollback stays clean.
 func loginCheckCancelled(ctx context.Context, err error) bool {
 	if errors.Is(ctx.Err(), context.Canceled) {
 		return true

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
 
 func TestIsGUIBinary(t *testing.T) {
 	tests := []struct {
@@ -27,5 +34,96 @@ func TestIsGUIBinary(t *testing.T) {
 				t.Errorf("isGUIBinary(%q) = %v, want %v", tc.arg0, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestLoginCheckSuppression_SubprocessRoundTrip exercises the spec's
+// "Immediate Re-Invocation" integration test: two back-to-back binary
+// invocations where the second must observe the marker the first wrote
+// and exit silently without a vault call. Uses a non-existent --config
+// path so the first invocation fails fast at config load (well before
+// the Vault client is constructed) and the test does not require a
+// running daemon or Vault instance.
+func TestLoginCheckSuppression_SubprocessRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess test")
+	}
+	if runtime.GOOS == "windows" {
+		// PATH and stdio semantics under a go-built test binary differ
+		// enough on Windows that the test deserves its own treatment;
+		// the unit tests in internal/loginsuppress already cover the
+		// platform-independent suppression logic.
+		t.Skip("subprocess test exercises POSIX shell-startup semantics")
+	}
+
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "dotvault")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build: %v", err)
+	}
+
+	workDir := t.TempDir()
+	markerPath := filepath.Join(workDir, "marker")
+	missingConfig := filepath.Join(workDir, "does-not-exist.yaml")
+
+	env := append(os.Environ(),
+		"DOTVAULT_SUPPRESS_MARKER="+markerPath,
+		// Reset the suppression window to the default so the test does
+		// not inherit any DOTVAULT_SUPPRESS_HOURS set in the surrounding
+		// shell.
+		"DOTVAULT_SUPPRESS_HOURS=6",
+	)
+
+	first := exec.Command(binPath, "--config", missingConfig, "login-check")
+	first.Env = env
+	first.Stdin = nil
+	if out, err := first.CombinedOutput(); err == nil {
+		t.Logf("first invocation output:\n%s", out)
+		// First invocation should fail because the config doesn't exist
+		// (exit 1 via cobra error). If it succeeded, something is wrong
+		// with the test setup, not the suppression logic.
+		t.Fatal("first invocation unexpectedly succeeded; test setup is wrong")
+	} else {
+		t.Logf("first invocation exited (expected): %v\noutput:\n%s", err, out)
+	}
+
+	info, err := os.Stat(markerPath)
+	if err != nil {
+		t.Fatalf("marker not created after first invocation: %v", err)
+	}
+	mtime1 := info.ModTime()
+
+	// Brief sleep so a missed-suppression path (which would refresh the
+	// marker) would produce a visibly different mtime.
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	second := exec.Command(binPath, "--config", missingConfig, "login-check")
+	second.Env = env
+	second.Stdin = nil
+	out2, err := second.CombinedOutput()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("second invocation failed (should be silent exit 0): %v\noutput:\n%s", err, out2)
+	}
+	if len(out2) != 0 {
+		t.Errorf("second invocation should produce no output, got: %q", out2)
+	}
+	// Second invocation must be near-instant — well under the time a
+	// real vault call would take. 5s is generous to absorb CI noise
+	// while still catching accidental network calls.
+	if elapsed > 5*time.Second {
+		t.Errorf("second invocation took %v, want <5s", elapsed)
+	}
+
+	info2, err := os.Stat(markerPath)
+	if err != nil {
+		t.Fatalf("stat marker after second invocation: %v", err)
+	}
+	if !info2.ModTime().Equal(mtime1) {
+		t.Errorf("suppressed second invocation should not touch marker mtime: was %v, now %v",
+			mtime1, info2.ModTime())
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,24 +51,35 @@ dotvault login [flags]
 
 ### `dotvault login-check`
 
-Intended to be wired into shell rc / login-profile scripts.
+Intended to be wired into shell rc / login-profile scripts via a thin
+wrapper that gates on interactivity, TTY, and daemon state. The binary
+trusts those preconditions and never re-checks them.
 
 ```sh
 dotvault login-check [flags]
 ```
 
-- If stdout is not a TTY, the command exits silently with status 0 so
-  non-interactive callers (cron, sshd ForceCommand, scp) never see a
-  prompt.
-- If the cached token is valid and still within the first half of its
-  creation TTL, exit clean.
-- If the cached token is valid but past the halfway mark, attempt
-  renewal. On success, exit clean. If renewal fails but the token is
-  still valid, warn with the absolute expiry time and exit 0.
-- If the cached token is missing or invalid, run the configured login
-  flow. Transient Vault/TLS/network errors warn and exit clean rather
-  than prompting. Ctrl-C exits without fanfare so the user can dismiss
-  the prompt on a fresh terminal session.
+- A suppression marker at
+  `${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress`
+  is checked first (override path with `DOTVAULT_SUPPRESS_MARKER`,
+  primarily for testing). If its mtime is within
+  `DOTVAULT_SUPPRESS_HOURS` (default `6`), the command exits silently.
+  A future mtime is treated as stale so clock skew or backup restores
+  cannot lock suppression on indefinitely.
+- Otherwise: if the cached token is valid and still within the first
+  half of its creation TTL, exit clean. Past halfway, attempt renewal;
+  if renewal fails but the token is still valid, warn with the
+  absolute expiry time and exit 0. If no valid token, run the
+  configured login flow.
+- The marker is refreshed on every exit past the suppression check
+  (success, decline, failure, Ctrl+C, internal errors), so concurrent
+  shell startups only ever prompt once per window and a single Ctrl+C
+  is enough — no second Enter required.
+- Exit `0` on suppressed, success, decline, cancellation, or expected
+  authentication failure. Exit `1` only on invalid
+  `DOTVAULT_SUPPRESS_HOURS` or genuine internal errors. The shell
+  wrapper does not branch on exit code; signalling is via the marker
+  state and stderr output.
 
 ### `dotvault status`
 
@@ -107,6 +118,8 @@ project README and the Windows admin docs for details.
 | Variable | Description |
 |----------|-------------|
 | `VAULT_TOKEN` | Vault token (takes precedence over `~/.vault-token`) |
+| `DOTVAULT_SUPPRESS_HOURS` | `dotvault login-check` suppression window in whole hours (default `6`). Zero, negative, or non-integer values cause `login-check` to exit `1`. |
+| `DOTVAULT_SUPPRESS_MARKER` | Override path for the `login-check` suppression marker. Primarily used by tests; the default location is `${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress`. |
 
 ## Logging
 

--- a/internal/loginsuppress/loginsuppress.go
+++ b/internal/loginsuppress/loginsuppress.go
@@ -63,7 +63,10 @@ func Window() (time.Duration, error) {
 	}
 	n, err := strconv.Atoi(raw)
 	if err != nil || n <= 0 {
-		return 0, fmt.Errorf("invalid %s: must be a positive integer", envHours)
+		// Echo the offending value so the diagnostic is actionable in
+		// shell scrollback even when the user has forgotten what (or
+		// where) the variable was set.
+		return 0, fmt.Errorf("invalid %s=%q: must be a positive integer", envHours, raw)
 	}
 	return time.Duration(n) * time.Hour, nil
 }

--- a/internal/loginsuppress/loginsuppress.go
+++ b/internal/loginsuppress/loginsuppress.go
@@ -1,0 +1,112 @@
+// Package loginsuppress implements the marker-file suppression that
+// coordinates `dotvault login-check` invocations across rapidly-launched
+// shells. The shell wrapper (.bashrc/.zshrc/profile.d) is authoritative
+// for environment gating — TTY, interactivity, daemon state — and this
+// package never repeats those checks. It only answers: "given the
+// resolved marker path and window, should this invocation prompt?"
+package loginsuppress
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultHours is the suppression window when DOTVAULT_SUPPRESS_HOURS
+	// is unset. Six hours matches the shell-wrapper era and keeps shell
+	// startup quiet across a normal working day.
+	DefaultHours = 6
+
+	envMarker = "DOTVAULT_SUPPRESS_MARKER"
+	envHours  = "DOTVAULT_SUPPRESS_HOURS"
+	fileName  = "login-check-suppress"
+	dirName   = "dotvault"
+)
+
+// Path returns the suppression marker file path.
+//
+// Resolution order:
+//  1. DOTVAULT_SUPPRESS_MARKER (used primarily by tests)
+//  2. ${XDG_STATE_HOME}/dotvault/login-check-suppress
+//  3. $HOME/.local/state/dotvault/login-check-suppress
+//
+// This matches the path the previous shell-side suppression script used,
+// so existing users retain their suppression state without migration.
+func Path() string {
+	if p := os.Getenv(envMarker); p != "" {
+		return p
+	}
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(base, dirName, fileName)
+}
+
+// Window returns the suppression window duration parsed from
+// DOTVAULT_SUPPRESS_HOURS, defaulting to DefaultHours when unset. The
+// value must be a positive integer number of hours; zero, negative, and
+// non-integer values are rejected so misconfiguration surfaces loudly
+// rather than silently disabling suppression.
+func Window() (time.Duration, error) {
+	raw := os.Getenv(envHours)
+	if raw == "" {
+		return DefaultHours * time.Hour, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid %s: must be a positive integer", envHours)
+	}
+	return time.Duration(n) * time.Hour, nil
+}
+
+// IsFresh reports whether the marker at path is recent enough to
+// suppress an invocation. A missing marker, a marker older than the
+// window, or a marker with an mtime in the future (clock skew, restored
+// backup, VM snapshot rollback) are all treated as stale so suppression
+// cannot lock itself on indefinitely.
+func IsFresh(path string, window time.Duration, now time.Time) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	mtime := info.ModTime()
+	if mtime.After(now) {
+		return false
+	}
+	return now.Sub(mtime) < window
+}
+
+// Refresh ensures the marker file exists and bumps its mtime to now.
+// Parent directories are created on demand. Concurrent callers racing
+// to refresh the same marker are safe: the worst case is interleaved
+// mtime updates, which is the intended behaviour for the "multiple
+// shells start at once" case.
+func Refresh(path string) error {
+	if path == "" {
+		return errors.New("empty marker path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	now := time.Now()
+	return os.Chtimes(path, now, now)
+}

--- a/internal/loginsuppress/loginsuppress_test.go
+++ b/internal/loginsuppress/loginsuppress_test.go
@@ -68,10 +68,14 @@ func TestPath_XDGStateHome(t *testing.T) {
 func TestPath_HomeFallback(t *testing.T) {
 	unsetenv(t, envMarker)
 	unsetenv(t, "XDG_STATE_HOME")
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("no home directory available")
-	}
+
+	// Pin HOME (and USERPROFILE on Windows) to a temp dir so the
+	// assertion is deterministic and cannot accidentally agree with
+	// whatever the developer's real home directory contains.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
 	want := filepath.Join(home, ".local", "state", dirName, fileName)
 	if got := Path(); got != want {
 		t.Errorf("Path() = %q, want %q", got, want)

--- a/internal/loginsuppress/loginsuppress_test.go
+++ b/internal/loginsuppress/loginsuppress_test.go
@@ -1,0 +1,215 @@
+package loginsuppress
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWindow(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"default", "", DefaultHours * time.Hour, false},
+		{"one hour", "1", time.Hour, false},
+		{"large", "240", 240 * time.Hour, false},
+		{"zero", "0", 0, true},
+		{"negative", "-1", 0, true},
+		{"non-integer", "1.5", 0, true},
+		{"alpha", "abc", 0, true},
+		{"empty-string-spaces", "  ", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envHours, tc.value)
+			got, err := Window()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Window(%q) = %v, want error", tc.value, got)
+				}
+				if !strings.Contains(err.Error(), "DOTVAULT_SUPPRESS_HOURS") {
+					t.Errorf("error %q should mention DOTVAULT_SUPPRESS_HOURS", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Window(%q): unexpected error: %v", tc.value, err)
+			}
+			if got != tc.want {
+				t.Errorf("Window(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPath_OverrideEnv(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "custom-marker")
+	t.Setenv(envMarker, override)
+	if got := Path(); got != override {
+		t.Errorf("Path() = %q, want %q", got, override)
+	}
+}
+
+func TestPath_XDGStateHome(t *testing.T) {
+	unsetenv(t, envMarker)
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+	want := filepath.Join(tmp, dirName, fileName)
+	if got := Path(); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestPath_HomeFallback(t *testing.T) {
+	unsetenv(t, envMarker)
+	unsetenv(t, "XDG_STATE_HOME")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory available")
+	}
+	want := filepath.Join(home, ".local", "state", dirName, fileName)
+	if got := Path(); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+// unsetenv removes an environment variable for the duration of the test
+// and restores its original value on cleanup. t.Setenv does not support
+// "unset," so we replicate its restore semantics by hand.
+func unsetenv(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unsetenv %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(key, prev)
+		} else {
+			os.Unsetenv(key)
+		}
+	})
+}
+
+func TestIsFresh(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	window := 6 * time.Hour
+
+	t.Run("missing", func(t *testing.T) {
+		if IsFresh(filepath.Join(dir, "nope"), window, now) {
+			t.Error("missing marker should not be fresh")
+		}
+	})
+
+	t.Run("fresh", func(t *testing.T) {
+		writeMarker(t, marker, now.Add(-1*time.Hour))
+		if !IsFresh(marker, window, now) {
+			t.Error("marker 1h old with 6h window should be fresh")
+		}
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		writeMarker(t, marker, now.Add(-7*time.Hour))
+		if IsFresh(marker, window, now) {
+			t.Error("marker 7h old with 6h window should be stale")
+		}
+	})
+
+	t.Run("boundary-exact", func(t *testing.T) {
+		// mtime exactly window-old: age == window, not strictly less than
+		// window, so treated as stale.
+		writeMarker(t, marker, now.Add(-window))
+		if IsFresh(marker, window, now) {
+			t.Error("marker at exact window boundary should be stale")
+		}
+	})
+
+	t.Run("future-mtime", func(t *testing.T) {
+		writeMarker(t, marker, now.Add(2*time.Hour))
+		if IsFresh(marker, window, now) {
+			t.Error("future mtime should be treated as stale")
+		}
+	})
+
+	t.Run("empty-path", func(t *testing.T) {
+		if IsFresh("", window, now) {
+			t.Error("empty path should not be fresh")
+		}
+	})
+}
+
+func TestRefresh_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "c", "marker")
+	if err := Refresh(nested); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if time.Since(info.ModTime()) > 5*time.Second {
+		t.Errorf("marker mtime not recent: %v", info.ModTime())
+	}
+}
+
+func TestRefresh_UpdatesExistingMtime(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	old := time.Now().Add(-24 * time.Hour)
+	writeMarker(t, marker, old)
+	if err := Refresh(marker); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	info, err := os.Stat(marker)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !info.ModTime().After(old) {
+		t.Errorf("mtime not bumped: was %v, now %v", old, info.ModTime())
+	}
+}
+
+func TestRefresh_EmptyPath(t *testing.T) {
+	if err := Refresh(""); err == nil {
+		t.Error("Refresh(\"\") should error")
+	}
+}
+
+func TestSuppressionEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	window := 6 * time.Hour
+
+	// First call: stale -> would proceed, then refresh.
+	if IsFresh(marker, window, time.Now()) {
+		t.Fatal("fresh before first refresh")
+	}
+	if err := Refresh(marker); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	// Second call: fresh -> suppress.
+	if !IsFresh(marker, window, time.Now()) {
+		t.Error("marker should be fresh immediately after Refresh")
+	}
+}
+
+func writeMarker(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}

--- a/internal/loginsuppress/loginsuppress_test.go
+++ b/internal/loginsuppress/loginsuppress_test.go
@@ -22,7 +22,7 @@ func TestWindow(t *testing.T) {
 		{"negative", "-1", 0, true},
 		{"non-integer", "1.5", 0, true},
 		{"alpha", "abc", 0, true},
-		{"empty-string-spaces", "  ", 0, true},
+		{"whitespace-only", "  ", 0, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Moves login-check throttling and Ctrl+C handling out of the shell wrapper and into the dotvault binary, per the suppression specification. The wrapper stays minimal (interactive shell + TTY + daemon active) and the binary owns suppression state, prompt cancellation, and concurrent-shell tolerance.

- New `internal/loginsuppress` package: marker path resolution (`DOTVAULT_SUPPRESS_MARKER` override, `XDG_STATE_HOME` / `$HOME/.local/state` fallback matching the legacy shell-wrapper location so existing users carry their suppression state forward without migration), `DOTVAULT_SUPPRESS_HOURS` parsing (positive integer, default 6), freshness check that treats future mtimes as stale (clock skew / VM snapshot / backup restore), and marker refresh that auto-creates parent directories.
- `runLoginCheck` checks the marker first and exits silently when fresh, defers a refresh on every subsequent exit, and runs a dedicated signal-handling goroutine that restores the saved terminal state, refreshes the marker, and `os.Exit`s. `term.ReadPassword` does not observe context cancellation, so going through a goroutine + `os.Exit` is the only reliable way to honour the "single Ctrl+C exits immediately, no extra Enter" requirement.
- TTY pre-check removed from the binary — the wrapper guarantees it.
- Docs updated (`docs/cli.md`, `CLAUDE.md`).

## Test plan

- [x] `go test ./internal/loginsuppress/...` — covers window parsing (valid / zero / negative / non-integer), path resolution (override / XDG / `$HOME` fallback), freshness (missing / fresh / stale / boundary / future mtime / empty path), and marker creation (parent dirs auto-created, existing mtime bumped).
- [x] `go test ./cmd/dotvault/...` — `TestLoginCheckSuppression_SubprocessRoundTrip` exercises the spec's "Immediate Re-Invocation" integration scenario end-to-end: two back-to-back binary runs where the second is silent, fast (<5s), and leaves the marker mtime untouched.
- [x] `go test ./...` — full suite green.
- [ ] **Manual signal verification (required by spec):** open a new interactive shell with `dotvault.service` active and no cached token, confirm the prompt appears, press Ctrl+C once, and confirm the prompt exits immediately, the shell is responsive without an additional Enter, the marker is created, and opening another shell within the window does not re-prompt. This must be validated in a real terminal — `go test` alone is insufficient.

---
_Generated by [Claude Code](https://claude.ai/code/session_017HnjP4E9Lmzwjo3uXPgGT9)_