### PR TITLE
ci(review): inline + summary comment output for council reviewer

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,24 +7,19 @@ on:
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -36,14 +31,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          claude_args: >-
+            --allowed-tools
+            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Read,Glob,Grep,Task"
           prompt: |
-            You are orchestrating a council of reviewers for ${{ github.repository }}/pull/${{ github.event.pull_request.number }}.
+            You are orchestrating a council of reviewers for ${{ github.repository }} PR #${{ github.event.pull_request.number }}.
 
-            First, read the PR diff, description, and the CLAUDE.md project guide so every persona shares the same context. Then dispatch the following personas IN PARALLEL via the Agent tool (single message, multiple Agent tool calls). Each persona is independent — do not chain them.
+            First, read the PR diff, description, and the CLAUDE.md project guide so every persona shares the same context. Use `gh pr view ${{ github.event.pull_request.number }}` and `gh pr diff ${{ github.event.pull_request.number }}` for PR data. Then dispatch the following personas IN PARALLEL via the Task tool (single message, multiple Task tool calls). Each persona is independent — do not chain them.
 
-            Personas (run each as its own Agent call):
+            Personas (run each as its own Task call):
             1. Security reviewer — credential handling, file permissions (0600 invariants), CSRF/CSP on the web UI, loopback-only invariant, secrets in logs, registry/DACL on Windows, OAuth flows, template injection.
             2. Architecture reviewer — package boundaries (internal/auth, sync, enrol, handlers, web), interface contracts (FileHandler, Engine, Refresher, Watcher, SettingsFielder), lifecycle ordering in the daemon, error handling vs. project conventions in CLAUDE.md.
             3. Cross-platform / portability reviewer — Linux/macOS/Windows behaviour, CGO_ENABLED=0 invariant, path resolution (XDG vs %ProgramData% vs Application Support), Windows subsystem (console vs GUI), registry-vs-YAML config parity, atomic writes, signal handling.
@@ -52,14 +48,16 @@ jobs:
 
             Brief each persona with: PR number, the diff, the relevant CLAUDE.md sections, and an instruction to report in under 250 words with concrete file:line references and a severity tag (blocker / major / minor / nit). Tell each persona to suppress "no findings" filler — if there is nothing to say, return a single line saying so.
 
-            When all personas return, consolidate into ONE PR review:
-            - Open with a 2-3 sentence summary of the PR's intent and overall verdict.
-            - Group findings by severity (blocker → major → minor → nit), not by persona.
-            - For each finding cite file:line and tag the originating persona in parentheses.
-            - Drop personas that reported nothing — do not list them.
-            - End with a short "what I checked" line so the author knows the breadth of the pass.
+            When all personas return, post the review in TWO parts:
 
-            Post the consolidated review as a single PR review (not a top-level issue comment). Do not push code changes or open follow-up issues.
+            1. Inline comments for each concrete blocker/major finding using `mcp__github_inline_comment__create_inline_comment`. Each inline comment should be on the exact file:line the finding refers to, prefixed with the severity tag and the originating persona in parentheses (e.g. "**blocker** (security): ..."). Skip inline comments for minor/nit findings unless they tie to a specific line.
+
+            2. A single summary comment via `gh pr comment ${{ github.event.pull_request.number }} --body "..."` containing:
+               - A 2-3 sentence summary of the PR's intent and overall verdict.
+               - Findings grouped by severity (blocker → major → minor → nit), each as a bullet with file:line and the originating persona in parentheses. Findings already posted inline can be referenced briefly here ("see inline").
+               - A short "what I checked" line so the author knows the breadth of the pass.
+               - Drop personas that reported nothing — do not list them.
+
+            Do not push code changes, do not open follow-up issues, and do not call any tool that is not on the allowed list.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary

- Replace the `plugin_marketplaces` / `plugins` invocation of `anthropics/claude-code-action@v1` with an explicit `claude_args` allowlist (covers `mcp__github_inline_comment__create_inline_comment`, scoped `gh` Bash commands, `Read`/`Glob`/`Grep`/`Task`).
- Update the orchestrator prompt: personas now dispatch via the `Task` tool, and the consolidated PR review is replaced by two outputs — inline comments for each blocker/major finding plus one summary PR comment (`gh pr comment`).
- Tighten the prompt with an explicit "do not call any tool not on the allowed list" guard.

## Test plan

- [ ] Open a PR against `main` and confirm the workflow runs without permission prompts for the listed tools.
- [ ] Verify blocker/major findings land as inline comments on the correct file:line.
- [ ] Verify the summary comment is posted once and groups findings by severity, dropping silent personas.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CC8D9Yo8tGrtB7ZVE3DJuW)_