### PR TITLE
feat(login-check): announce why we're prompting before fresh auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,13 +176,22 @@ startup.
 - If the cached token is valid but past the halfway mark, attempt renewal.
   On renewal failure where the token is still valid, warn with the
   absolute expiry time and exit 0.
-- If the cached token is missing or invalid, run the configured login
-  flow. Ctrl-C exits immediately without requiring an extra Enter: a
-  dedicated signal handler restores the terminal state captured before
-  the password prompt, refreshes the marker, and `os.Exit(0)`s
-  (`term.ReadPassword` does not observe context cancellation, so going
-  through a goroutine + `os.Exit` is the only reliable way to honour
-  the contract).
+- If the cached token is missing or invalid, print a one-line
+  explanation of why an authentication prompt is about to appear
+  ("no cached Vault token was found", "the cached Vault token has
+  expired", "the cached Vault token is no longer valid") and then
+  run the configured login flow. The line is yellow on a colour-capable
+  TTY (ANSI SGR 33; honours `NO_COLOR`; ANSI is gated on the writer
+  being `os.Stderr` so test buffers / piped output stay plain) and
+  plain text otherwise. Without it, a profile-script invocation would
+  drop the user straight into a context-free password prompt. Pass
+  `--quiet` to suppress just the notice (the prompt still appears) for
+  wrappers that surface their own context. Ctrl-C exits immediately
+  without requiring an extra Enter: a dedicated signal handler restores
+  the terminal state captured before the password prompt, refreshes the
+  marker, and `os.Exit(0)`s (`term.ReadPassword` does not observe
+  context cancellation, so going through a goroutine + `os.Exit` is the
+  only reliable way to honour the contract).
 - The marker is refreshed on every exit past the freshness check
   (success, decline, failure, Ctrl+C, internal errors) so concurrent
   shells across tmux/IDE/SSH-multiplex fanout only ever prompt once

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -102,35 +102,7 @@ Equivalent to "vault login -address <vault.address> -method <vault.auth_method>"
 but driven by dotvault's loaded configuration (YAML or Group Policy).`,
 			RunE: runLogin,
 		},
-		&cobra.Command{
-			Use:   "login-check",
-			Short: "Validate cached token on interactive login, renew or re-login as needed",
-			Long: `Intended to be wired into shell rc / login-profile scripts via a thin
-wrapper that gates on interactivity, TTY, and daemon state. This binary
-trusts those preconditions and does not re-check them.
-
-Behaviour:
-  - A suppression marker at
-    ${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress
-    (overridable with DOTVAULT_SUPPRESS_MARKER) is checked first. If
-    the marker's mtime is within DOTVAULT_SUPPRESS_HOURS (default 6),
-    the command exits silently. A future mtime is treated as stale so
-    clock skew or backup restores cannot lock suppression on.
-  - Otherwise: if the cached token is valid and still within the first
-    half of its creation TTL, exit clean. Past halfway, attempt
-    renewal; if renewal fails but the token is still valid, warn with
-    the absolute expiry time. If no valid token, run the configured
-    fresh-auth flow.
-  - On every exit past the suppression check the marker is refreshed,
-    so a declined login, a failed login, an internal error, or Ctrl+C
-    all silence the next shell in the window. Ctrl+C exits immediately
-    without requiring an additional Enter.
-
-Exits 0 on suppressed, success, decline, cancellation, or expected
-authentication failure. Exits 1 on invalid DOTVAULT_SUPPRESS_HOURS or
-genuine internal errors.`,
-			RunE: runLoginCheck,
-		},
+		newLoginCheckCmd(),
 		&cobra.Command{
 			Use:   "status",
 			Short: "Show auth and sync status",
@@ -786,6 +758,47 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// newLoginCheckCmd defines the `login-check` subcommand. The body of
+// the work lives in runLoginCheck; this builder exists so the command
+// can carry its own --quiet flag without polluting the top-level flag
+// namespace shared by every other subcommand.
+func newLoginCheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "login-check",
+		Short: "Validate cached token on interactive login, renew or re-login as needed",
+		Long: `Intended to be wired into shell rc / login-profile scripts via a thin
+wrapper that gates on interactivity, TTY, and daemon state. This binary
+trusts those preconditions and does not re-check them.
+
+Behaviour:
+  - A suppression marker at
+    ${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress
+    (overridable with DOTVAULT_SUPPRESS_MARKER) is checked first. If
+    the marker's mtime is within DOTVAULT_SUPPRESS_HOURS (default 6),
+    the command exits silently. A future mtime is treated as stale so
+    clock skew or backup restores cannot lock suppression on.
+  - Otherwise: if the cached token is valid and still within the first
+    half of its creation TTL, exit clean. Past halfway, attempt
+    renewal; if renewal fails but the token is still valid, warn with
+    the absolute expiry time. If no valid token, print a short
+    explanation of why an authentication prompt is about to appear
+    (yellow on a colour-capable TTY, plain text otherwise) and then
+    run the configured fresh-auth flow. Pass --quiet to suppress that
+    explanation when the caller has its own context display.
+  - On every exit past the suppression check the marker is refreshed,
+    so a declined login, a failed login, an internal error, or Ctrl+C
+    all silence the next shell in the window. Ctrl+C exits immediately
+    without requiring an additional Enter.
+
+Exits 0 on suppressed, success, decline, cancellation, or expected
+authentication failure. Exits 1 on invalid DOTVAULT_SUPPRESS_HOURS or
+genuine internal errors.`,
+		RunE: runLoginCheck,
+	}
+	cmd.Flags().Bool("quiet", false, "suppress the explanation printed before triggering an interactive login")
+	return cmd
+}
+
 // runLoginCheck implements `dotvault login-check`, intended to be wired
 // into shell rc / login-profile scripts via a thin wrapper that handles
 // environment gating (interactive shell, TTYs, daemon active). The
@@ -793,6 +806,8 @@ func runLogin(cmd *cobra.Command, args []string) error {
 // loginsuppress package and the login-check Long help for the full
 // contract.
 func runLoginCheck(cmd *cobra.Command, args []string) error {
+	quiet, _ := cmd.Flags().GetBool("quiet")
+
 	// Catch SIGINT before any other work so a Ctrl+C arriving during
 	// setup (env parse, marker stat, term.GetState) cannot fall through
 	// to Go's default handler and bypass the terminal-restore +
@@ -896,6 +911,13 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 
 	tokenPath := paths.VaultTokenPath()
 	token := auth.ResolveToken(tokenPath)
+	// loginReason captures why we're about to drop the user into an
+	// interactive login prompt — printed (yellow on a colour-capable
+	// TTY) before the prompt unless --quiet is set, so a shell-startup
+	// invocation doesn't surface a context-free password prompt.
+	// Default covers the "no cached token" path; the branches below
+	// overwrite it for the expired / revoked cases.
+	loginReason := "no cached Vault token was found"
 	if token != "" {
 		vc.SetToken(token)
 		secret, lookupErr := vc.LookupSelf(ctx)
@@ -911,10 +933,12 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 			if handled {
 				return nil
 			}
+			loginReason = "the cached Vault token has expired"
 		} else if vault.IsForbidden(lookupErr) {
 			// 403: the cached token is revoked or otherwise invalid.
 			// Clear it and fall through to the interactive login flow.
 			vc.SetToken("")
+			loginReason = "the cached Vault token is no longer valid"
 		} else {
 			// Backstop for context.Canceled: the SIGINT handler usually
 			// wins the race and os.Exits before this point, but if
@@ -968,6 +992,9 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 		AuthMount:     cfg.Vault.AuthMount,
 		AuthRole:      cfg.Vault.AuthRole,
 		Username:      username,
+	}
+	if !quiet {
+		printLoginNotice(os.Stderr, loginReason)
 	}
 	if err := mgr.Login(ctx); err != nil {
 		// Backstop for context.Canceled. The SIGINT handler normally
@@ -1362,6 +1389,45 @@ func validateYAML(data []byte) error {
 // isStderrTerminal reports whether stderr is connected to a TTY, used to
 // pick the slog text vs JSON handler at startup.
 func isStderrTerminal() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// printLoginNotice tells the user why dotvault is about to interrupt
+// them with an authentication prompt. A profile-script-triggered
+// login-check would otherwise present a context-free password prompt
+// to a user who didn't ask for one — printing the reason first gives
+// them a chance to either consent or Ctrl-C out.
+//
+// Yellow on a colour-capable TTY, plain text otherwise (so log
+// captures, piped output, and dumb terminals stay readable). Honours
+// NO_COLOR. Enables ENABLE_VIRTUAL_TERMINAL_PROCESSING on Windows for
+// the duration so the ANSI sequence renders rather than printing as
+// literal text on conhost; matches the convention used by the enrol
+// picker (cmd/dotvault/enrol.go).
+//
+// Writes to w (passed in so tests can capture output). Colour is gated
+// on the writer being os.Stderr — anything else (a *bytes.Buffer in
+// tests, stderr piped into a logger) gets plain text regardless of
+// the host terminal's capability.
+func printLoginNotice(w io.Writer, reason string) {
+	msg := fmt.Sprintf("dotvault: %s — starting Vault login flow...", reason)
+	if w != os.Stderr || !stderrSupportsColour() {
+		fmt.Fprintln(w, msg)
+		return
+	}
+	restore := enableVTOutput(os.Stderr)
+	defer restore()
+	fmt.Fprintf(w, "\x1b[33m%s\x1b[0m\n", msg)
+}
+
+// stderrSupportsColour reports whether the current stderr is safe to
+// emit ANSI colour to: a real TTY with NO_COLOR unset (per
+// https://no-color.org). Used by printLoginNotice; takes no arguments
+// because the only meaningful question is about os.Stderr specifically.
+func stderrSupportsColour() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
 	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -34,6 +36,86 @@ func TestIsGUIBinary(t *testing.T) {
 				t.Errorf("isGUIBinary(%q) = %v, want %v", tc.arg0, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestPrintLoginNotice exercises the happy paths for the explanation
+// message printed before login-check drops into an interactive auth
+// prompt. The colour gate is exercised by writing to a *bytes.Buffer
+// (not os.Stderr), which forces plain-text output regardless of the
+// surrounding test environment's TTY state — covering both the
+// content of the message and the fact that ANSI escapes are gated
+// on the writer identity rather than emitted unconditionally.
+func TestPrintLoginNotice(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   string
+	}{
+		{
+			name:   "missing token",
+			reason: "no cached Vault token was found",
+			want:   "dotvault: no cached Vault token was found — starting Vault login flow...\n",
+		},
+		{
+			name:   "expired token",
+			reason: "the cached Vault token has expired",
+			want:   "dotvault: the cached Vault token has expired — starting Vault login flow...\n",
+		},
+		{
+			name:   "revoked token",
+			reason: "the cached Vault token is no longer valid",
+			want:   "dotvault: the cached Vault token is no longer valid — starting Vault login flow...\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printLoginNotice(&buf, tc.reason)
+			if got := buf.String(); got != tc.want {
+				t.Errorf("printLoginNotice() = %q, want %q", got, tc.want)
+			}
+			// Defensive: a buffer is not os.Stderr, so the helper must
+			// never emit ANSI colour through it. Catches a future
+			// regression where the gate is widened without intent.
+			if strings.Contains(buf.String(), "\x1b[") {
+				t.Errorf("printLoginNotice() leaked ANSI escape into non-stderr writer: %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestStderrSupportsColour verifies the cheap branch of the gating
+// logic used by printLoginNotice — NO_COLOR forces false even against
+// a real terminal. The "stderr is a TTY" branch can't be exercised
+// portably in a unit test (the surrounding test harness drives stderr
+// to a pipe), so we accept that gap; the test still pins NO_COLOR
+// behaviour, which is the more frequently-broken half.
+func TestStderrSupportsColour(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	if stderrSupportsColour() {
+		t.Error("stderrSupportsColour() with NO_COLOR set = true, want false")
+	}
+}
+
+// TestLoginCheckQuietFlagRegistered locks in the --quiet flag wiring on
+// the login-check command. The flag is the user-visible escape hatch
+// for the new login notice; deleting it (or renaming it) would silently
+// break callers that pass --quiet in their shell wrapper. A subprocess
+// test exercising the full flag flow would need a stub Vault server to
+// reach the notice branch — out of scope here; this assertion catches
+// the regression that matters most cheaply.
+func TestLoginCheckQuietFlagRegistered(t *testing.T) {
+	cmd := newLoginCheckCmd()
+	flag := cmd.Flags().Lookup("quiet")
+	if flag == nil {
+		t.Fatal("--quiet flag not registered on login-check command")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Errorf("--quiet flag type = %q, want bool", flag.Value.Type())
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--quiet flag default = %q, want false", flag.DefValue)
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,12 +69,22 @@ dotvault login-check [flags]
 - Otherwise: if the cached token is valid and still within the first
   half of its creation TTL, exit clean. Past halfway, attempt renewal;
   if renewal fails but the token is still valid, warn with the
-  absolute expiry time and exit 0. If no valid token, run the
-  configured login flow.
+  absolute expiry time and exit 0. If no valid token, print a one-line
+  explanation of why an authentication prompt is about to appear ("no
+  cached Vault token was found", "the cached Vault token has expired",
+  or "the cached Vault token is no longer valid") and then run the
+  configured login flow. The line is yellow on a colour-capable TTY
+  (ANSI SGR 33; honours `NO_COLOR`) and plain text otherwise — without
+  it, a profile-script invocation would surface a context-free password
+  prompt the user did not ask for.
 - The marker is refreshed on every exit past the suppression check
   (success, decline, failure, Ctrl+C, internal errors), so concurrent
   shell startups only ever prompt once per window and a single Ctrl+C
   is enough — no second Enter required.
+- Pass `--quiet` to suppress just the explanation line — the prompt
+  still appears. Use this from wrappers that already surface their
+  own context (a Window Manager indicator, a desktop notification,
+  etc.) and don't want a duplicate message on stderr.
 - Exit `0` on suppressed, success, decline, cancellation, or expected
   authentication failure. Exit `1` only on invalid
   `DOTVAULT_SUPPRESS_HOURS` or genuine internal errors. The shell


### PR DESCRIPTION
## Summary

When `dotvault login-check` runs from a profile script and discovers the cached token is missing, expired, or revoked, the user previously dropped straight into a context-free Vault login prompt. They had asked for a shell, not for an authentication prompt, and nothing on stderr explained the interruption. This change prints a single yellow line first ("no cached Vault token was found", "the cached Vault token has expired", or "the cached Vault token is no longer valid") so the user understands what they're being asked for and can either consent or Ctrl-C out.

Colour is yellow ANSI SGR 33 on a colour-capable TTY, plain text otherwise. The gate honours `NO_COLOR` (per no-color.org) and only emits ANSI when stderr is a real terminal — piped output and logger captures stay plain. Windows VT processing is enabled inline for the duration of the print, matching the convention the enrol picker already uses (`cmd/dotvault/enrol.go`).

Add `--quiet` to suppress just the notice (the prompt itself still appears) for wrappers that already surface their own context — desktop notification daemons, status-bar indicators, IDE integrations — and don't want a duplicate message on stderr.

## Test plan

- [x] `go test ./...` (whole tree green)
- [x] `go vet ./...`
- [x] `dotvault login-check --help` shows the new `--quiet` flag and the updated `Long` description
- [x] New unit tests: `TestPrintLoginNotice` (each reason string formats correctly through a buffer), `TestStderrSupportsColour` (NO_COLOR gate), `TestLoginCheckQuietFlagRegistered` (flag wiring lock)
- [x] Existing `TestLoginCheckSuppression_SubprocessRoundTrip` still passes
- [ ] End-to-end subprocess test exercising `--quiet` against a stubbed Vault — deferred (flagged in the council review; building the fixture would mean a fake KVv2 endpoint plus a `Sys().Health` stub). The three `loginReason` assignments sit three lines apart in `runLoginCheck` and the unit tests pin the formatted output; a future change in this area should close the gap.
- [ ] Manual smoke on Windows conhost to confirm the em-dash and SGR 33 render correctly — not run in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W46G5HYVshx3g97LzT2B51)_