### PR TITLE
feat(jfrog): capture reference_token alongside access token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,18 +413,20 @@ Flow (enrolment — runs once per user):
 1. POST `{url}/access/api/v2/authentication/jfrog_client_login/request` with a random UUID
 2. Open `{url}/ui/login?jfClientSession=<uuid>&jfClientName=JFrog-CLI&jfClientCode=1` — user confirms the last 4 chars of the UUID after sign-in
 3. Poll GET `{url}/access/api/v2/authentication/jfrog_client_login/token/<uuid>` until 200 — returns a bootstrap token with the JFrog server default TTL (typically 1 year)
-4. POST `{url}/access/api/v1/tokens` with `Authorization: Bearer <bootstrap>` and `{"expires_in":<token_ttl_seconds>,"refreshable":true,"scope":"applied-permissions/user"}` — mints the dotvault-owned pair; the bootstrap token is discarded. v1 rather than v2 because v2 is admin-only on most JFrog deployments (non-admins and older Artifactory versions see it as a 404); v1 has been the self-token endpoint since Artifactory 7.21.1 and is what `jfrog-client-go` uses.
+4. POST `{url}/access/api/v1/tokens` with `Authorization: Bearer <bootstrap>` and `{"expires_in":<token_ttl_seconds>,"refreshable":true,"scope":"applied-permissions/user","include_reference_token":true}` — mints the dotvault-owned pair; the bootstrap token is discarded. v1 rather than v2 because v2 is admin-only on most JFrog deployments (non-admins and older Artifactory versions see it as a 404); v1 has been the self-token endpoint since Artifactory 7.21.1 and is what `jfrog-client-go` uses. `include_reference_token` is always sent so the response also carries an opaque `reference_token` alongside the JWT `access_token`; on servers older than Access 7.38.4 the field is simply absent and `reference_token` is stored empty.
 
 Flow (refresh — periodic, driven by `RefreshManager`):
 1. Every `check_interval` (daemon-wired at 5 min), iterate all enrolments whose engine implements `Refresher`
 2. For each, read the secret and skip unless `now >= issued_at + (expires_at - issued_at) / 2`
-3. POST `{url}/access/api/v1/tokens` with `grant_type=refresh_token&access_token=<current>&refresh_token=<current>` — **JFrog rotates both tokens on every successful refresh**, so the old refresh_token is invalid immediately
+3. POST `{url}/access/api/v1/tokens` with `grant_type=refresh_token&access_token=<current>&refresh_token=<current>&include_reference_token=true` — **JFrog rotates both tokens (and the reference token) on every successful refresh**, so the old refresh_token is invalid immediately
 4. Stamp new `issued_at: now`, `expires_at: now + token_ttl` (dotvault's configured TTL, not whatever JFrog returns), write the replacement map atomically
 5. `401`/`403` from the refresh endpoint is treated as permanent revocation — the secret is deleted from Vault and the user is prompted to re-enrol. Other errors are transient; the existing secret is kept and retried with exponential backoff
 
-Vault schema (7 fields): `access_token`, `refresh_token`, `url`, `server_id`, `user`, `issued_at` (RFC3339), `expires_at` (RFC3339). The rendered `jfrog-cli.conf.v6` only contains `accessToken` — `refreshToken` and `webLogin: true` are deliberately omitted so `jf` never attempts its own refresh (which would race the sync-engine clobber).
+Vault schema (8 fields): `access_token`, `refresh_token`, `reference_token`, `url`, `server_id`, `user`, `issued_at` (RFC3339), `expires_at` (RFC3339). The rendered `jfrog-cli.conf.v6` only contains `accessToken` — `refreshToken` and `webLogin: true` are deliberately omitted so `jf` never attempts its own refresh (which would race the sync-engine clobber). `reference_token` is the opaque equivalent of the JWT access token — useful where a compact credential is preferred (Docker/registry logins, clients that choke on long JWTs). It is captured unconditionally but not written to any target by default; a sync rule opts in by referencing `{{ .reference_token }}` in its template.
 
-`server_id` is deduced from the platform hostname (e.g. `mycompany.jfrog.io` → `mycompany`, IP addresses → `default-server`); `user` is extracted from the access-token JWT subject. Requires JFrog Artifactory 7.64.0 or newer on the remote side.
+`server_id` is deduced from the platform hostname (e.g. `mycompany.jfrog.io` → `mycompany`, IP addresses → `default-server`); `user` is extracted from the access-token JWT subject. Requires JFrog Artifactory 7.64.0 or newer on the remote side. `reference_token` additionally requires Access 7.38.4 or newer; older servers leave it empty.
+
+`reference_token` and `user` are written when available but are deliberately excluded from the engine's `Fields()` set, so `enrol.Manager.HasAllFields` does not reject enrolments on deployments that don't return them.
 
 ### SSH Engine
 

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -58,6 +58,9 @@ rules:
     target:
       path: "~/tmp/.jfrog/jfrog-cli.conf.v6"
       format: json
+      # The enrolment also stores `reference_token` (the opaque equivalent
+      # of `access_token`); reference it via `{{ .reference_token }}` in a
+      # rule template if a downstream tool prefers the short form.
       template: |
         {
           "servers": [

--- a/docs/superpowers/specs/2026-04-17-jfrog-token-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-17-jfrog-token-refresh-design.md
@@ -105,6 +105,8 @@ Current JFrog KV secret (8 fields):
 After this change (7 fields):
 `access_token, refresh_token, url, server_id, user, issued_at, expires_at`
 
+> **Later addendum (reference-token support):** a subsequent change added an 8th field, `reference_token` — the opaque equivalent of the JWT access token, captured unconditionally via `include_reference_token=true` and stored empty on servers older than Access 7.38.4. It is not rendered by default and is excluded from `Fields()`, mirroring `user`. CLAUDE.md's JFrog Engine section is the authoritative schema reference.
+
 Changes:
 
 - **Add `issued_at`** — RFC3339. Stamped when the token is minted (or refreshed).

--- a/internal/enrol/jfrog.go
+++ b/internal/enrol/jfrog.go
@@ -63,6 +63,11 @@ func (e *JFrogEngine) Name() string { return "JFrog" }
 // enrolments with reference-token deployments. GitHub's engine takes the
 // same approach — its `user` value is written when available but isn't
 // required for `HasAllFields`.
+//
+// `reference_token` is likewise NOT listed: the engine always requests one
+// (include_reference_token=true) and writes it when present, but JFrog only
+// returns it on Access 7.38.4+. Requiring it would reject enrolments on
+// older servers; downstream sync rules opt in via `{{ .reference_token }}`.
 func (e *JFrogEngine) Fields() []string {
 	return []string{
 		"access_token",
@@ -213,18 +218,19 @@ func (e *JFrogEngine) Run(ctx context.Context, settings map[string]any, io IO) (
 
 	now := e.clock()
 	result := map[string]string{
-		"access_token":  minted.AccessToken,
-		"refresh_token": minted.RefreshToken,
-		"url":           platformURL,
-		"server_id":     serverID,
-		"user":          user,
-		"issued_at":     now.UTC().Format(time.RFC3339),
-		"expires_at":    now.Add(ttl).UTC().Format(time.RFC3339),
+		"access_token":    minted.AccessToken,
+		"refresh_token":   minted.RefreshToken,
+		"reference_token": minted.ReferenceToken,
+		"url":             platformURL,
+		"server_id":       serverID,
+		"user":            user,
+		"issued_at":       now.UTC().Format(time.RFC3339),
+		"expires_at":      now.Add(ttl).UTC().Format(time.RFC3339),
 	}
 	return result, nil
 }
 
-// Refresh rotates a dotvault-owned JFrog token pair. Returns the same 7
+// Refresh rotates a dotvault-owned JFrog token pair. Returns the same 8
 // fields that Run returns so the caller can atomically replace the Vault
 // secret. A 401/403 from the access service means the refresh token itself
 // has been revoked upstream — callers should treat that as permanent and
@@ -278,13 +284,14 @@ func (e *JFrogEngine) Refresh(ctx context.Context, settings map[string]any, exis
 
 	now := e.clock()
 	return map[string]string{
-		"access_token":  rotated.AccessToken,
-		"refresh_token": rotated.RefreshToken,
-		"url":           platformURL,
-		"server_id":     serverID,
-		"user":          user,
-		"issued_at":     now.UTC().Format(time.RFC3339),
-		"expires_at":    now.Add(ttl).UTC().Format(time.RFC3339),
+		"access_token":    rotated.AccessToken,
+		"refresh_token":   rotated.RefreshToken,
+		"reference_token": rotated.ReferenceToken,
+		"url":             platformURL,
+		"server_id":       serverID,
+		"user":            user,
+		"issued_at":       now.UTC().Format(time.RFC3339),
+		"expires_at":      now.Add(ttl).UTC().Format(time.RFC3339),
 	}, nil
 }
 
@@ -349,11 +356,12 @@ func deduceJFrogServerID(platformURL string) (string, error) {
 
 // jfrogCommonTokenParams mirrors jfrog-client-go's auth.CommonTokenParams.
 type jfrogCommonTokenParams struct {
-	Scope        string `json:"scope,omitempty"`
-	AccessToken  string `json:"access_token,omitempty"`
-	ExpiresIn    *uint  `json:"expires_in,omitempty"`
-	TokenType    string `json:"token_type,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope          string `json:"scope,omitempty"`
+	AccessToken    string `json:"access_token,omitempty"`
+	ExpiresIn      *uint  `json:"expires_in,omitempty"`
+	TokenType      string `json:"token_type,omitempty"`
+	RefreshToken   string `json:"refresh_token,omitempty"`
+	ReferenceToken string `json:"reference_token,omitempty"`
 }
 
 // jfrogSendLoginRequest performs the initial POST to the JFrog Access service
@@ -459,13 +467,20 @@ func jfrogPollForToken(ctx context.Context, client *http.Client, platformURL, se
 func jfrogMintRefreshableToken(ctx context.Context, client *http.Client, platformURL, bootstrapToken string, ttl time.Duration) (jfrogCommonTokenParams, error) {
 	endpoint := platformURL + "/access/api/v1/tokens"
 	body, err := json.Marshal(struct {
-		ExpiresIn   int64  `json:"expires_in"`
-		Refreshable bool   `json:"refreshable"`
-		Scope       string `json:"scope"`
+		ExpiresIn             int64  `json:"expires_in"`
+		Refreshable           bool   `json:"refreshable"`
+		Scope                 string `json:"scope"`
+		IncludeReferenceToken bool   `json:"include_reference_token"`
 	}{
 		ExpiresIn:   int64(ttl.Seconds()),
 		Refreshable: true,
 		Scope:       "applied-permissions/user",
+		// Always ask JFrog to also mint an opaque reference token alongside
+		// the JWT access token. Downstream sync rules decide whether to write
+		// it out; capturing it here is free and avoids a re-enrolment later.
+		// On servers older than Access 7.38.4 the field is simply absent from
+		// the response, so reference_token ends up empty — never an error.
+		IncludeReferenceToken: true,
 	})
 	if err != nil {
 		return jfrogCommonTokenParams{}, err
@@ -510,9 +525,10 @@ func jfrogMintRefreshableToken(ctx context.Context, client *http.Client, platfor
 func jfrogExchangeRefreshToken(ctx context.Context, client *http.Client, platformURL, accessToken, refreshToken string) (jfrogCommonTokenParams, error) {
 	endpoint := platformURL + "/access/api/v1/tokens"
 	form := url.Values{
-		"grant_type":    []string{"refresh_token"},
-		"access_token":  []string{accessToken},
-		"refresh_token": []string{refreshToken},
+		"grant_type":              []string{"refresh_token"},
+		"access_token":            []string{accessToken},
+		"refresh_token":           []string{refreshToken},
+		"include_reference_token": []string{"true"},
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {

--- a/internal/enrol/jfrog_test.go
+++ b/internal/enrol/jfrog_test.go
@@ -204,9 +204,10 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 
 	var gotSession, gotBearer string
 	var gotMintBody struct {
-		ExpiresIn   int64  `json:"expires_in"`
-		Refreshable bool   `json:"refreshable"`
-		Scope       string `json:"scope"`
+		ExpiresIn             int64  `json:"expires_in"`
+		Refreshable           bool   `json:"refreshable"`
+		Scope                 string `json:"scope"`
+		IncludeReferenceToken bool   `json:"include_reference_token"`
 	}
 	var requestHits, tokenHits, mintHits int
 
@@ -246,9 +247,10 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 				return
 			}
 			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
-				AccessToken:  mintedAccess,
-				RefreshToken: "dotvault-refresh-1",
-				TokenType:    "Bearer",
+				AccessToken:    mintedAccess,
+				RefreshToken:   "dotvault-refresh-1",
+				ReferenceToken: "minted-reference-1",
+				TokenType:      "Bearer",
 			})
 		default:
 			http.NotFound(w, r)
@@ -286,6 +288,9 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 	}
 	if creds["refresh_token"] != "dotvault-refresh-1" {
 		t.Errorf("refresh_token = %q, want %q", creds["refresh_token"], "dotvault-refresh-1")
+	}
+	if creds["reference_token"] != "minted-reference-1" {
+		t.Errorf("reference_token = %q, want %q", creds["reference_token"], "minted-reference-1")
 	}
 	if creds["user"] != "alice" {
 		t.Errorf("user = %q, want %q", creds["user"], "alice")
@@ -330,6 +335,9 @@ func TestJFrogEngine_Run_FullFlow(t *testing.T) {
 	}
 	if gotMintBody.Scope != "applied-permissions/user" {
 		t.Errorf("mint scope = %q, want %q", gotMintBody.Scope, "applied-permissions/user")
+	}
+	if !gotMintBody.IncludeReferenceToken {
+		t.Error("mint include_reference_token = false, want true")
 	}
 	if gotSession == "" {
 		t.Error("server did not observe a session uuid")
@@ -401,6 +409,12 @@ func TestJFrogEngine_Run_MintUsesV1Endpoint(t *testing.T) {
 	}
 	if creds["access_token"] != minted {
 		t.Errorf("access_token = %q, want minted %q", creds["access_token"], minted)
+	}
+	// This server omits reference_token (pre-7.38.4 behaviour). The field must
+	// still be present in the stored secret as an empty string rather than
+	// absent, so downstream `{{ .reference_token }}` templates render cleanly.
+	if rt, ok := creds["reference_token"]; !ok || rt != "" {
+		t.Errorf("reference_token = %q (present=%t), want present and empty", rt, ok)
 	}
 	if v1Hits != 1 {
 		t.Errorf("v1 /tokens hits = %d, want 1", v1Hits)
@@ -505,8 +519,9 @@ func TestJFrogEngine_Refresh_Success(t *testing.T) {
 			_ = r.ParseForm()
 			gotForm = r.PostForm
 			_ = json.NewEncoder(w).Encode(jfrogCommonTokenParams{
-				AccessToken:  rotatedAccess,
-				RefreshToken: "new-refresh",
+				AccessToken:    rotatedAccess,
+				RefreshToken:   "new-refresh",
+				ReferenceToken: "rotated-reference",
 			})
 			return
 		}
@@ -535,6 +550,9 @@ func TestJFrogEngine_Refresh_Success(t *testing.T) {
 	if got["refresh_token"] != "new-refresh" {
 		t.Errorf("refresh_token = %q, want %q", got["refresh_token"], "new-refresh")
 	}
+	if got["reference_token"] != "rotated-reference" {
+		t.Errorf("reference_token = %q, want %q", got["reference_token"], "rotated-reference")
+	}
 	if got["user"] != "alice" {
 		t.Errorf("user = %q, want alice", got["user"])
 	}
@@ -555,6 +573,9 @@ func TestJFrogEngine_Refresh_Success(t *testing.T) {
 	}
 	if gotForm.Get("refresh_token") != "old-refresh" {
 		t.Errorf("form refresh_token = %q, want old-refresh", gotForm.Get("refresh_token"))
+	}
+	if gotForm.Get("include_reference_token") != "true" {
+		t.Errorf("form include_reference_token = %q, want true", gotForm.Get("include_reference_token"))
 	}
 }
 
@@ -583,6 +604,11 @@ func TestJFrogEngine_Refresh_NonJWTKeepsUser(t *testing.T) {
 	}
 	if got["user"] != "alice" {
 		t.Errorf("user = %q, want alice (preserved from existing)", got["user"])
+	}
+	// The rotated response carries no reference_token; the field must be
+	// present-and-empty rather than absent.
+	if rt, ok := got["reference_token"]; !ok || rt != "" {
+		t.Errorf("reference_token = %q (present=%t), want present and empty", rt, ok)
 	}
 }
 


### PR DESCRIPTION
The JFrog enrolment now always asks JFrog to mint an opaque **reference token** alongside the JWT access token, and stores it as an 8th field on the Vault secret. This lets downstream tooling that prefers a compact credential — Docker/registry logins, clients that choke on long JWTs — use the short form while everything else keeps using the full JWT. Both tokens authenticate as the same identity; the reference token is just an alternate handle.

## What changed

- `include_reference_token=true` is sent on both the enrolment mint (`POST /access/api/v1/tokens` JSON body) and the periodic refresh (form body). JFrog rotates the reference token on every refresh just like the access/refresh pair, so it is re-captured on each rotation.
- `reference_token` is written into the Vault secret by both `Run` and `Refresh`. The rendered `jfrog-cli.conf.v6` is unchanged — the reference token is captured but not written to any target by default; a sync rule opts in by referencing `{{ .reference_token }}` in its template.
- `reference_token` is deliberately **not** added to `Engine.Fields()`. JFrog only returns it on Access 7.38.4+, so requiring it would make `enrol.Manager.HasAllFields` reject otherwise-valid enrolments on older servers. This mirrors exactly how `user` is already handled. On older servers the field is stored present-but-empty so `{{ .reference_token }}` templates still render cleanly.

## Docs & tests

CLAUDE.md's JFrog Engine section is updated (schema is now 8 fields, with the version requirement and the opt-in template note); the dated refresh-token design spec gets a forward-reference addendum rather than a rewrite, since "7 fields" was the correct end state of that earlier change. `config.dev.yaml` gains a discoverability comment. Tests assert the new field round-trips on both mint and refresh, that the request parameters are set, and — closing a coverage gap — that the field is stored present-but-empty when the server omits it (pre-7.38.4 path).

https://claude.ai/code/session_01FXxaYyGwjcaAiUkU7S5js2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXxaYyGwjcaAiUkU7S5js2)_