### PR TITLE
feat(login-check): show progress during token renewal

### DIFF
--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -1214,17 +1214,20 @@ const renewProgressTick = 400 * time.Millisecond
 // no interstitial ticking so captured logs stay on one tidy line.
 //
 // On failure the line ends with " failed: <err>" and the error is
-// returned for the caller to add its own follow-up detail. On Ctrl+C
-// (context cancellation) the error is returned without writing an outcome:
-// the SIGINT handler owns the newline and the exit, so we leave the
-// dangling line for it to terminate rather than racing a second write onto
-// it.
+// returned for the caller to add its own follow-up detail. On Ctrl+C the
+// select observes ctx cancellation directly and returns ctx.Err() at once
+// — without writing an outcome and without waiting for renew to unwind —
+// so the dots stop immediately and the SIGINT handler is left to own the
+// terminating newline and the exit rather than racing a second write onto
+// the dangling line.
 //
 // renew is injected (rather than taking the Vault client directly) so the
 // presentation stays decoupled from Vault plumbing and is unit-testable
-// with a fake. It must honour ctx; the wait blocks until it returns. The
-// done channel is buffered so the renew goroutine never leaks even if this
-// function has already returned on cancellation.
+// with a fake. It must honour ctx. The done channel is buffered so the
+// renew goroutine's send never blocks: if this function has already
+// returned on cancellation, the goroutine still runs until renew unwinds
+// (promptly, since renew honours ctx) and then exits cleanly rather than
+// blocking forever on an unread channel.
 func renewTokenWithProgress(ctx context.Context, renew func(context.Context) error, w io.Writer) error {
 	fmt.Fprint(w, "Vault token needs extending")
 
@@ -1243,13 +1246,19 @@ func renewTokenWithProgress(ctx context.Context, renew func(context.Context) err
 			select {
 			case err = <-done:
 				waiting = false
+			case <-ctx.Done():
+				return ctx.Err()
 			case <-ticker.C:
 				fmt.Fprint(w, ".")
 			}
 		}
 	} else {
 		fmt.Fprint(w, "...")
-		err = <-done
+		select {
+		case err = <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	if err != nil {

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -1173,7 +1173,11 @@ func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Se
 		return true, nil
 	}
 
-	if _, err := vc.RenewSelf(ctx, 0); err != nil {
+	renew := func(ctx context.Context) error {
+		_, err := vc.RenewSelf(ctx, 0)
+		return err
+	}
+	if err := renewTokenWithProgress(ctx, renew, os.Stderr); err != nil {
 		// Backstop for context.Canceled (the SIGINT handler cancels
 		// the outer context before os.Exit, but the race usually goes
 		// to os.Exit). If RenewSelf does happen to unwind first, exit
@@ -1182,13 +1186,81 @@ func handleValidToken(ctx context.Context, vc *vault.Client, secret *vaultapi.Se
 		if loginCheckCancelled(ctx, err) {
 			return true, err
 		}
-		fmt.Fprintf(os.Stderr, "vault token renewal failed: %v\n", err)
 		fmt.Fprintf(os.Stderr, "token is still valid but nearing expiry: %s remaining, expires %s\n",
 			ttl.Truncate(time.Second), absoluteExpiry(ttl))
 		return true, err
 	}
-	fmt.Fprintln(os.Stderr, "vault token renewed")
 	return true, nil
+}
+
+// renewProgressTick is the interval between progress dots emitted while a
+// token renewal is in flight. Small enough that a slow renewal feels
+// responsive, large enough that the dots read as a deliberate "working…"
+// animation rather than a stutter.
+const renewProgressTick = 400 * time.Millisecond
+
+// renewTokenWithProgress runs renew while keeping the user informed that
+// something is happening. login-check frequently runs at shell startup,
+// and a token renewal can block for a noticeable beat against a slow or
+// distant Vault — with no output the terminal looks hung (the user
+// reported exactly this). We print a prefix, emit a dot every
+// renewProgressTick while the renewal is in flight, and finish the line
+// with the outcome, all on a single line: a successful renewal reads as
+//
+//	Vault token needs extending... renewed.
+//
+// The dot animation is gated on w being the real stderr TTY; piped output
+// and test buffers get the prefix, a static ellipsis, and the outcome with
+// no interstitial ticking so captured logs stay on one tidy line.
+//
+// On failure the line ends with " failed: <err>" and the error is
+// returned for the caller to add its own follow-up detail. On Ctrl+C
+// (context cancellation) the error is returned without writing an outcome:
+// the SIGINT handler owns the newline and the exit, so we leave the
+// dangling line for it to terminate rather than racing a second write onto
+// it.
+//
+// renew is injected (rather than taking the Vault client directly) so the
+// presentation stays decoupled from Vault plumbing and is unit-testable
+// with a fake. It must honour ctx; the wait blocks until it returns. The
+// done channel is buffered so the renew goroutine never leaks even if this
+// function has already returned on cancellation.
+func renewTokenWithProgress(ctx context.Context, renew func(context.Context) error, w io.Writer) error {
+	fmt.Fprint(w, "Vault token needs extending")
+
+	done := make(chan error, 1)
+	go func() { done <- renew(ctx) }()
+
+	var err error
+	if w == os.Stderr && term.IsTerminal(int(os.Stderr.Fd())) {
+		// Anchor the ellipsis with an immediate dot so even an
+		// instantaneous renewal reads coherently, then tick for as long
+		// as the renewal is in flight.
+		fmt.Fprint(w, ".")
+		ticker := time.NewTicker(renewProgressTick)
+		defer ticker.Stop()
+		for waiting := true; waiting; {
+			select {
+			case err = <-done:
+				waiting = false
+			case <-ticker.C:
+				fmt.Fprint(w, ".")
+			}
+		}
+	} else {
+		fmt.Fprint(w, "...")
+		err = <-done
+	}
+
+	if err != nil {
+		if loginCheckCancelled(ctx, err) {
+			return err
+		}
+		fmt.Fprintf(w, " failed: %v\n", err)
+		return err
+	}
+	fmt.Fprintln(w, " renewed.")
+	return nil
 }
 
 // loginCheckCancelled reports whether err is a context-cancellation.

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,6 +97,63 @@ func TestStderrSupportsColour(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	if stderrSupportsColour() {
 		t.Error("stderrSupportsColour() with NO_COLOR set = true, want false")
+	}
+}
+
+// TestRenewTokenWithProgress exercises the single-line progress output of
+// the login-check renewal helper. Writing to a *bytes.Buffer (not
+// os.Stderr) forces the non-animated branch, so the output is
+// deterministic: prefix + static "..." ellipsis + outcome. The renew
+// function is injected, so no Vault is needed.
+func TestRenewTokenWithProgress(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     func() (context.Context, context.CancelFunc)
+		renew   func(context.Context) error
+		wantErr bool
+		wantOut string
+	}{
+		{
+			name:    "success",
+			ctx:     func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) },
+			renew:   func(context.Context) error { return nil },
+			wantErr: false,
+			wantOut: "Vault token needs extending... renewed.\n",
+		},
+		{
+			name:    "failure surfaces the error inline",
+			ctx:     func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) },
+			renew:   func(context.Context) error { return errors.New("permission denied") },
+			wantErr: true,
+			wantOut: "Vault token needs extending... failed: permission denied\n",
+		},
+		{
+			name: "cancellation writes no outcome",
+			ctx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel() // already cancelled — mimics the SIGINT handler
+				return ctx, cancel
+			},
+			renew:   func(context.Context) error { return context.Canceled },
+			wantErr: true,
+			// Only the prefix + ellipsis; the SIGINT handler owns the
+			// terminating newline, so no " renewed."/" failed:" suffix.
+			wantOut: "Vault token needs extending...",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.ctx()
+			defer cancel()
+			var buf bytes.Buffer
+			err := renewTokenWithProgress(ctx, tc.renew, &buf)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("renewTokenWithProgress() err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got := buf.String(); got != tc.wantOut {
+				t.Errorf("renewTokenWithProgress() output = %q, want %q", got, tc.wantOut)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When `dotvault login-check` finds a cached token past its halfway TTL it renews in place, but `RenewSelf` can block for a noticeable beat against a slow or distant Vault. With no output the terminal looks hung at shell startup — the prompt eventually unblocks and prints `vault token renewed` with no prior indication anything was happening. This was reported from a real outdated session that paused, then printed `vault token renewed`, then the PS1.

This prints a single-line progress indicator instead: `Vault token needs extending` followed by a dot every 400ms while the renewal is in flight, finishing the same line with ` renewed.` on success or ` failed: <err>` on failure. So a successful renewal reads as `Vault token needs extending... renewed.` — a pause after each dot, no newline until renewal completes or fails. The dot animation is gated on stderr being a real TTY (the same gate `printLoginNotice` uses for colour); piped output and test buffers get a static `...` ellipsis so captured logs stay on one tidy line. On Ctrl+C no outcome is written — the existing SIGINT handler owns the terminating newline and the exit.

The renewal is injected as a `func(context.Context) error` rather than the Vault client, decoupling the presentation from Vault plumbing and making `renewTokenWithProgress` unit-testable with a fake. A table-driven test covers success, inline failure, and the no-outcome cancellation path. The renew goroutine writes to a size-1 buffered channel so it never leaks even when the function has already returned on cancellation.

https://claude.ai/code/session_01XGUsD4Jzk4SxVugj9unTju

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGUsD4Jzk4SxVugj9unTju)_