### PR TITLE
fix(docs): resolve strict-mode build failures

### DIFF
--- a/docs/guide/ssh-agent.md
+++ b/docs/guide/ssh-agent.md
@@ -7,7 +7,7 @@ can answer signing requests without ever writing a private key to disk.
 Two key sources are supported:
 
 - **KV keys** — raw key pairs discovered under a KV path prefix (the same
-  `public_key` / `private_key` schema the [SSH enrolment engine](enrolment.md)
+  `public_key` / `private_key` schema the [SSH enrolment engine](../services/ssh.md)
   writes).
 - **Vault-CA certificates** — short-lived certificates minted on demand by a
   Vault SSH CA secrets engine. The private key is generated in memory and never

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,11 @@ site_url: https://goodtune.github.io/dotvault/
 repo_url: https://github.com/goodtune/dotvault
 repo_name: goodtune/dotvault
 
+# Internal planning/spec artifacts live under docs/superpowers/ for repo-local
+# reference but are not part of the published site.
+exclude_docs: |
+  superpowers/
+
 theme:
   name: material
   palette:


### PR DESCRIPTION
The docs publish job was aborting because `mkdocs build --strict` failed. Two distinct problems were in play.

The fatal one was a broken cross-reference: `guide/ssh-agent.md` linked to `enrolment.md`, which resolves relative to `guide/` as `guide/enrolment.md` — a file that does not exist. The SSH enrolment engine is actually documented under Service Onboarding at `services/ssh.md`, so the link now points at `../services/ssh.md`. That clears the lone strict-mode WARNING that was triggering the abort.

The second problem was noise rather than a hard failure: the internal planning and spec artifacts under `docs/superpowers/{plans,specs}/` were being picked up by the build and reported as orphaned pages not present in the `nav`. These are repo-local development records, not part of the published site, so the change adds an `exclude_docs: superpowers/` stanza to `mkdocs.yml` to keep them out of the build entirely. They remain in the repo for reference.

With both addressed, `mkdocs build --strict` completes with no warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiCpEBDWdzf1nTBJwByoMs)_