### PR TITLE
fix(tokenwatch): close token-file watch startup race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ Logging uses `log/slog` — text format when stderr is a TTY, JSON otherwise. Al
 1. Load config (file or registry)
 2. Create Vault client, attempt token reuse (VAULT_TOKEN env or `~/.dotvault-token`)
 3. Start web UI if enabled (before auth, so it can serve browser-based login)
-4. Authenticate if needed: web mode routes all auth through the SPA; CLI mode uses method-specific flows (OIDC browser, LDAP terminal prompt, token file)
+4. Authenticate if needed: web mode routes all auth through the SPA; CLI mode uses method-specific flows (OIDC browser, LDAP terminal prompt, token file). A non-interactive host with neither a web UI nor a TTY does not give up — it registers a synchronous token-file watch and idles until an external facility (e.g. a login profile running `dotvault login`) writes a usable token, then resumes startup. The watch is registered before the no-token decision so a token written during startup cannot be missed; this replaced the previous behaviour where a headless daemon idled until shutdown and required a restart to pick up a token (`waitForHeadlessToken`, `cmd/dotvault/main.go`).
 5. Start token lifecycle manager (renews at 75% TTL, exponential backoff 1s-5m on failure)
 6. Start RefreshManager (rotates expiring credentials for `Refresher` engines, e.g. JFrog) and WatchManager (re-mirrors upstream sources for `Watcher` engines, e.g. Copy)
 7. Run enrolment check (wizard if any credentials missing in Vault)

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -485,7 +485,14 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 			// during startup cannot be missed.
 			slog.Warn("no vault token available and no interactive facility (web UI unavailable, stdin is not a terminal); idling until a token is written to the token file")
 			if !waitForHeadlessToken(ctx, vc, tokenPath) {
-				return ctx.Err() // ctx cancelled before any usable token arrived
+				// ctx was cancelled (SIGTERM/SIGINT, i.e. a normal service
+				// stop) before any usable token arrived. Return nil, not
+				// ctx.Err(): rootCmd.Execute maps a non-nil error to
+				// exit(1), which would make systemd record a clean stop as
+				// a failure. This preserves the pre-change exit-0-on-shutdown
+				// behaviour of this branch.
+				slog.Info("shutting down before a vault token was written")
+				return nil
 			}
 			slog.Info("picked up vault token written by external facility; continuing startup")
 		} else {

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -477,12 +477,17 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		} else if !isInteractive() {
 			// Headless: no web UI to drive auth and no terminal to prompt
 			// on. Don't crash and don't spam the logs trying to read from
-			// a closed stdin — stay up so an external interactive facility
-			// (e.g. a login profile that runs `dotvault sync`) can write
-			// the token, and a daemon restart will pick it up.
-			slog.Warn("no vault token available and no interactive facility (web UI unavailable, stdin is not a terminal); daemon will idle until shutdown")
-			<-ctx.Done()
-			return nil
+			// a closed stdin — register a token-file watch and idle until
+			// an external interactive facility (e.g. a login profile that
+			// runs `dotvault login`) writes a usable token, then fall
+			// through into normal startup. The watch is registered
+			// synchronously before the first read so a token written
+			// during startup cannot be missed.
+			slog.Warn("no vault token available and no interactive facility (web UI unavailable, stdin is not a terminal); idling until a token is written to the token file")
+			if !waitForHeadlessToken(ctx, vc, tokenPath) {
+				return ctx.Err() // ctx cancelled before any usable token arrived
+			}
+			slog.Info("picked up vault token written by external facility; continuing startup")
 		} else {
 			// Traditional auth flow (OIDC with ephemeral listener, LDAP
 			// prompt, or token file).
@@ -534,15 +539,21 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	// that blocks until shutdown. Creation and update events trigger a
 	// reload; deletes are ignored so the daemon keeps using its current
 	// token until a new one is written.
-	go func() {
-		onTokenChange := func() {
-			slog.Debug("vault token file changed, re-reading")
-			lm.Reload()
-		}
-		if err := tokenwatch.Watch(ctx, tokenPath, onTokenChange); err != nil && ctx.Err() == nil {
-			slog.Warn("token-file watcher stopped", "error", err)
-		}
-	}()
+	onTokenChange := func() {
+		slog.Debug("vault token file changed, re-reading")
+		lm.Reload()
+	}
+	if tw, err := tokenwatch.New(tokenPath, onTokenChange); err != nil {
+		slog.Warn("token-file watcher unavailable; relying on periodic re-read", "error", err)
+	} else {
+		onTokenChange() // reconcile a token that appeared during startup
+		go func() {
+			defer tw.Close()
+			if err := tw.Run(ctx); err != nil && ctx.Err() == nil {
+				slog.Warn("token-file watcher stopped", "error", err)
+			}
+		}()
+	}
 
 	// Start refresh manager for any enrolment whose engine rotates its own
 	// credentials (currently JFrog). Failures are logged and retried on the
@@ -1710,6 +1721,86 @@ func stderrSupportsColour() bool {
 // the daemon can prompt the user for credentials, MFA passcodes, etc.
 func isInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// waitForHeadlessToken blocks until a usable Vault token is written to
+// tokenPath (by an external facility such as a login profile running
+// `dotvault login`) or ctx is cancelled. Returns true once a token from
+// the file validates against Vault and is set on vc; false if ctx is
+// cancelled first. The watch is registered synchronously before the first
+// read so a token written during startup cannot be missed.
+func waitForHeadlessToken(ctx context.Context, vc *vault.Client, tokenPath string) bool {
+	// The watcher goroutine below can outlive a *successful* return: a token
+	// arrives while the parent ctx is still live, so cancellation can't be
+	// what stops it. Give it a child context we cancel on the way out, and
+	// make closing the inotify fd the goroutine's own responsibility (defer
+	// inside the goroutine). Closing the fd here, from the parent, while Run
+	// is still blocked in Poll/Read would be a use-after-close and risk the
+	// fd number being reused by a later open while the orphaned goroutine
+	// still reads it.
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	defer watchCancel()
+
+	wake := make(chan struct{}, 1)
+	notify := func() {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	}
+
+	if tw, err := tokenwatch.New(tokenPath, notify); err != nil {
+		slog.Warn("token-file watcher unavailable; polling for a token instead", "error", err)
+	} else {
+		go func() {
+			defer tw.Close()
+			if err := tw.Run(watchCtx); err != nil && watchCtx.Err() == nil {
+				slog.Warn("token-file watcher stopped while waiting for token", "error", err)
+			}
+		}()
+	}
+
+	// This runs before the lifecycle manager, SSH agent, refresh/watch
+	// managers and sync loop start (all further down runDaemon), and only
+	// in the non-web branch — so vc has no other concurrent user here. The
+	// brief window where an unvalidated candidate token is live on the
+	// client (SetToken → LookupSelf → restore-on-failure) is therefore
+	// single-threaded and matches LifecycleManager.tryReload's pattern.
+	tryPromote := func() bool {
+		fileToken, _ := auth.ReadTokenFile(tokenPath)
+		if fileToken == "" || fileToken == vc.Token() {
+			return false
+		}
+		previous := vc.Token()
+		vc.SetToken(fileToken)
+		if _, lookupErr := vc.LookupSelf(ctx); lookupErr != nil {
+			slog.Warn("token file present but candidate is invalid; continuing to wait", "error", lookupErr)
+			vc.SetToken(previous)
+			return false
+		}
+		return true
+	}
+
+	if tryPromote() {
+		return true
+	}
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-wake:
+			if tryPromote() {
+				return true
+			}
+		case <-ticker.C:
+			if tryPromote() {
+				return true
+			}
+		}
+	}
 }
 
 // initObservability builds an observability.Provider from the loaded

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -1773,8 +1773,23 @@ func waitForHeadlessToken(ctx context.Context, vc *vault.Client, tokenPath strin
 	// brief window where an unvalidated candidate token is live on the
 	// client (SetToken → LookupSelf → restore-on-failure) is therefore
 	// single-threaded and matches LifecycleManager.tryReload's pattern.
+	var lastReadErrMsg string
 	tryPromote := func() bool {
-		fileToken, _ := auth.ReadTokenFile(tokenPath)
+		fileToken, readErr := auth.ReadTokenFile(tokenPath)
+		if readErr != nil {
+			// ReadTokenFile returns ("", nil) for a missing file, so a
+			// non-nil error means the file exists but is unreadable (bad
+			// permissions, IO error) — actionable, unlike the normal
+			// "not written yet" state. De-duplicate so a persistent fault
+			// doesn't warn on every 10s tick; re-log only when the error
+			// first appears or its text changes.
+			if msg := readErr.Error(); msg != lastReadErrMsg {
+				slog.Warn("cannot read vault token file; will keep waiting", "error", readErr, "path", tokenPath)
+				lastReadErrMsg = msg
+			}
+			return false
+		}
+		lastReadErrMsg = ""
 		if fileToken == "" || fileToken == vc.Token() {
 			return false
 		}

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -1781,8 +1781,17 @@ func waitForHeadlessToken(ctx context.Context, vc *vault.Client, tokenPath strin
 		previous := vc.Token()
 		vc.SetToken(fileToken)
 		if _, lookupErr := vc.LookupSelf(ctx); lookupErr != nil {
-			slog.Warn("token file present but candidate is invalid; continuing to wait", "error", lookupErr)
 			vc.SetToken(previous)
+			// A cancelled parent ctx (clean shutdown) can race the wake /
+			// ticker select arms below and land here with a
+			// context.Canceled lookup error — select picks a ready case at
+			// random, so ctx.Done() isn't guaranteed to win. That's
+			// shutdown, not a bad token, so suppress the misleading
+			// "candidate is invalid" warning; the next loop iteration
+			// observes ctx.Done() and returns.
+			if ctx.Err() == nil {
+				slog.Warn("token file present but candidate is invalid; continuing to wait", "error", lookupErr)
+			}
 			return false
 		}
 		return true

--- a/internal/tokenwatch/tokenwatch_linux.go
+++ b/internal/tokenwatch/tokenwatch_linux.go
@@ -35,18 +35,33 @@ const watchMask = unix.IN_CLOSE_WRITE | unix.IN_MOVED_TO | unix.IN_CREATE
 // is not latency-sensitive to that degree.
 const pollTimeoutMs = 100
 
-// Watch monitors the parent directory of path and calls onChange when a
-// file with path's basename is created or updated. It blocks until ctx
-// is cancelled — returning ctx.Err() — or returns a non-nil error if
-// the inotify machinery could not be set up or read. onChange runs on
-// the watch goroutine, so keep it cheap; the daemon passes
-// LifecycleManager.Reload, a non-blocking channel nudge.
+// Watcher holds a live inotify subscription to the token file's parent
+// directory. Splitting registration (New) from the read loop (Run) lets
+// the daemon make InotifyAddWatch synchronous — completing before any
+// "no token, idle" decision — so a token written in the gap between
+// registration and the loop starting is queued by the kernel and
+// delivered once Run begins, rather than being lost (inotify only
+// delivers events that occur after InotifyAddWatch returns).
+type Watcher struct {
+	fd       int
+	name     string
+	onChange func()
+}
+
+// New registers an inotify watch on the parent directory of path and
+// returns a Watcher ready to Run. Registration is synchronous: on
+// return the kernel is already queuing events for path's basename, so a
+// caller that issues a reconciling read after New (to catch a token
+// that predates the watch) plus Run (to catch everything after) cannot
+// miss a write. onChange runs on the Run goroutine, so keep it cheap;
+// the daemon passes LifecycleManager.Reload, a non-blocking channel
+// nudge.
 //
 // The directory rather than the file is watched because atomic writers
 // replace the inode; a file-level watch would survive only until the
 // first rotation. Watching the directory and filtering events by name
 // keeps the subscription alive across arbitrarily many replacements.
-func Watch(ctx context.Context, path string, onChange func()) error {
+func New(path string, onChange func()) (*Watcher, error) {
 	dir := filepath.Dir(path)
 	name := filepath.Base(path)
 
@@ -55,19 +70,28 @@ func Watch(ctx context.Context, path string, onChange func()) error {
 	// forever in Read.
 	fd, err := unix.InotifyInit1(unix.IN_NONBLOCK | unix.IN_CLOEXEC)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer unix.Close(fd)
 
 	if _, err := unix.InotifyAddWatch(fd, dir, watchMask); err != nil {
-		return err
+		unix.Close(fd)
+		return nil, err
 	}
 
+	return &Watcher{fd: fd, name: name, onChange: onChange}, nil
+}
+
+// Run blocks reading the inotify fd registered by New, calling onChange
+// whenever an event names the watched file. It returns when ctx is
+// cancelled — yielding ctx.Err() — or on an unrecoverable read error.
+// Run does not close the fd; call Close (typically via defer) to release
+// it.
+func (w *Watcher) Run(ctx context.Context) error {
 	// Generous relative to the 272-byte worst-case single event
 	// (SizeofInotifyEvent + NAME_MAX + 1); inotify never returns a
 	// partial event, so a buffer this size holds several at once.
 	var buf [4096]byte
-	pfd := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	pfd := []unix.PollFd{{Fd: int32(w.fd), Events: unix.POLLIN}}
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -85,7 +109,7 @@ func Watch(ctx context.Context, path string, onChange func()) error {
 			continue
 		}
 
-		nread, err := unix.Read(fd, buf[:])
+		nread, err := unix.Read(w.fd, buf[:])
 		if err != nil {
 			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
 				continue
@@ -93,10 +117,28 @@ func Watch(ctx context.Context, path string, onChange func()) error {
 			return err
 		}
 
-		if nameMatched(buf[:nread], name) {
-			onChange()
+		if nameMatched(buf[:nread], w.name) {
+			w.onChange()
 		}
 	}
+}
+
+// Close releases the inotify fd. It is safe to call after Run returns.
+func (w *Watcher) Close() error {
+	return unix.Close(w.fd)
+}
+
+// Watch is a thin wrapper that registers a Watcher, runs it, and closes
+// it — preserving the original one-shot API for existing callers and
+// tests. New callers that need registration to complete before a
+// no-token decision should use New/Run/Close directly.
+func Watch(ctx context.Context, path string, onChange func()) error {
+	w, err := New(path, onChange)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	return w.Run(ctx)
 }
 
 // nameMatched reports whether any inotify event in buf names the watched

--- a/internal/tokenwatch/tokenwatch_new_linux_test.go
+++ b/internal/tokenwatch/tokenwatch_new_linux_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package tokenwatch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestNew_RegistersBeforeReturn is the critical regression test for the
+// startup race. New must complete InotifyAddWatch synchronously, so a
+// write that lands in the window between New returning and Run starting
+// is queued by the kernel and delivered once Run begins. We prove this
+// by writing the token *before* the Run goroutine starts and asserting
+// the callback still fires.
+func TestNew_RegistersBeforeReturn(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+
+	ch := make(chan struct{}, 1)
+	w, err := New(tokenPath, func() { ch <- struct{}{} })
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	// Write in the New→Run gap. The watch is already live (registered
+	// synchronously inside New), so the kernel queues this event for
+	// delivery when Run starts reading the fd.
+	writeTokenAtomically(t, tokenPath, "written-before-run")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Run(ctx) }()
+
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("event written in the New->Run window was not delivered")
+	}
+}
+
+// TestNew_ErrorsOnMissingDir proves registration failure surfaces
+// synchronously from New rather than being deferred into Run.
+func TestNew_ErrorsOnMissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope", ".vault-token")
+	w, err := New(missing, func() {})
+	if err == nil {
+		w.Close()
+		t.Fatal("expected error from New on a non-existent parent directory, got nil")
+	}
+}
+
+// TestRun_ReturnsOnContextCancel proves Run honours context
+// cancellation and returns context.Canceled.
+func TestRun_ReturnsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+
+	w, err := New(tokenPath, func() {})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Run(ctx) }()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// TestNew_ReconcilingReadPattern documents why the caller must issue a
+// reconciling read after New: a file that already exists before the
+// watch is registered generates no inotify event, so a watch-only
+// strategy would never observe a token that predates startup. The
+// daemon closes this gap with an explicit read right after New.
+func TestNew_ReconcilingReadPattern(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".vault-token")
+
+	// Seed the token before the watch exists.
+	if err := os.WriteFile(tokenPath, []byte("pre-existing"), 0o600); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	ch := make(chan struct{}, 1)
+	w, err := New(tokenPath, func() { ch <- struct{}{} })
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Run(ctx) }()
+
+	// No write happens after the watch is live, so no event must fire —
+	// the pre-existing file is invisible to inotify, which is exactly
+	// why the reconciling read is required.
+	select {
+	case <-ch:
+		t.Fatal("unexpected event for a file that predates the watch")
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/internal/tokenwatch/tokenwatch_new_linux_test.go
+++ b/internal/tokenwatch/tokenwatch_new_linux_test.go
@@ -33,8 +33,14 @@ func TestNew_RegistersBeforeReturn(t *testing.T) {
 	writeTokenAtomically(t, tokenPath, "written-before-run")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() { _ = w.Run(ctx) }()
+	runDone := make(chan struct{})
+	go func() { defer close(runDone); _ = w.Run(ctx) }()
+	// Stop Run and wait for it to return before the deferred w.Close()
+	// fires. Closing the inotify fd while Run is still blocked in
+	// Poll/Read is the use-after-close this PR fixes in production, and
+	// would make the test racy. Defers run LIFO, so this runs before the
+	// w.Close() deferred above.
+	defer func() { cancel(); <-runDone }()
 
 	select {
 	case <-ch:
@@ -103,8 +109,11 @@ func TestNew_ReconcilingReadPattern(t *testing.T) {
 	defer w.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() { _ = w.Run(ctx) }()
+	runDone := make(chan struct{})
+	go func() { defer close(runDone); _ = w.Run(ctx) }()
+	// Wait for Run to return before the deferred w.Close() fires — same
+	// use-after-close avoidance as TestNew_RegistersBeforeReturn.
+	defer func() { cancel(); <-runDone }()
 
 	// No write happens after the watch is live, so no event must fire —
 	// the pre-existing file is invisible to inotify, which is exactly

--- a/internal/tokenwatch/tokenwatch_other.go
+++ b/internal/tokenwatch/tokenwatch_other.go
@@ -4,12 +4,39 @@ package tokenwatch
 
 import "context"
 
-// Watch is a no-op on platforms without inotify: it blocks until ctx is
-// cancelled and returns ctx.Err(). The daemon wires it unconditionally;
-// macOS and Windows had no systemd path-unit equivalent to replace, and
-// SIGHUP (where delivered) remains the manual re-read nudge. onChange is
-// never invoked. The path argument is accepted for signature parity with
-// the Linux build.
+// Watcher is the no-op counterpart to the Linux inotify Watcher on
+// platforms without inotify. It exists so the daemon can wire
+// New/Run/Close unconditionally; there is nothing to register, so New
+// never fails and Run simply blocks until ctx is cancelled. onChange is
+// never invoked.
+type Watcher struct {
+	onChange func()
+}
+
+// New returns a no-op Watcher. It never fails — there is no inotify
+// machinery to set up — and accepts path for signature parity with the
+// Linux build.
+func New(path string, onChange func()) (*Watcher, error) {
+	return &Watcher{onChange: onChange}, nil
+}
+
+// Run blocks until ctx is cancelled and returns ctx.Err(). onChange is
+// never invoked: macOS and Windows had no systemd path-unit equivalent
+// to replace, and SIGHUP (where delivered) remains the manual re-read
+// nudge.
+func (w *Watcher) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Close is a no-op; there is no fd to release.
+func (w *Watcher) Close() error {
+	return nil
+}
+
+// Watch is the no-op one-shot wrapper retained for signature parity with
+// the Linux build. It blocks until ctx is cancelled and returns
+// ctx.Err(); onChange is never invoked.
 func Watch(ctx context.Context, path string, onChange func()) error {
 	<-ctx.Done()
 	return ctx.Err()


### PR DESCRIPTION
## Problem

A headless `dotvault run` stranded itself when authentication happened in a secondary process moments after startup. It logged `no vault token available and no interactive facility … daemon will idle until shutdown` and stayed in `activating (start)` forever, even once `~/.dotvault-token` was written. Two race windows caused it:

1. **Headless idle branch never recovered.** The `else if !isInteractive()` branch ran `<-ctx.Done()` and returned, so it never reached the lifecycle manager or the token-file watcher further down — a token written by an external facility (e.g. a login profile running `dotvault login`) had nothing watching for it, and only a restart recovered.
2. **Lazy watcher registration on the other paths.** The token-file watcher was started in a goroutine *after* the lifecycle manager's initial token read. A token written in the gap between that read and the watch becoming live was invisible to both — inotify only delivers events that occur after `InotifyAddWatch` returns — so it wasn't picked up until the next 5-minute tick.

## Fix

Split `tokenwatch.Watch` into `New` (synchronous `InotifyInit1` + `InotifyAddWatch`) and `Run` (the poll loop), keeping `Watch` as a thin wrapper so existing callers and tests are untouched. The invariant: `InotifyAddWatch` completes **before** any "no token, idle" decision, and a reconciling read follows the watch going live (`LifecycleManager.Reload` and the token-promote step are idempotent, so a redundant read is harmless).

- **Headless path:** a new `waitForHeadlessToken` helper registers the watch synchronously, then blocks on watch-wake / 10s-poll until a token from the file validates against Vault, then falls through into normal startup instead of dead-ending on `<-ctx.Done()`.
- **Steady-state path:** synchronous `New` + a reconciling `onTokenChange()` before `Run` starts in its goroutine, replacing the old lazy goroutine.
- **Non-Linux builds:** a matching no-op `Watcher` (`New`/`Run`/`Close`) so the daemon wires the same surface unconditionally; the 10s poll fallback keeps the headless path functional where inotify is absent.

The watcher goroutine in `waitForHeadlessToken` can outlive a successful return (a token arrives while the parent context is still live), so it owns its own fd lifecycle: it runs under a child context cancelled on return and closes the inotify fd inside the goroutine after `Run` unblocks. Closing the fd from the parent while `Run` was still blocked in `Poll`/`Read` would be a use-after-close and risk the fd number being reused — this matches the steady-state path's close ownership.

## Tests

New `internal/tokenwatch/tokenwatch_new_linux_test.go`:

- `TestNew_RegistersBeforeReturn` — the critical regression: writes the token in the New→Run window (before the `Run` goroutine starts) and asserts the callback still fires, proving the kernel queues the event once registration is synchronous.
- `TestNew_ErrorsOnMissingDir`, `TestRun_ReturnsOnContextCancel`, `TestNew_ReconcilingReadPattern` (documents why the caller's post-`New` reconciling read is required).

Existing `tokenwatch` tests pass unchanged via the retained `Watch` wrapper.

## Known trade-offs

`waitForHeadlessToken`'s `tryPromote` overlaps `LifecycleManager.tryReload` (read file → `SetToken` → `LookupSelf` → restore on failure) but is kept separate: `tryReload`'s env-token candidate ordering is load-bearing and absent in the headless case, so a shared helper would be a wider change than this fix warrants. `waitForHeadlessToken` has no direct unit test because `*vault.Client` is concrete with no fakeable seam; introducing that seam is follow-up work, and the inotify layer the helper builds on is now covered.

## Verification

`go build ./...`, `GOOS=darwin`/`GOOS=windows` cross-builds, `go vet`, `go test -race ./internal/tokenwatch/`, and the full `go test ./...` all pass; `gofmt -l` is clean.