### PR TITLE
docs: add internal/regfile to architecture tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ cmd/dotvault/main.go     CLI entry point (Cobra)
 client/                  Public, importable Go API (facade over internal/{config,auth,vault}) — see "Public client API"
 internal/
   config/                Config loading: YAML file + Windows Registry (GPO)
+  regfile/               .reg ⇄ YAML conversion (reg-import/reg-export, web config download)
   paths/                 OS-specific path resolution
   vault/                 Vault client wrapper, KVv2 operations, Events API (WebSocket)
   auth/                  Auth orchestration (OIDC, LDAP with MFA, token)


### PR DESCRIPTION
A CLAUDE.md audit found the `internal/regfile/` package — the `.reg` ⇄ YAML conversion engine behind `reg-import`/`reg-export` and the web `GET /api/v1/config/download` endpoint — referenced four times in prose but missing from the canonical architecture directory map. This adds it between `config/` and `paths/`, where it logically belongs as the config-format conversion layer, so a reader scanning the tree sees the package exists. Every other spot-checked claim in CLAUDE.md (build commands, all 17 `internal/` packages, the five enrolment engines, six format handlers, CLI subcommands, web routes, template functions) verified accurate against the current codebase, so this is the sole change.