### PR TITLE
feat(login-check): add --no-passwd local-account early exit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ internal/
   vault/                 Vault client wrapper, KVv2 operations, Events API (WebSocket)
   auth/                  Auth orchestration (OIDC, LDAP with MFA, token)
   loginsuppress/         login-check suppression marker (path/window/freshness/refresh)
+  passwd/                /etc/passwd parsing for login-check --no-passwd (local vs directory account)
   observability/         OTel metrics + logs SDK wiring, package-level instrument helpers
   sdnotify/              Tiny sd_notify(3) helper (READY/STOPPING/WATCHDOG); no-op off Linux
   tokenwatch/            Watches ~/.dotvault-token for replacement (inotify on Linux); no-op elsewhere
@@ -182,6 +183,23 @@ startup.
   tests). The path matches the previous shell-managed location, so
   existing suppression state survives the rollout without migration.
   Logic lives in `internal/loginsuppress/`.
+- `--no-passwd` exits 0 immediately when the current user has an entry
+  in `/etc/passwd` — in directory-service fleets a passwd entry means a
+  local machine account with no Vault credentials, so a fleet-wide
+  profile.d script can pass the flag unconditionally. The file is
+  parsed directly (`internal/passwd/`), never via getent/NSS, because
+  merged-source lookups cannot say which source an entry came from.
+  NIS/compat `+`/`-` splice lines are skipped (they reference directory
+  sources, not local accounts). Ignored with a WARN log on Windows. A
+  passwd read failure warns and falls through to the normal check (fail
+  open; exit 1 stays reserved for genuine internal errors). The check
+  runs after the suppression-marker freshness check and refreshes the
+  marker on early exit, so subsequent shells in the window stop at the
+  marker without re-reading the file. The heuristic is Linux-targeted:
+  macOS keeps local accounts in Open Directory, so the lookup never
+  matches a human there and the flag degrades to a no-op (falls through
+  to the normal check — it cannot wrongly skip auth). Test override:
+  `DOTVAULT_PASSWD_FILE`.
 - If a cached token is valid and still within the first half of its
   creation TTL, exit clean.
 - If the cached token is valid but past the halfway mark, attempt renewal.

--- a/cmd/dotvault/main.go
+++ b/cmd/dotvault/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/goodtune/dotvault/internal/enrol"
 	"github.com/goodtune/dotvault/internal/loginsuppress"
 	"github.com/goodtune/dotvault/internal/observability"
+	"github.com/goodtune/dotvault/internal/passwd"
 	"github.com/goodtune/dotvault/internal/paths"
 	"github.com/goodtune/dotvault/internal/regfile"
 	"github.com/goodtune/dotvault/internal/sdnotify"
@@ -989,6 +990,14 @@ Behaviour:
     the marker's mtime is within DOTVAULT_SUPPRESS_HOURS (default 6),
     the command exits silently. A future mtime is treated as stale so
     clock skew or backup restores cannot lock suppression on.
+  - With --no-passwd, exit 0 immediately when the current user has an
+    entry in /etc/passwd. In fleets where human accounts come from a
+    directory service, a passwd entry means a local machine account
+    with no Vault credentials to check — a fleet-wide profile.d script
+    can pass this flag unconditionally and stay silent for local
+    accounts. The file is parsed directly (getent would merge all NSS
+    sources and hide the distinction). Ignored with a warning on
+    Windows; a read failure warns and continues with the normal check.
   - Otherwise: if the cached token is valid and still within the first
     half of its creation TTL, exit clean. Past halfway, attempt
     renewal; if renewal fails but the token is still valid, warn with
@@ -1008,6 +1017,7 @@ genuine internal errors.`,
 		RunE: runLoginCheck,
 	}
 	cmd.Flags().Bool("quiet", false, "suppress the explanation printed before triggering an interactive login")
+	cmd.Flags().Bool("no-passwd", false, "exit immediately when the current user has a local /etc/passwd entry (ignored on Windows)")
 	return cmd
 }
 
@@ -1019,6 +1029,7 @@ genuine internal errors.`,
 // contract.
 func runLoginCheck(cmd *cobra.Command, args []string) error {
 	quiet, _ := cmd.Flags().GetBool("quiet")
+	noPasswd, _ := cmd.Flags().GetBool("no-passwd")
 
 	// Catch SIGINT before any other work so a Ctrl+C arriving during
 	// setup (env parse, marker stat, term.GetState) cannot fall through
@@ -1069,6 +1080,27 @@ func runLoginCheck(cmd *cobra.Command, args []string) error {
 			slog.Warn("failed to refresh login-check suppression marker", "error", rerr, "path", markerPath)
 		}
 	}()
+
+	// --no-passwd: a user with a local passwd entry is a machine
+	// account in a directory-service fleet — nothing to check, no
+	// prompt to raise. Runs after the marker-refresh defer is armed so
+	// the early exit also silences the next window of shells (they stop
+	// at the freshness check without re-parsing the file). Read or
+	// lookup failures fail open into the normal flow: the exit-0
+	// contract reserves non-zero for genuine internal errors, and a
+	// directory user must not be locked out by a broken local file.
+	if noPasswd {
+		if runtime.GOOS == "windows" {
+			slog.Warn("--no-passwd is not supported on Windows; ignoring")
+		} else if username, uerr := paths.Username(); uerr != nil {
+			slog.Warn("--no-passwd: cannot resolve current user; continuing with login check", "error", uerr)
+		} else if found, perr := passwd.ContainsUser(passwd.Path(), username); perr != nil {
+			slog.Warn("--no-passwd: cannot read passwd file; continuing with login check", "error", perr)
+		} else if found {
+			slog.Debug("user has a local passwd entry; skipping login check", "user", username)
+			return nil
+		}
+	}
 
 	// Capture the terminal state now so the SIGINT handler can restore
 	// it even if mgr.Login is mid-prompt (term.ReadPassword puts the

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -398,6 +398,13 @@ func TestLoginCheckNoPasswd_Subprocess(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected config-load failure when user absent from passwd file, got exit 0\noutput:\n%s", out)
 		}
+		// A bare non-zero exit could come from anywhere (including a
+		// future bug in the --no-passwd check itself); requiring the
+		// config-load error message proves the flow fell through past
+		// the passwd lookup into the normal startup path.
+		if !strings.Contains(string(out), "load config") {
+			t.Errorf("expected failure at config load, got different error:\n%s", out)
+		}
 	})
 }
 

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -291,6 +292,111 @@ func TestLoginCheckQuietFlagRegistered(t *testing.T) {
 	if flag.DefValue != "false" {
 		t.Errorf("--quiet flag default = %q, want false", flag.DefValue)
 	}
+}
+
+// TestLoginCheckNoPasswdFlagRegistered locks in the --no-passwd flag
+// wiring on the login-check command, for the same reason as the --quiet
+// assertion above: fleet profile.d scripts pass it unconditionally, so
+// renaming or dropping it would break every deployed wrapper at shell
+// startup.
+func TestLoginCheckNoPasswdFlagRegistered(t *testing.T) {
+	cmd := newLoginCheckCmd()
+	flag := cmd.Flags().Lookup("no-passwd")
+	if flag == nil {
+		t.Fatal("--no-passwd flag not registered on login-check command")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Errorf("--no-passwd flag type = %q, want bool", flag.Value.Type())
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--no-passwd flag default = %q, want false", flag.DefValue)
+	}
+}
+
+// TestLoginCheckNoPasswd_Subprocess exercises the --no-passwd early
+// exit end-to-end. Both cases run with a deliberately missing --config:
+// when the current user appears in the (overridden) passwd file the
+// command must exit 0 silently *before* config load is ever reached;
+// when the user is absent it must fall through to the normal flow and
+// fail at config load like any other invocation.
+func TestLoginCheckNoPasswd_Subprocess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess test")
+	}
+	if runtime.GOOS == "windows" {
+		// --no-passwd is ignored on Windows; the flag-registration test
+		// above covers the wiring there.
+		t.Skip("subprocess test exercises POSIX passwd semantics")
+	}
+
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "dotvault")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build: %v", err)
+	}
+
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+
+	workDir := t.TempDir()
+	missingConfig := filepath.Join(workDir, "does-not-exist.yaml")
+	baseEnv := append(os.Environ(), "DOTVAULT_SUPPRESS_HOURS=6")
+
+	t.Run("local user exits silently before config load", func(t *testing.T) {
+		passwdFile := filepath.Join(workDir, "passwd-with-user")
+		entry := u.Username + ":x:1000:1000::/home/" + u.Username + ":/bin/bash\n"
+		if err := os.WriteFile(passwdFile, []byte(entry), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		markerPath := filepath.Join(workDir, "marker-local")
+
+		check := exec.Command(binPath, "--config", missingConfig, "login-check", "--no-passwd")
+		check.Env = append(baseEnv,
+			"DOTVAULT_SUPPRESS_MARKER="+markerPath,
+			"DOTVAULT_PASSWD_FILE="+passwdFile,
+		)
+		check.Stdin = nil
+		out, err := check.CombinedOutput()
+		if err != nil {
+			t.Fatalf("expected silent exit 0 for local user: %v\noutput:\n%s", err, out)
+		}
+		if len(out) != 0 {
+			t.Errorf("expected no output, got: %q", out)
+		}
+		// The early exit happens past the freshness check, so the
+		// marker contract applies: subsequent shells in the window must
+		// be silenced without re-parsing the passwd file.
+		if _, err := os.Stat(markerPath); err != nil {
+			t.Errorf("marker not refreshed on --no-passwd early exit: %v", err)
+		}
+	})
+
+	t.Run("directory user falls through to normal flow", func(t *testing.T) {
+		// The fixture entry is derived from the real username so it can
+		// never collide with whoever runs the tests (root in CI, a
+		// developer locally).
+		passwdFile := filepath.Join(workDir, "passwd-without-user")
+		entry := "not-" + u.Username + ":x:0:0::/root:/bin/bash\n"
+		if err := os.WriteFile(passwdFile, []byte(entry), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		markerPath := filepath.Join(workDir, "marker-directory")
+
+		check := exec.Command(binPath, "--config", missingConfig, "login-check", "--no-passwd")
+		check.Env = append(baseEnv,
+			"DOTVAULT_SUPPRESS_MARKER="+markerPath,
+			"DOTVAULT_PASSWD_FILE="+passwdFile,
+		)
+		check.Stdin = nil
+		out, err := check.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected config-load failure when user absent from passwd file, got exit 0\noutput:\n%s", out)
+		}
+	})
 }
 
 // TestLoginCheckSuppression_SubprocessRoundTrip exercises the spec's

--- a/cmd/dotvault/main_test.go
+++ b/cmd/dotvault/main_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -337,9 +336,12 @@ func TestLoginCheckNoPasswd_Subprocess(t *testing.T) {
 		t.Fatalf("go build: %v", err)
 	}
 
-	u, err := user.Current()
+	// Resolve the username exactly as production does (paths.Username
+	// strips any DOMAIN\ prefix) so the fixture entry always matches
+	// what login-check looks up.
+	username, err := paths.Username()
 	if err != nil {
-		t.Fatalf("user.Current: %v", err)
+		t.Fatalf("paths.Username: %v", err)
 	}
 
 	workDir := t.TempDir()
@@ -348,7 +350,7 @@ func TestLoginCheckNoPasswd_Subprocess(t *testing.T) {
 
 	t.Run("local user exits silently before config load", func(t *testing.T) {
 		passwdFile := filepath.Join(workDir, "passwd-with-user")
-		entry := u.Username + ":x:1000:1000::/home/" + u.Username + ":/bin/bash\n"
+		entry := username + ":x:1000:1000::/home/" + username + ":/bin/bash\n"
 		if err := os.WriteFile(passwdFile, []byte(entry), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -380,7 +382,7 @@ func TestLoginCheckNoPasswd_Subprocess(t *testing.T) {
 		// never collide with whoever runs the tests (root in CI, a
 		// developer locally).
 		passwdFile := filepath.Join(workDir, "passwd-without-user")
-		entry := "not-" + u.Username + ":x:0:0::/root:/bin/bash\n"
+		entry := "not-" + username + ":x:0:0::/root:/bin/bash\n"
 		if err := os.WriteFile(passwdFile, []byte(entry), 0o644); err != nil {
 			t.Fatal(err)
 		}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,6 +66,22 @@ dotvault login-check [flags]
   `DOTVAULT_SUPPRESS_HOURS` (default `6`), the command exits silently.
   A future mtime is treated as stale so clock skew or backup restores
   cannot lock suppression on indefinitely.
+- Pass `--no-passwd` to exit `0` immediately when the current user has
+  an entry in `/etc/passwd`. In corporate fleets where human accounts
+  come from a directory service (SSSD, LDAP, AD), a passwd entry means
+  a local machine account with no Vault credentials to check — a
+  fleet-wide `profile.d` script can pass the flag unconditionally and
+  login-check stays silent for local accounts. The file is parsed
+  directly rather than via `getent`, which merges every NSS source and
+  cannot say which source an entry came from. The flag is ignored with
+  a warning on Windows; a passwd read failure warns and falls through
+  to the normal check (fail open — a directory user must not be locked
+  out by a broken local file). The early exit refreshes the suppression
+  marker, so subsequent shells in the window stop at the freshness
+  check without re-parsing the file. The heuristic is Linux-targeted:
+  on macOS local accounts live in Open Directory rather than
+  `/etc/passwd`, so the flag never matches a human account there and
+  safely degrades to the normal check.
 - Otherwise: if the cached token is valid and still within the first
   half of its creation TTL, exit clean. Past halfway, attempt renewal;
   if renewal fails but the token is still valid, warn with the
@@ -130,6 +146,7 @@ project README and the Windows admin docs for details.
 | `DOTVAULT_TOKEN` | Vault token (takes precedence over `~/.dotvault-token`). Earlier releases honoured the standard `VAULT_TOKEN` variable; it is now deliberately ignored — it belongs to the `vault` CLI and must not leak into dotvault's session. See the [upgrade note](authentication/token.md#upgrading-from-earlier-releases). |
 | `DOTVAULT_SUPPRESS_HOURS` | `dotvault login-check` suppression window in whole hours (default `6`). Zero, negative, or non-integer values cause `login-check` to exit `1`. |
 | `DOTVAULT_SUPPRESS_MARKER` | Override path for the `login-check` suppression marker. Primarily used by tests; the default location is `${XDG_STATE_HOME:-$HOME/.local/state}/dotvault/login-check-suppress`. |
+| `DOTVAULT_PASSWD_FILE` | Override path for the passwd file consulted by `login-check --no-passwd`. Primarily used by tests; defaults to `/etc/passwd`. |
 
 ## Logging
 

--- a/internal/passwd/passwd.go
+++ b/internal/passwd/passwd.go
@@ -1,0 +1,89 @@
+// Package passwd answers one narrow question for `dotvault login-check
+// --no-passwd`: does the current OS user have an entry in the local
+// passwd file? In corporate fleets where human accounts come from a
+// directory service (SSSD, LDAP, AD), an account listed in /etc/passwd
+// is a local machine account — not a human with Vault credentials — so
+// login-check can exit before any token checks or prompts.
+//
+// The file is parsed directly rather than via getent/os/user lookups,
+// which merge every NSS source and cannot say *which* source an entry
+// came from — exactly the distinction this check exists to draw.
+// Deliberately no third-party dependency: the format is a stable,
+// trivially line-oriented contract (passwd(5)) and the libraries that
+// exist parse far more than the lookup needs.
+//
+// The heuristic is Linux-targeted. On macOS local accounts live in
+// Open Directory, not /etc/passwd (which holds only system and
+// single-user-mode entries), so the lookup never matches a human there
+// and --no-passwd degrades safely to a no-op: the caller falls through
+// to the normal login check rather than skipping it.
+package passwd
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	// DefaultPath is the local account database on every Unix-like
+	// platform dotvault targets. The Windows caller never reaches this
+	// package (the flag is ignored there).
+	DefaultPath = "/etc/passwd"
+
+	envPath = "DOTVAULT_PASSWD_FILE"
+)
+
+// Path returns the passwd file to consult: the DOTVAULT_PASSWD_FILE
+// override when set (used primarily by tests, mirroring
+// DOTVAULT_SUPPRESS_MARKER), otherwise DefaultPath.
+func Path() string {
+	if p := os.Getenv(envPath); p != "" {
+		return p
+	}
+	return DefaultPath
+}
+
+// ContainsUser reports whether the passwd file at path defines a local
+// entry for username. A missing or unreadable file is an error — the
+// caller decides whether to fail open; this package does not guess.
+func ContainsUser(path, username string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	return scan(f, username)
+}
+
+// scan is the io.Reader core of ContainsUser, split out for tests.
+// Matching is exact on the first colon-separated field of each entry,
+// per passwd(5). Lines that are not local entries are skipped:
+//   - blank lines and #-comments (not standard, but present on some
+//     systems and emitted by some provisioning tools)
+//   - NIS/compat `+`/`-` entries (`+@netgroup`, `+username`, bare `+`),
+//     which splice in *directory* sources — the opposite of the "local
+//     account" signal this lookup exists to detect
+//   - lines without a colon (malformed; no name field to match)
+func scan(r io.Reader, username string) (bool, error) {
+	if username == "" {
+		return false, nil
+	}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\r")
+		if line == "" || strings.HasPrefix(line, "#") ||
+			strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") {
+			continue
+		}
+		name, _, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		if name == username {
+			return true, nil
+		}
+	}
+	return false, sc.Err()
+}

--- a/internal/passwd/passwd.go
+++ b/internal/passwd/passwd.go
@@ -27,9 +27,11 @@ import (
 )
 
 const (
-	// DefaultPath is the local account database on every Unix-like
-	// platform dotvault targets. The Windows caller never reaches this
-	// package (the flag is ignored there).
+	// DefaultPath is the local account database on Linux. On macOS the
+	// file holds only system and single-user-mode entries (see the
+	// package doc), so the lookup never matches a human account there.
+	// The Windows caller never reaches this package (the flag is
+	// ignored there).
 	DefaultPath = "/etc/passwd"
 
 	envPath = "DOTVAULT_PASSWD_FILE"

--- a/internal/passwd/passwd_test.go
+++ b/internal/passwd/passwd_test.go
@@ -1,0 +1,106 @@
+package passwd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sample mirrors a realistic compat-mode /etc/passwd: system accounts,
+// a local human-shaped account, comments, NIS splice entries, and a
+// malformed line. The directory-sourced user "gary" is deliberately
+// absent — that is the whole point of the lookup.
+const sample = `# local accounts
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+
+svc-backup:x:998:998:gary backup service:/var/lib/backup:/usr/sbin/nologin
++@humans
++gary
+-blocked
++::::::
+not-an-entry-without-colon
+localadmin:x:1000:1000::/home/localadmin:/bin/bash
+`
+
+func TestScan(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		want     bool
+	}{
+		{"local system account", "root", true},
+		{"local trailing entry", "localadmin", true},
+		{"local service account", "svc-backup", true},
+		{"directory user absent from file", "gary", false},
+		{"nis netgroup splice not a local entry", "@humans", false},
+		{"prefix of a local name", "local", false},
+		{"local name plus suffix", "rootx", false},
+		{"match in gecos field only", "backup", false},
+		{"comment line", "# local accounts", false},
+		{"empty username", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := scan(strings.NewReader(sample), tt.username)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("scan(%q) = %v, want %v", tt.username, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanCRLF(t *testing.T) {
+	got, err := scan(strings.NewReader("alice:x:1:1::/home/alice:/bin/sh\r\n"), "alice")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !got {
+		t.Error("CRLF line ending should not defeat the username match")
+	}
+}
+
+func TestContainsUser(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "passwd")
+	if err := os.WriteFile(path, []byte(sample), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	found, err := ContainsUser(path, "localadmin")
+	if err != nil {
+		t.Fatalf("ContainsUser: %v", err)
+	}
+	if !found {
+		t.Error("ContainsUser(localadmin) = false, want true")
+	}
+	found, err = ContainsUser(path, "gary")
+	if err != nil {
+		t.Fatalf("ContainsUser: %v", err)
+	}
+	if found {
+		t.Error("ContainsUser(gary) = true, want false")
+	}
+}
+
+// A missing file must surface as an error, not a silent "not found" —
+// the caller's fail-open decision should be deliberate and logged.
+func TestContainsUserMissingFile(t *testing.T) {
+	_, err := ContainsUser(filepath.Join(t.TempDir(), "nope"), "root")
+	if err == nil {
+		t.Fatal("ContainsUser on missing file: want error, got nil")
+	}
+}
+
+func TestPathOverride(t *testing.T) {
+	t.Setenv(envPath, "/tmp/custom-passwd")
+	if got := Path(); got != "/tmp/custom-passwd" {
+		t.Errorf("Path() with override = %q", got)
+	}
+	t.Setenv(envPath, "")
+	if got := Path(); got != DefaultPath {
+		t.Errorf("Path() without override = %q, want %q", got, DefaultPath)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional `--no-passwd` flag to `dotvault login-check` that exits `0` immediately when the current OS user has an entry in `/etc/passwd`. In corporate fleets where human accounts are sourced from a directory service (SSSD, LDAP, AD), anything defined in the file is a local machine account with no Vault credentials to check — so a fleet-wide `profile.d` script can pass the flag unconditionally and login-check stays silent for local accounts, exiting before any token checks or authentication challenges.

## How

- New `internal/passwd` package parses the file directly rather than via `getent` or `os/user`, because merged-NSS lookups cannot say which source an entry came from — exactly the distinction this check exists to draw. Matching is exact on the first colon-separated field per passwd(5); blank lines, `#` comments, malformed lines, and NIS/compat `+`/`-` splice entries are skipped (the splice entries reference directory sources, the opposite of the local-account signal). No third-party dependency — the format is a stable, trivially line-oriented contract.
- The check is wired into `runLoginCheck` after the suppression-marker freshness check and after the marker-refresh defer is armed, so the early exit also refreshes the marker and subsequent shells in the window short-circuit at the marker without re-reading the file.
- On Windows the flag is ignored with a WARN log, as requested. Username-resolution or passwd-read failures warn and fall through to the normal flow (fail open): exit `1` stays reserved for genuine internal errors, and a directory user must not be locked out by a broken local file.
- `DOTVAULT_PASSWD_FILE` overrides the consulted path, primarily for tests — mirroring the existing `DOTVAULT_SUPPRESS_MARKER` convention.
- macOS note: local accounts there live in Open Directory, not `/etc/passwd`, so the lookup never matches a human account on darwin and the flag degrades safely to a no-op (falls through to the normal check; it cannot wrongly skip auth). This is documented in the package godoc, CLAUDE.md, and docs/cli.md rather than branching on darwin.

## Testing

- Table-driven unit tests for the parser (`internal/passwd/passwd_test.go`): exact-field matching, NIS splice entries, comments, CRLF tolerance, GECOS-field non-matches, missing-file error, env override.
- Flag-registration test plus an end-to-end subprocess test (`cmd/dotvault/main_test.go`): with a deliberately missing `--config`, a user present in the overridden passwd file exits `0` silently before config load is ever reached and refreshes the suppression marker; an absent user falls through and fails at config load like any other invocation.
- `go test ./...` passes; cross-compiles clean for `windows/amd64` and `darwin/arm64`.

https://claude.ai/code/session_01Y5TVf1tuC64KeCowwhRHtk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5TVf1tuC64KeCowwhRHtk)_